### PR TITLE
[F] Show section title when user scrolls down

### DIFF
--- a/client/src/components/reader/Header.js
+++ b/client/src/components/reader/Header.js
@@ -9,6 +9,7 @@ export default class Header extends Component {
 
   static propTypes = {
     text: PropTypes.object,
+    sectionId: PropTypes.string,
     authenticated: PropTypes.bool,
     visibility: PropTypes.object,
     appearance: PropTypes.object,
@@ -25,6 +26,17 @@ export default class Header extends Component {
     setColorScheme: PropTypes.func,
     startLogout: PropTypes.func
   };
+
+  getSectionTitle(id) {
+    let title = '';
+    this.props.text.attributes.toc.forEach((section) => {
+      if (section.id === id) {
+        title = section.label;
+      }
+    });
+
+    return title;
+  }
 
   handleContentsButtonClick = () => {
     this.props.visibilityToggle('tocDrawer');
@@ -89,9 +101,12 @@ export default class Header extends Component {
               </button>
             </Link>
             { this.renderContentsButton(this.props.text.attributes.toc) }
-            <h2 className="title">
-              {this.props.text.attributes.title}
-            </h2>
+            <header className="title">
+              <h3 className="text-title">{this.props.text.attributes.title}</h3>
+              <h2 className="section-title">
+                {this.getSectionTitle(Number(this.props.sectionId))}
+              </h2>
+            </header>
             <nav className="menu-buttons">
               <ul>
                 <li>

--- a/client/src/components/reader/Header.js
+++ b/client/src/components/reader/Header.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
-import { TocDrawer, AppearanceMenuButton, AppearanceMenuBody } from './';
-import { ScrollAware, SearchMenuButton, SearchMenuBody, UIPanel, UserMenuButton, UserMenuBody }
+import { AppearanceMenuButton, AppearanceMenuBody, TextTitles, TocDrawer } from './';
+import { SearchMenuButton, SearchMenuBody, UIPanel, UserMenuButton, UserMenuBody }
   from '../../components/shared';
 import { Link } from 'react-router';
 import classNames from 'classnames';
@@ -24,6 +24,7 @@ export default class Header extends Component {
     incrementMargins: PropTypes.func,
     decrementMargins: PropTypes.func,
     setColorScheme: PropTypes.func,
+    scrollAware: PropTypes.object,
     startLogout: PropTypes.func
   };
 
@@ -89,86 +90,83 @@ export default class Header extends Component {
     });
 
     return (
-      <ScrollAware>
-        <header className="header-reader">
-          <nav className="container-banner">
-            <Link to={`/browse/project/${this.props.text.relationships.project.data.id}`} >
-              <button className="button-close" >
-                <i className="manicon manicon-x"></i>
-                  <span className="screen-reader-text">
-                    {'Click to close reader'}
-                  </span>
-              </button>
-            </Link>
-            { this.renderContentsButton(this.props.text.attributes.toc) }
-            <header className="title">
-              <h3 className="text-title">{this.props.text.attributes.title}</h3>
-              <h2 className="section-title">
-                {this.getSectionTitle(Number(this.props.sectionId))}
-              </h2>
-            </header>
-            <nav className="menu-buttons">
-              <ul>
-                <li>
-                  <SearchMenuButton
-                    toggleSearchMenu={this.handleSearchMenuButtonClick}
-                    active={this.props.visibility.uiPanels.search}
-                  />
-                </li>
-                <li>
-                  <AppearanceMenuButton
-                    toggleAppearanceMenu={this.handleAppearanceMenuButtonClick}
-                    active={this.props.visibility.uiPanels.appearance}
-                  />
-                </li>
-                <li>
-                  <UserMenuButton
-                    authenticated={this.props.authenticated}
-                    active={this.props.visibility.uiPanels.user}
-                    showLoginOverlay={this.triggerShowLoginOverlay}
-                    toggleUserMenu={this.triggerToggleUserMenu}
-                  />
-                </li>
-              </ul>
-            </nav>
-            <div className={bannerGradientClass}></div>
-          </nav>
-          <TocDrawer
-            text={this.props.text}
-            visible={this.props.visibility.tocDrawer}
-            hideTocDrawer={this.triggerHideToc}
+      <header className="header-reader">
+        <nav className="container-banner">
+          <Link to={`/browse/project/${this.props.text.relationships.project.data.id}`} >
+            <button className="button-close" >
+              <i className="manicon manicon-x"></i>
+                <span className="screen-reader-text">
+                  {'Click to close reader'}
+                </span>
+            </button>
+          </Link>
+          { this.renderContentsButton(this.props.text.attributes.toc) }
+          <TextTitles
+            textTitle={this.props.text.attributes.title}
+            sectionTitle={this.getSectionTitle(Number(this.props.sectionId))}
+            showSection={!this.props.scrollAware.top}
           />
-          <nav className="menu-panels">
-            <UIPanel
-              id="search"
-              visibility={this.props.visibility.uiPanels}
-              bodyComponent={SearchMenuBody}
-            />
-            <UIPanel
-              id="appearance"
-              visibility={this.props.visibility.uiPanels}
-              bodyComponent={AppearanceMenuBody}
-
-              // Props required by body component
-              appearance={this.props.appearance}
-              selectFont={this.props.selectFont}
-              setColorScheme={this.props.setColorScheme}
-              incrementFontSize={this.props.incrementFontSize}
-              decrementFontSize={this.props.decrementFontSize}
-              incrementMargins={this.props.incrementMargins}
-              decrementMargins={this.props.decrementMargins}
-            />
-            <UIPanel
-              id="user"
-              visibility={this.props.visibility.uiPanels}
-              bodyComponent={UserMenuBody}
-
-              // Props required by body component
-              startLogout={this.props.startLogout}
-            />
+          <nav className="menu-buttons">
+            <ul>
+              <li>
+                <SearchMenuButton
+                  toggleSearchMenu={this.handleSearchMenuButtonClick}
+                  active={this.props.visibility.uiPanels.search}
+                />
+              </li>
+              <li>
+                <AppearanceMenuButton
+                  toggleAppearanceMenu={this.handleAppearanceMenuButtonClick}
+                  active={this.props.visibility.uiPanels.appearance}
+                />
+              </li>
+              <li>
+                <UserMenuButton
+                  authenticated={this.props.authenticated}
+                  active={this.props.visibility.uiPanels.user}
+                  showLoginOverlay={this.triggerShowLoginOverlay}
+                  toggleUserMenu={this.triggerToggleUserMenu}
+                />
+              </li>
+            </ul>
           </nav>
-        </header>
-      </ScrollAware>
+          <div className={bannerGradientClass}></div>
+        </nav>
+        <TocDrawer
+          text={this.props.text}
+          visible={this.props.visibility.tocDrawer}
+          hideTocDrawer={this.triggerHideToc}
+        />
+        <nav className="menu-panels">
+          <UIPanel
+            id="search"
+            visibility={this.props.visibility.uiPanels}
+            bodyComponent={SearchMenuBody}
+          />
+          <UIPanel
+            id="appearance"
+            visibility={this.props.visibility.uiPanels}
+            bodyComponent={AppearanceMenuBody}
+
+            // Props required by body component
+            appearance={this.props.appearance}
+            selectFont={this.props.selectFont}
+            setColorScheme={this.props.setColorScheme}
+            incrementFontSize={this.props.incrementFontSize}
+            decrementFontSize={this.props.decrementFontSize}
+            incrementMargins={this.props.incrementMargins}
+            decrementMargins={this.props.decrementMargins}
+          />
+          <UIPanel
+            id="user"
+            visibility={this.props.visibility.uiPanels}
+            bodyComponent={UserMenuBody}
+
+            // Props required by body component
+            startLogout={this.props.startLogout}
+          />
+        </nav>
+      </header>
     );
   }
 }

--- a/client/src/components/reader/TextTitles.js
+++ b/client/src/components/reader/TextTitles.js
@@ -1,0 +1,55 @@
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+
+export default class TextTitles extends Component {
+  static propTypes = {
+    textTitle: PropTypes.string,
+    sectionTitle: PropTypes.string,
+    showSection: PropTypes.bool
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      showSection: true
+    };
+
+    this.handleTitleClick = this.handleTitleClick.bind(this);
+  }
+
+  toggleTitles() {
+    // Only toggle the title back showSection is coming from scrollAware
+    if (this.props.showSection && this.state.showSection) {
+      this.setState({
+        showSection: false
+      });
+
+      setTimeout(() => {
+        this.setState({
+          showSection: true
+        });
+      }, 2500);
+    }
+  }
+
+  handleTitleClick() {
+    // Not using event, but handler stub will allow it if it becomes necessary
+    this.toggleTitles();
+  }
+
+  render() {
+    const titleClass = classNames({
+      title: true,
+      'show-section': this.props.showSection && this.state.showSection
+    });
+
+    return (
+      <header className={titleClass} onClick={this.handleTitleClick}>
+        <h3 className="text-title">{this.props.textTitle}</h3>
+        <h2 className="section-title">
+          {this.props.sectionTitle}
+        </h2>
+      </header>
+    );
+  }
+}

--- a/client/src/components/reader/index.js
+++ b/client/src/components/reader/index.js
@@ -2,6 +2,7 @@ import AppearanceMenuBody from './AppearanceMenuBody';
 import AppearanceMenuButton from './AppearanceMenuButton';
 import Header from './Header';
 import SectionPagination from './SectionPagination';
+import TextTitles from './TextTitles';
 import Toc from './Toc';
 import TocDrawer from './TocDrawer';
 
@@ -10,6 +11,7 @@ export {
     AppearanceMenuButton,
     Header,
     SectionPagination,
+    TextTitles,
     Toc,
     TocDrawer,
 };

--- a/client/src/components/shared/higherOrder/scrollAware.js
+++ b/client/src/components/shared/higherOrder/scrollAware.js
@@ -6,12 +6,16 @@ export default class ScrollAware extends Component {
   static propTypes = {
     children: PropTypes.object,
     threshold: PropTypes.number,
-    throttle: PropTypes.number
+    throttle: PropTypes.number,
+    topClass: PropTypes.string,
+    notTopClass: PropTypes.string
   };
 
   static defaultProps = {
     threshold: 200,
-    throttle: 500
+    throttle: 500,
+    topClass: 'top',
+    notTopClass: 'not-top'
   };
 
   constructor() {
@@ -49,16 +53,34 @@ export default class ScrollAware extends Component {
     this.setState({ top: isTop });
   }, 500);
 
-  render() {
-    const scrollClass = classNames({
-      'scroll-aware': true,
-      top: this.state.top,
-      'not-top': !this.state.top
+  renderChildren() {
+    let firstChild = false;
+    if (React.Children.count(this.props.children) > 1) {
+      firstChild = this.props.children[0];
+    } else {
+      firstChild = this.props.children;
+    }
+    return React.cloneElement(firstChild, {
+      scrollAware: {
+        top: this.state.top
+      }
     });
+  }
+
+  render() {
+    // Dynaimcally assign scroller classes based on props
+    const scrollClasses = {
+      'scroll-aware': true
+    };
+
+    scrollClasses[this.props.topClass] = this.state.top;
+    scrollClasses[this.props.notTopClass] = !this.state.top;
+
+    const scrollClass = classNames(scrollClasses);
 
     return (
         <div className={scrollClass}>
-          {this.props.children}
+          {this.renderChildren()}
         </div>
     );
   }

--- a/client/src/containers/reader/Reader.js
+++ b/client/src/containers/reader/Reader.js
@@ -3,7 +3,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import DocumentMeta from 'react-document-meta';
 import config from '../../config';
-import { BodyClass, LoginOverlay, LoadingBar } from '../../components/shared';
+import { BodyClass, LoginOverlay, LoadingBar, ScrollAware } from '../../components/shared';
 import { Header, SectionPagination } from '../../components/reader';
 import connectData from '../../decorators/connectData';
 import { fetchOneText } from '../../actions/shared/collections';
@@ -137,16 +137,19 @@ class Reader extends Component {
           {this.renderStyles()}
           <DocumentMeta {...config.app}/>
           <LoadingBar loading={this.props.loading} />
-          {/* Header inside scroll-aware HOC */}
-          <Header
-            // Props required by body component
-            text={text}
-            sectionId={this.props.sectionId}
-            authenticated={this.props.authentication.authToken === null ? false : true}
-            visibility={this.props.visibility }
-            appearance={this.props.appearance}
-            {...this.headerMethods()}
-          />
+          <ScrollAware>
+            {/* Header inside scroll-aware HOC */}
+            <Header
+
+              // Props required by body component
+              text={text}
+              sectionId={this.props.sectionId}
+              authenticated={this.props.authentication.authToken === null ? false : true}
+              visibility={this.props.visibility }
+              appearance={this.props.appearance}
+              {...this.headerMethods()}
+            />
+          </ScrollAware>
           <LoginOverlay
             visible={this.props.visibility.loginOverlay}
             hideLoginOverlay={hideLoginOverlay}

--- a/client/src/containers/reader/Reader.js
+++ b/client/src/containers/reader/Reader.js
@@ -141,6 +141,7 @@ class Reader extends Component {
           <Header
             // Props required by body component
             text={text}
+            sectionId={this.props.sectionId}
             authenticated={this.props.authentication.authToken === null ? false : true}
             visibility={this.props.visibility }
             appearance={this.props.appearance}

--- a/client/src/theme/Components/reader/_header-reader.scss
+++ b/client/src/theme/Components/reader/_header-reader.scss
@@ -90,14 +90,31 @@
     }
   }
 
-  // <h2>
+  // <header>
   .title {
     @include templateHead();
-    float: left;
-    margin-left: 27px;
-    font-size: $type80;
-    font-weight: $regular; // OD
-    color: $neutral50;
+    position: relative;
+    height: 100%;
+    overflow: hidden;
+
+    .text-title, .section-title {
+      @include templateHead();
+      position: relative;
+      height: 100%;
+      padding: 19px 190px 0 27px;
+      margin: 0;
+      overflow: hidden;
+      font-size: $type80;
+      font-weight: $regular; // OD
+      color: $neutral50;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      transition: transform 0.4s $timing;
+
+      .not-top & {
+        transform: translateY(-100%);
+      }
+    }
   }
 
   .menu-buttons {

--- a/client/src/theme/Components/reader/_header-reader.scss
+++ b/client/src/theme/Components/reader/_header-reader.scss
@@ -96,6 +96,7 @@
     position: relative;
     height: 100%;
     overflow: hidden;
+    cursor: pointer;
 
     .text-title, .section-title {
       @include templateHead();
@@ -107,13 +108,13 @@
       font-size: $type80;
       font-weight: $regular; // OD
       color: $neutral50;
-      white-space: nowrap;
       text-overflow: ellipsis;
+      white-space: nowrap;
       transition: transform 0.4s $timing;
+    }
 
-      .not-top & {
-        transform: translateY(-100%);
-      }
+    &.show-section .text-title, &.show-section .section-title {
+      transform: translateY(-100%);
     }
   }
 


### PR DESCRIPTION
Initial Commit:
[FEATURE DELIVERS #112837675] In the reader, the header banner now
shows the title of the text-section after the user begins to scroll
down into the reader. The design logic behind this is that the user
almost always sees the section title when the reader is at the top of a
given section, so showing the text title gives the most context. Once
the user is further into the section, we switch to the section title to
provide a persistent reminder of the user's location in the TOC.

From a front-end standpoint, this section title is always in the markup
and the swap happens with a CSS translateX function.

In addition to this markup, a layout bug has also been addressed which
ensures that the titles are truncated if they are longer than their
allotted space.

It should be noted that the section title value is dependent on commit
1e26ef412c78182e6dc3a289f5cb62597de1c21e (submitted as a pull request
in feature/pagination) as it gets the sectionId which is added to the
reader props in that commit. If the pagination branch is rejected for
any reason, this will need to be substituted.

commit b9f9a33a90dc88395f516a88f9d18bf4bf01bf99:
The scroll aware component has been
refactored to pass its state down to the first child component that it
wraps. Using this, the new "TextTitles" component can apply the state
to swap titles. Additionally, a click handler has been added that
un-toggles the section title for a set amount of time.