### PR TITLE
[F] Add margin controls to reader

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -3,3 +3,6 @@ ruby:
 
 scss:
   config_file: .scss-lint.yml
+
+javascript:
+  enabled: false

--- a/client/src/actions/reader/ui/typography.js
+++ b/client/src/actions/reader/ui/typography.js
@@ -3,3 +3,5 @@ import { createAction } from 'redux-actions';
 export const selectFont = createAction('SELECT_FONT', subject => subject);
 export const incrementFontSize = createAction('INCREMENT_FONT_SIZE');
 export const decrementFontSize = createAction('DECREMENT_FONT_SIZE');
+export const incrementMargins = createAction('INCREMENT_MARGINS');
+export const decrementMargins = createAction('DECREMENT_MARGINS');

--- a/client/src/components/reader/AppearanceMenuBody.js
+++ b/client/src/components/reader/AppearanceMenuBody.js
@@ -6,9 +6,11 @@ export default class AppearanceMenuBody extends Component {
   static propTypes = {
     appearance: PropTypes.object,
     selectFont: PropTypes.func,
+    setColorScheme: PropTypes.func,
     incrementFontSize: PropTypes.func,
     decrementFontSize: PropTypes.func,
-    setColorScheme: PropTypes.func
+    incrementMargins: PropTypes.func,
+    decrementMargins: PropTypes.func,
   };
 
   setColorHandler = (event, scheme) => {
@@ -31,11 +33,21 @@ export default class AppearanceMenuBody extends Component {
     this.props.decrementFontSize();
   };
 
-  handleSerifButtonClick = (event) => {
+  incrementMarginsHandler = (event) => {
+    event.stopPropagation();
+    this.props.incrementMargins();
+  };
+
+  decrementMarginsHandler = (event) => {
+    event.stopPropagation();
+    this.props.decrementMargins();
+  };
+
+  serifButtonHandler = (event) => {
     this.selectFontHandler(event, 'serif');
   };
 
-  handleSansSerifButtonClick = (event) => {
+  sansSerifButtonHandler = (event) => {
     this.selectFontHandler(event, 'sans-serif');
   };
 
@@ -50,6 +62,7 @@ export default class AppearanceMenuBody extends Component {
 
   render = () => {
     const typography = this.props.appearance.typography;
+    const fontSize = this.props.appearance.typography.fontSize;
     const colorScheme = this.props.appearance.colors.colorScheme;
 
     // Conditional Classes
@@ -77,14 +90,14 @@ export default class AppearanceMenuBody extends Component {
           <div className="control-font">
             <button
               className={serifButtonClass}
-              onClick={this.handleSerifButtonClick}
+              onClick={this.serifButtonHandler}
             >
               {'Serif'}
             </button>
 
             <div className="font-size">
               <button
-                disabled={typography.size === typography.sizeMin ||
+                disabled={fontSize.current === fontSize.min ||
                   typography.font === 'sans-serif'}
                 onClick={this.decrementSizeHandler}
               >
@@ -94,7 +107,7 @@ export default class AppearanceMenuBody extends Component {
                 </span>
               </button>
               <button
-                disabled={typography.size === typography.sizeMax ||
+                disabled={fontSize.current === fontSize.max ||
                   typography.font === 'sans-serif'}
                 onClick={this.incrementSizeHandler}
               >
@@ -107,14 +120,14 @@ export default class AppearanceMenuBody extends Component {
           </div>
           <div className="control-font">
             <button className={sansSerifButtonClass}
-              onClick={this.handleSansSerifButtonClick}
+              onClick={this.sansSerifButtonHandler}
             >
               {'Sans Serif'}
             </button>
 
             <div className="font-size">
               <button
-                disabled={typography.size === typography.sizeMin ||
+                disabled={fontSize.current === fontSize.min ||
                   typography.font === 'serif'}
                 onClick={this.decrementSizeHandler}
               >
@@ -124,7 +137,7 @@ export default class AppearanceMenuBody extends Component {
                 </span>
               </button>
               <button
-                disabled={typography.size === typography.sizeMax ||
+                disabled={fontSize.current === fontSize.max ||
                   typography.font === 'serif'}
                 onClick={this.incrementSizeHandler}
               >
@@ -151,6 +164,27 @@ export default class AppearanceMenuBody extends Component {
               <i className="manicon manicon-check"></i>
               <span className="screen-reader-text">
                 {'Click to use dark color scheme in reader'}
+              </span>
+            </button>
+          </div>
+
+          <div className="control-margins">
+            <button className="margin-increase" onClick={this.incrementMarginsHandler}>
+              <i className="compound-icon">
+                <i className="manicon manicon-margins-narrow-arrows"></i>
+                <i className="manicon manicon-margins-narrow-text"></i>
+              </i>
+              <span className="screen-reader-text">
+                {'Click to increase text margins'}
+              </span>
+            </button>
+            <button className="margin-decrease" onClick={this.decrementMarginsHandler}>
+              <i className="compound-icon">
+                <i className="manicon manicon-margins-wide-arrows"></i>
+                <i className="manicon manicon-margins-wide-text"></i>
+              </i>
+              <span className="screen-reader-text">
+                {'Click to increase text margins'}
               </span>
             </button>
           </div>

--- a/client/src/components/reader/Header.js
+++ b/client/src/components/reader/Header.js
@@ -21,6 +21,8 @@ export default class Header extends Component {
     selectFont: PropTypes.func,
     incrementFontSize: PropTypes.func,
     decrementFontSize: PropTypes.func,
+    incrementMargins: PropTypes.func,
+    decrementMargins: PropTypes.func,
     setColorScheme: PropTypes.func,
     startLogout: PropTypes.func
   };
@@ -126,9 +128,11 @@ export default class Header extends Component {
             // Props required by body component
             appearance={this.props.appearance}
             selectFont={this.props.selectFont}
+            setColorScheme={this.props.setColorScheme}
             incrementFontSize={this.props.incrementFontSize}
             decrementFontSize={this.props.decrementFontSize}
-            setColorScheme={this.props.setColorScheme}
+            incrementMargins={this.props.incrementMargins}
+            decrementMargins={this.props.decrementMargins}
           />
           <UIPanel
             id="user"

--- a/client/src/containers/reader/Reader.js
+++ b/client/src/containers/reader/Reader.js
@@ -12,7 +12,7 @@ import { startLogout } from '../../actions/shared/authentication';
 import { visibilityToggle, visibilityHide, visibilityShow, panelToggle, panelHide }
   from '../../actions/shared/ui/visibility';
 import { values } from 'lodash/object';
-import { selectFont, incrementFontSize, decrementFontSize }
+import { selectFont, incrementFontSize, decrementFontSize, incrementMargins, decrementMargins }
   from '../../actions/reader/ui/typography';
 import { setColorScheme } from '../../actions/reader/ui/colors';
 
@@ -90,6 +90,23 @@ class Reader extends Component {
     this.props.history.push(`/read/${this.props.text.id}/section/${firstSectionId}`);
   };
 
+  headerMethods = () => {
+    return {
+      visibilityToggle: bindActionCreators((el) => visibilityToggle(el), this.props.dispatch),
+      visibilityHide: bindActionCreators((el) => visibilityHide(el), this.props.dispatch),
+      visibilityShow: bindActionCreators((el) => visibilityShow(el), this.props.dispatch),
+      panelToggle: bindActionCreators((el) => panelToggle(el), this.props.dispatch),
+      panelHide: bindActionCreators((el) => panelHide(el), this.props.dispatch),
+      selectFont: bindActionCreators((el) => selectFont(el), this.props.dispatch),
+      incrementFontSize: bindActionCreators(incrementFontSize, this.props.dispatch),
+      decrementFontSize: bindActionCreators(decrementFontSize, this.props.dispatch),
+      incrementMargins: bindActionCreators(incrementMargins, this.props.dispatch),
+      decrementMargins: bindActionCreators(decrementMargins, this.props.dispatch),
+      setColorScheme: bindActionCreators((el) => setColorScheme(el), this.props.dispatch),
+      startLogout: bindActionCreators(startLogout, this.props.dispatch)
+    };
+  };
+
   renderStyles = () => {
     return values(this.props.stylesheets).map((stylesheet, index) => {
       return (
@@ -117,16 +134,7 @@ class Reader extends Component {
             authenticated={this.props.authentication.authToken === null ? false : true}
             visibility={this.props.visibility }
             appearance={this.props.appearance}
-            visibilityToggle={bindActionCreators((el) => visibilityToggle(el), this.props.dispatch)}
-            visibilityHide={bindActionCreators((el) => visibilityHide(el), this.props.dispatch)}
-            visibilityShow={bindActionCreators((el) => visibilityShow(el), this.props.dispatch)}
-            panelToggle={bindActionCreators((el) => panelToggle(el), this.props.dispatch)}
-            panelHide={bindActionCreators((el) => panelHide(el), this.props.dispatch)}
-            selectFont={bindActionCreators((el) => selectFont(el), this.props.dispatch)}
-            incrementFontSize={bindActionCreators(incrementFontSize, this.props.dispatch)}
-            decrementFontSize={bindActionCreators(decrementFontSize, this.props.dispatch)}
-            setColorScheme={bindActionCreators((el) => setColorScheme(el), this.props.dispatch)}
-            startLogout={bindActionCreators(startLogout, this.props.dispatch)}
+            {...this.headerMethods()}
           />
           <LoginOverlay
             visible={this.props.visibility.loginOverlay}

--- a/client/src/containers/reader/Section.js
+++ b/client/src/containers/reader/Section.js
@@ -56,6 +56,13 @@ class Reader extends Component {
     };
   };
 
+  getMarginSize = (sizeIndex) => {
+    const baseSizes = [790, 680, 500];
+    return {
+      maxWidth: baseSizes[sizeIndex] + 'px'
+    };
+  };
+
   reset = () => {
     this.counter = 0;
   };
@@ -159,8 +166,8 @@ class Reader extends Component {
     const section = this.getSection();
     return (
         <section className={readerAppearanceClass}>
-          <div className="container-focus">
-            <div className={textSectionClass} style={this.getFontSize(typography.size)}>
+          <div className="container-focus" style={this.getMarginSize(typography.margins.current)}>
+            <div className={textSectionClass} style={this.getFontSize(typography.fontSize.current)}>
               {this.buildTextSection()}
             </div>
           </div>

--- a/client/src/store/reducers/ui/__tests__/typography-test.js
+++ b/client/src/store/reducers/ui/__tests__/typography-test.js
@@ -7,9 +7,16 @@ describe('store/reducers/ui/typography', () => {
     // Must mirror initial state declared in '../typography'
     expect(state).to.deep.equal({
       font: 'serif',
-      size: 3,
-      sizeMax: 5,
-      sizeMin: 0
+      fontSize:{
+        current: 3,
+        max: 5,
+        min: 0
+      },
+      margins: {
+        current: 1,
+        max: 3,
+        min: 0
+      }
     });
   });
 });
@@ -31,22 +38,28 @@ describe('store/reducers/ui/typography/selectFont', () => {
 describe('store/reducers/ui/typography/incrementFontSize', () => {
   it('Should increment the value by 1', () => {
     const initialState = {
-      size: 1,
-      sizeMax: 5
+      fontSize:{
+        current: 1,
+        max: 5
+      }
     };
 
     const action = { type: 'INCREMENT_FONT_SIZE' };
     const state = typographyReducer(initialState, action);
     expect(state).to.deep.equal({
-      size: 2,
-      sizeMax: 5
+      fontSize:{
+        current: 2,
+        max: 5
+      }
     });
   });
 
   it('Should return the same value if it is at maximum', () => {
     const initialState = {
-      size: 5,
-      sizeMax: 5
+      fontSize:{
+        current: 5,
+        max: 5
+      }
     };
 
     const action = { type: 'INCREMENT_FONT_SIZE' };
@@ -58,25 +71,97 @@ describe('store/reducers/ui/typography/incrementFontSize', () => {
 describe('store/reducers/ui/typography/decrementFontSize', () => {
   it('Should decrement the value by 1', () => {
     const initialState = {
-      size: 1,
-      sizeMin: -5
+      fontSize:{
+        current: 1,
+        min: -5
+      }
     };
 
     const action = { type: 'DECREMENT_FONT_SIZE' };
     const state = typographyReducer(initialState, action);
     expect(state).to.deep.equal({
-      size: 0,
-      sizeMin: -5
+      fontSize:{
+        current: 0,
+        min: -5
+      }
     });
   });
 
   it('Should return the same value if it is at minimum', () => {
     const initialState = {
-      size: -5,
-      sizeMin: -5
+      fontSize:{
+        current: -5,
+        min: -5
+      }
     };
 
     const action = { type: 'DECREMENT_FONT_SIZE' };
+    const state = typographyReducer(initialState, action);
+    expect(state).to.deep.equal(initialState);
+  });
+});
+
+describe('store/reducers/ui/typography/incrementMargins', () => {
+  it('Should increment the value by 1', () => {
+    const initialState = {
+      margins:{
+        current: 1,
+        max: 2
+      }
+    };
+
+    const action = { type: 'INCREMENT_MARGINS' };
+    const state = typographyReducer(initialState, action);
+    expect(state).to.deep.equal({
+      margins:{
+        current: 2,
+        max: 2
+      }
+    });
+  });
+
+  it('Should return the same value if it is at maximum', () => {
+    const initialState = {
+      margins:{
+        current: 2,
+        max: 2
+      }
+    };
+
+    const action = { type: 'INCREMENT_MARGINS' };
+    const state = typographyReducer(initialState, action);
+    expect(state).to.deep.equal(initialState);
+  });
+});
+
+describe('store/reducers/ui/typography/decrementFontSize', () => {
+  it('Should decrement the value by 1', () => {
+    const initialState = {
+      margins:{
+        current: 1,
+        min: 0
+      }
+    };
+
+    const action = { type: 'DECREMENT_MARGINS' };
+    const state = typographyReducer(initialState, action);
+    expect(state).to.deep.equal({
+      margins:{
+        current: 0,
+        min: 0
+      }
+    });
+  });
+
+  it('Should return the same value if it is at minimum', () => {
+    const initialState = {
+      margins:{
+        current: 0,
+        min: 0
+      }
+    };
+
+    const action = { type: 'DECREMENT_MARGINS' };
     const state = typographyReducer(initialState, action);
     expect(state).to.deep.equal(initialState);
   });

--- a/client/src/store/reducers/ui/typography.js
+++ b/client/src/store/reducers/ui/typography.js
@@ -2,33 +2,42 @@ import { handleActions } from 'redux-actions';
 
 const initialState = {
   font: 'serif',
-  size: 3,
-  sizeMax: 5,
-  sizeMin: 0
+  fontSize: {
+    current: 3,
+    max: 5,
+    min: 0
+  },
+  margins: {
+    current: 1,
+    max: 3,
+    min: 0
+  }
 };
 
 const selectFont = (state, action) => {
   return Object.assign({}, state, { font: action.payload });
 };
 
-const incrementFontSize = (state) => {
-  let value = state.size;
-  if (value < state.sizeMax) {
-    value = value + 1;
+const incrementAttribute = (state, attribute) => {
+  const parameter = state[attribute];
+  if (parameter.current < parameter.max) {
+    parameter.current = parameter.current + 1;
   }
-  return Object.assign({}, state, { size: value });
+  return Object.assign({}, state, { [attribute]: parameter });
 };
 
-const decrementFontSize = (state) => {
-  let value = state.size;
-  if (value > state.sizeMin) {
-    value = value - 1;
+const decrementAttribute = (state, attribute) => {
+  const parameter = state[attribute];
+  if (parameter.current > parameter.min) {
+    parameter.current = parameter.current - 1;
   }
-  return Object.assign({}, state, { size: value });
+  return Object.assign({}, state, { [attribute]: parameter });
 };
 
 export default handleActions({
   SELECT_FONT: selectFont,
-  INCREMENT_FONT_SIZE: incrementFontSize,
-  DECREMENT_FONT_SIZE: decrementFontSize
+  INCREMENT_FONT_SIZE: (state) => { return incrementAttribute(state, 'fontSize'); },
+  DECREMENT_FONT_SIZE: (state) => { return decrementAttribute(state, 'fontSize'); },
+  INCREMENT_MARGINS: (state) => { return incrementAttribute(state, 'margins'); },
+  DECREMENT_MARGINS: (state) => { return decrementAttribute(state, 'margins'); }
 }, initialState);

--- a/client/src/theme/Components/_shared.scss
+++ b/client/src/theme/Components/_shared.scss
@@ -52,6 +52,7 @@ section {
 
 .container-focus {
   @include containerNarrow;
+  transition: max-width $duration $timing;
 }
 
 .section-heading-utility-right {

--- a/client/src/theme/Components/reader/_appearance-menu.scss
+++ b/client/src/theme/Components/reader/_appearance-menu.scss
@@ -9,7 +9,7 @@
     background-color: $neutral10;
   }
 
-  .manicon-aa:before {
+  .manicon-aa::before {
     font-size: 21px;
   }
 }
@@ -137,6 +137,65 @@
 
     + button {
       margin-left: 20px;
+    }
+  }
+
+  .control-margins {
+    button {
+      @include buttonUnstyled();
+      width: 120px;
+      height: 60px;
+      background-color: $neutralWhite;
+      transition: color $duration $timing, background-color $duration $timing;
+
+      &.margin-increase .compound-icon {
+        position: relative;
+        display: inline-block;
+        width: 83px;
+        height: 23px;
+
+        i {
+          position: absolute;
+          top: 0;
+          left: 0;
+          font-size: 28px;
+        }
+      }
+
+      &.margin-decrease .compound-icon {
+        position: relative;
+        display: inline-block;
+        width: 85px;
+        height: 23px;
+
+        i {
+          position: absolute;
+          top: 0;
+          left: 0;
+          font-size: 28px;
+        }
+      }
+
+      // Icon coloring
+      .manicon-margins-narrow-text,  .manicon-margins-wide-text {
+        color: $neutral40;
+      }
+
+      .manicon-margins-narrow-arrows, .manicon-margins-wide-arrows {
+        color: $neutralOffBlack;
+      }
+
+      &:hover {
+        background-color: $accentPrimary;
+
+        i {
+          color: $neutralWhite;
+        }
+      }
+
+      + button {
+        margin-left: 20px;
+      }
     }
   }
 }

--- a/client/src/theme/STACSS/_structure.scss
+++ b/client/src/theme/STACSS/_structure.scss
@@ -73,9 +73,12 @@
 }
 
 @mixin containerNarrow {
+  // Default max width
   max-width: $containerWidthNarrow;
   margin-right: auto;
   margin-left: auto;
+  padding-right: $containerPaddingMin;
+  padding-left: $containerPaddingMin;
 }
 
 

--- a/client/src/theme/_variables.scss
+++ b/client/src/theme/_variables.scss
@@ -40,7 +40,8 @@ $baseLineHeight: 1.2;
 $containerWidthFull: 1235px; // Maximum container width of 1135 plus maximum gutter padding
 $containerPaddingFull: 50px;
 
-$containerWidthNarrow: 650px; // Narrow container width for reading
+$containerWidthNarrow: 680px; // Narrow container width for reading
+$containerPaddingMin: 15px; // Minimum gutter padding
 
 // Font Weights
 // These are convenience variables to keep font weight declarations consistent

--- a/client/src/theme/assets/svg/fonts/manicon/margins-narrow-arrows.svg
+++ b/client/src/theme/assets/svg/fonts/manicon/margins-narrow-arrows.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="191px" height="64px" viewBox="0 0 191 64" style="enable-background:new 0 0 191 64;" xml:space="preserve">
+<g>
+	<polygon points="190.9,29.9 156.7,29.9 171.2,17.7 168.4,14.4 147.4,32.1 168.4,49.8 171.2,46.5 156.7,34.2 190.9,34.2 	"/>
+	<polygon points="22.6,14.4 19.8,17.7 34.3,29.9 0.1,29.9 0.1,34.2 34.3,34.2 19.8,46.5 22.6,49.8 43.6,32.1 	"/>
+</g>
+</svg>

--- a/client/src/theme/assets/svg/fonts/manicon/margins-narrow-text.svg
+++ b/client/src/theme/assets/svg/fonts/manicon/margins-narrow-text.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="191px" height="64px" viewBox="0 0 191 64" style="enable-background:new 0 0 191 64;" xml:space="preserve">
+<g>
+	<g>
+		<rect x="70.9" width="50" height="4.3"/>
+	</g>
+	<g>
+		<rect x="70.9" y="14.9" width="50" height="4.3"/>
+	</g>
+	<g>
+		<rect x="70.9" y="29.8" width="50" height="4.3"/>
+	</g>
+	<g>
+		<rect x="70.9" y="44.8" width="50" height="4.3"/>
+	</g>
+	<g>
+		<rect x="70.9" y="59.7" width="50" height="4.3"/>
+	</g>
+</g>
+</svg>

--- a/client/src/theme/assets/svg/fonts/manicon/margins-wide-arrows.svg
+++ b/client/src/theme/assets/svg/fonts/manicon/margins-wide-arrows.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="198px" height="64px" viewBox="0 0 198 64" style="enable-background:new 0 0 198 64;" xml:space="preserve">
+<polygon points="176.7,14.4 173.9,17.7 188.4,29.9 156.4,29.9 156.4,34.2 188.4,34.2 173.9,46.5 176.7,49.8 197.7,32.1 "/>
+<polygon points="41.6,29.9 9.6,29.9 24.1,17.7 21.3,14.4 0.3,32.1 21.3,49.8 24.1,46.5 9.6,34.2 41.6,34.2 "/>
+</svg>

--- a/client/src/theme/assets/svg/fonts/manicon/margins-wide-text.svg
+++ b/client/src/theme/assets/svg/fonts/manicon/margins-wide-text.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="198px" height="64px" viewBox="0 0 198 64" style="enable-background:new 0 0 198 64;" xml:space="preserve">
+<g>
+	<rect x="57.1" width="84.6" height="4.3"/>
+</g>
+<g>
+	<rect x="57.1" y="14.9" width="84.6" height="4.3"/>
+</g>
+<g>
+	<rect x="57.1" y="29.8" width="84.6" height="4.3"/>
+</g>
+<g>
+	<rect x="57.1" y="44.8" width="84.6" height="4.3"/>
+</g>
+<g>
+	<rect x="57.1" y="59.7" width="84.6" height="4.3"/>
+</g>
+</svg>


### PR DESCRIPTION
[FEATURE DELIVERS #111080632] New actions have been added to increment/
decrement margin values in the store, that use a now-abstracted version
of the font-size increment/decrement reducers. In the view, there are
now buttons to increase/decrease the margin size in the reader. It's
important to note that while these buttons do not have disabled states
for minimum and maximum sizes, they do stop changing the store when a
limit is reached.