### PR TITLE
Prevent scroll propagation if the cursor is over the drawer. [#139240881]

### DIFF
--- a/client/src/components/backend/Drawer/Wrapper.js
+++ b/client/src/components/backend/Drawer/Wrapper.js
@@ -2,6 +2,7 @@ import React, { PureComponent, PropTypes } from 'react';
 import { browserHistory } from 'react-router';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { Link } from 'react-router';
+import Utility from 'components/global/Utility';
 
 export default class DrawerWrapper extends PureComponent {
 
@@ -9,7 +10,12 @@ export default class DrawerWrapper extends PureComponent {
 
   static propTypes = {
     closeUrl: PropTypes.string,
-    closeCallback: PropTypes.func
+    closeCallback: PropTypes.func,
+    lockScroll: PropTypes.bool
+  };
+
+  static defaultProps = {
+    lockScroll: true
   };
 
   constructor(props) {
@@ -57,36 +63,40 @@ export default class DrawerWrapper extends PureComponent {
     }
   }
 
+  renderDrawer() {
+    return (
+      <div key="drawer" className="drawer-primary">
+        <div className="rel">
+          <div onClick={this.handleLeaveEvent} className="close-button-primary">
+            <i className="manicon manicon-x"></i>
+            <span className="screen-reader-text">
+              Close Drawer
+            </span>
+          </div>
+          {this.props.children}
+        </div>
+      </div>
+    );
+  }
+
+  renderDrawerWrapper() {
+    return this.props.lockScroll ? (
+      <Utility.ScrollLock>
+        {this.renderDrawer()}
+      </Utility.ScrollLock>
+    ) : this.renderDrawer();
+  }
+
   render() {
     return (
       <ReactCSSTransitionGroup
         transitionName="drawer"
         // True value required to enable transform
-        /* eslint-disable */
-        transitionAppear={true}
-        /* eslint-enable */
-        transitionEnter={false}
-        transitionAppearTimeout={1}
+        transitionEnterTimeout={5000}
         transitionLeaveTimeout={200}
       >
-        {this.state.leaving ?
-          null
-          :
-          <div key="drawer" className="drawer-primary drawer-appear">
-            <div className="rel">
-              <div onClick={this.handleLeaveEvent} className="close-button-primary">
-                <i className="manicon manicon-x"></i>
-                <span className="screen-reader-text">
-                  Close Drawer
-                </span>
-              </div>
-
-              {this.props.children}
-            </div>
-          </div>
-        }
+        { this.state.leaving ? null : this.renderDrawerWrapper() }
       </ReactCSSTransitionGroup>
     );
   }
-
 }

--- a/client/src/components/global/Utility/ScrollLock.js
+++ b/client/src/components/global/Utility/ScrollLock.js
@@ -1,0 +1,72 @@
+import React, { PureComponent, PropTypes } from 'react';
+import ReactDOM from 'react-dom';
+import isString from 'lodash/isString';
+
+export default class ScrollLock extends PureComponent {
+
+  static displayName = "Utility.ScrollLock";
+
+  static propTypes = {
+    children: React.PropTypes.element.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      touchStart: null
+    };
+
+    this.edgeLock = this.edgeLock.bind(this);
+  }
+
+  edgeLock(scroller, event, touchDelta) {
+    const delta = touchDelta ? touchDelta : event.deltaY;
+    if (delta < 0 && scroller.scrollTop <= 0) {
+      event.preventDefault();
+    }
+
+    if (delta > 0 && scroller.scrollTop >= scroller.scrollHeight - window.innerHeight) {
+      event.preventDefault();
+    }
+  }
+
+  componentDidMount() {
+    this.scroller = isString(this.props.children.type) ?
+      this.child : ReactDOM.findDOMNode(this.child);
+
+    this.handleWheel = (event) => {
+      this.edgeLock(this.scroller, event);
+    };
+
+    this.handleTouch = (event) => {
+      const touchDelta = this.state.touchStart - event.touches[0].pageY;
+      this.edgeLock(this.scroller, event, touchDelta);
+    };
+
+    this.setTouchStart = (event) => {
+      this.setState({
+        touchStart: event.touches[0].pageY
+      });
+    };
+
+    this.scroller.addEventListener('mousewheel', this.handleWheel);
+    this.scroller.addEventListener('touchmove', this.handleTouch);
+    this.scroller.addEventListener('touchstart', this.setTouchStart);
+  }
+
+  componentWillUnmount() {
+    this.scroller.removeEventListener('mousewheel', this.handleWheel);
+    this.scroller.removeEventListener('touchmove', this.handleTouch);
+    this.scroller.removeEventListener('touchstart', this.setTouchStart);
+  }
+
+  render() {
+    return (
+      <div className="scroll-lock">
+        {React.cloneElement(this.props.children, { ref: (child) => { this.child = child; } })}
+      </div>
+    );
+  }
+
+}

--- a/client/src/components/global/Utility/index.js
+++ b/client/src/components/global/Utility/index.js
@@ -1,7 +1,9 @@
 import Pagination from './Pagination';
 import EntityCount from './EntityCount';
+import ScrollLock from './ScrollLock';
 
 export default {
   Pagination,
-  EntityCount
+  EntityCount,
+  ScrollLock
 };

--- a/client/src/components/reader/TocDrawer.js
+++ b/client/src/components/reader/TocDrawer.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { Toc } from 'components/reader';
+import Utility from 'components/global/Utility';
 import classNames from 'classnames';
 
 export default class TocDrawer extends Component {
@@ -18,13 +19,16 @@ export default class TocDrawer extends Component {
       'drawer-visible': this.props.visible
     });
     return (
-      <div className={drawerClass}>
-        <Toc
-          text={this.props.text}
-          tocDrawerVisible={this.props.visible}
-          hideTocDrawer={this.props.hideTocDrawer}
-        />
-      </div>
+      <Utility.ScrollLock>
+        {/* NB: This ref is not currently accessible by the parent element */}
+        <div className={drawerClass}>
+          <Toc
+            text={this.props.text}
+            tocDrawerVisible={this.props.visible}
+            hideTocDrawer={this.props.hideTocDrawer}
+          />
+        </div>
+      </Utility.ScrollLock>
     );
   }
 }

--- a/client/src/theme/Components/backend/_drawer.scss
+++ b/client/src/theme/Components/backend/_drawer.scss
@@ -27,8 +27,23 @@
     padding: 33px 70px;
   }
 
-  &.drawer-appear, &.drawer-leave {
+  // Can handle nested appear state, or secondary class state
+  .drawer-enter & {
     right: -555px;
+  }
+
+  .drawer-enter.drawer-enter-active & {
+    right: 0;
+    transition: right $duration $timing;
+  }
+
+  .drawer-leave & {
+    right: 0;
+  }
+
+  .drawer-leave.drawer-leave-active & {
+    right: -555px;
+    transition: right $duration $timing;
   }
 
   .reader & {

--- a/client/src/theme/Components/reader/_toc-drawer.scss
+++ b/client/src/theme/Components/reader/_toc-drawer.scss
@@ -5,6 +5,7 @@
   max-width: 90vw;
   padding: 20px 0 100px;
   overflow-y: scroll;
+  -webkit-overflow-scrolling: auto;
   background-color: $neutral05;
   transition: left $duration $timing;
 


### PR DESCRIPTION
[#139240881]
Initial POC converted to use the TOC; See TocDrawer.js
Note that the HOC (ScrollLock.js) is manipulating the direct child with
a ref, but it might be better if the child can pass a specific ref into
the HOC for cases where the scrolling element may be more deeply nested
(like on a resource drawer inside a ReactCSSTransition)