### PR TITLE
Hash anchors only work after refreshing [#138746857]

### DIFF
--- a/client/src/components/global/HigherOrder/ResolveDataDependencies.js
+++ b/client/src/components/global/HigherOrder/ResolveDataDependencies.js
@@ -25,6 +25,7 @@ class ResolveDataDependenciesComponent extends Component {
     // we don't trigger fetching data unless the route has changed in some way. Without
     // this, changes to the anchor in the URL will refetch data.
     if (this.props.authenticated !== nextProps.authenticated) return true;
+    if (this.props.location.hash !== nextProps.location.hash) return true;
     if (this.props.location.pathname === nextProps.location.pathname) return false;
     if (this.props.components !== nextProps.components) return true;
     return false;

--- a/client/src/components/reader/Section/Text.js
+++ b/client/src/components/reader/Section/Text.js
@@ -78,14 +78,14 @@ export default class Text extends Component {
   // TODO: My sense is that this method is not working very well. It may need to be
   // revisited.
   maybeScrollToAnchor(previousHash, currentHash) {
-    if (currentHash && previousHash !== currentHash) {
-      const scrollTarget = document.querySelector(currentHash);
-      if (!scrollTarget) return false;
-      const position = scrollTarget.getBoundingClientRect().top + window.pageYOffset;
-      setTimeout(() => {
-        smoothScroll(position - 125);
-      }, 0);
-    }
+    if (!currentHash) return;
+    if (previousHash === currentHash) return;
+    const scrollTarget = document.querySelector(currentHash);
+    if (!scrollTarget) return false;
+    const position = scrollTarget.getBoundingClientRect().top + window.pageYOffset;
+    setTimeout(() => {
+      smoothScroll(position - 125);
+    }, 0);
   }
 
   render() {


### PR DESCRIPTION
This commit makes a significant change to how the reader fetches data.
With the reader we don’t want to trigger fetchData when hashes in the
URL change. This may not be a long-term change. The bigger problem is
a question of how we pass a new location to components rendered by the
router without triggering a new fetchData call. This doesn’t address that
problem per se, but does provide a work around for the time being.