### PR TITLE
[B] Fix select element cross-browser appearance

### DIFF
--- a/client/src/theme/STACSS/_appearance.scss
+++ b/client/src/theme/STACSS/_appearance.scss
@@ -113,12 +113,12 @@
     margin: 0;
     font-size: $type40;
     line-height: $baseLineHeight;
+    cursor: pointer;
     background-color: transparent;
     border: 3px solid $neutral40;
     border-radius: 0;
     outline: 0;
-    // This should be auto-prefixed
-    -webkit-appearance: none;
+    appearance: none;
 
     &:focus {
       border-color: $accentPrimary;


### PR DESCRIPTION
[BUGFIX FIXES #110890746] We can use the autoprefixed "appearance"
property to ensure that select arrows are removed on all modern
browsers. This change also forces the "pointer" cursor on styled select
elements.