### PR TITLE
[F] Change text-fade on reader dark color scheme

### DIFF
--- a/client/src/components/reader/Header.js
+++ b/client/src/components/reader/Header.js
@@ -68,6 +68,16 @@ export default class Header extends Component {
   };
 
   render() {
+    const colorScheme = this.props.appearance.colors.colorScheme;
+
+    const bannerGradientClass = classNames({
+      'banner-gradient': true,
+      'scheme-light': colorScheme === 'light',
+      'scheme-dark': colorScheme === 'dark'
+    });
+
+    console.log(this.props.appearance);
+
     return (
       <ScrollAware>
         <header className="header-reader">
@@ -108,6 +118,7 @@ export default class Header extends Component {
                 </li>
               </ul>
             </nav>
+            <div className={bannerGradientClass}></div>
           </nav>
           <TocDrawer
             text={this.props.text}

--- a/client/src/theme/Components/browse/_header-browse.scss
+++ b/client/src/theme/Components/browse/_header-browse.scss
@@ -1,10 +1,15 @@
 // <header>
 .header-browse {
-  @include bannerGlow;
   position: fixed;
   width: 100%;
   padding: 30px 52px 30px 40px;
   background-color: $neutralWhite;
+  border-bottom: 1px solid transparent;
+  transition: border-color $duration $timing;
+
+  .not-top & {
+    border-bottom: 1px solid $neutral40;
+  }
 
   // <a> return link with logo
   .logo {

--- a/client/src/theme/Components/reader/_header-reader.scss
+++ b/client/src/theme/Components/reader/_header-reader.scss
@@ -5,9 +5,34 @@
 
   .container-banner {
     @include clearfix;
-    @include bannerGlow;
     height: 63px;
     background-color: $neutralWhite;
+  }
+
+  .banner-gradient {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    // Relative z-index to container
+    z-index: -1;
+    width: 100%;
+    height: 60px;
+    // Escape linter to use CSS native function
+    // scss-lint:disable NameFormat
+    background: linear-gradient(to bottom, $neutralWhite 0%, transparentize($neutralWhite, 1) 100%);
+    content: '';
+    opacity: 0;
+    transition: opacity $duration $timing, background $duration $timing;
+
+    // Dark variant
+    &.scheme-dark {
+      background: linear-gradient(to bottom, $neutral90 0%, transparentize($neutral90, 1) 100%);
+    }
+
+    // Only visible when not at top of the page
+    .not-top & {
+      opacity: 1;
+    }
   }
 
   // <button>

--- a/client/src/theme/STACSS/_appearance.scss
+++ b/client/src/theme/STACSS/_appearance.scss
@@ -39,28 +39,6 @@
   border-color: transparent transparent $neutral10;
 }
 
-@mixin bannerGlow {
-  &::before {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    // Relative z-index to container
-    z-index: -1;
-    width: 100%;
-    height: 45px;
-    // Escape linter to use CSS native function
-    // scss-lint:disable NameFormat
-    background: linear-gradient(to bottom, $neutralWhite 0%, transparentize($neutralWhite, 1) 100%);
-    content: '';
-    opacity: 0;
-    transition: opacity $duration $timing;
-    // Only visible when not at top of the page
-    .not-top & {
-      opacity: 1;
-    }
-  }
-}
-
 
 // Buttons
 // --------------------------------------------------------


### PR DESCRIPTION
[FEATURE DELIVERS #113763363] In addition to swapping banner gradient
colors for the reader when it is in "dark mode," the banner gradient
has also been refactored as a DOM element (instead of a pseudo element)
and removed from the browse/frontend interface. In its place, a thin
border is used for now, but it should be noted that this is awaiting
approval from design.