### PR TITLE
[F] Set min-height to create sticky footer

### DIFF
--- a/client/src/containers/frontend/Frontend.js
+++ b/client/src/containers/frontend/Frontend.js
@@ -58,12 +58,12 @@ export default class Frontend extends Component {
       this.props.authentication.authenticated === true) {
       location.reload();
     }
-    this.setMinHeight();
   }
 
   setMinHeight() {
-    const windowHeight = window.innerHeight;
-    this.refs.mainContainer.style.minHeight = `${windowHeight}px`;
+    const mainHeight = this.refs.mainContainer.offsetHeight;
+    const offsetHeight = this.refs.mainContainer.parentNode.offsetHeight - mainHeight;
+    this.refs.mainContainer.style.minHeight = `calc(100vh - ${offsetHeight}px)`;
   }
 
   headerMethods() {

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -20,7 +20,9 @@ export default () => {
         <Route component={ProjectDetail} path="project/:id" />
       </Route>
 
-      <Route component={NotFound} path="*" />
+      <Route component={Frontend} path="*">
+        <IndexRoute component={NotFound} />
+      </Route>
     </Route>
   );
 };


### PR DESCRIPTION
[FEATURE #115350089] In addition to adding a min-height on all
Frontend pages, this commit also sets the 404 page/error pages to load
as children of the "Frontend" route, giving them the site-wide header/
footer templates.