### PR TITLE
In some cases, a stop loading action is being resolved before a start loading action, which leads to infinite load states. [#142145903]

### DIFF
--- a/client/src/store/reducers/ui/__tests__/loading-test.js
+++ b/client/src/store/reducers/ui/__tests__/loading-test.js
@@ -7,7 +7,8 @@ describe('store/reducers/ui/loading', () => {
     const state = loadingReducer(undefined, { type: 'SOME_ACTION'});
     expect(state).toEqual({
       active: false,
-      activeLoaders: []
+      activeLoaders: [],
+      pendingRemovals: []
     });
   });
 


### PR DESCRIPTION
Sometimes, especially in local development environments, a STOP_LOADING
action can be reduced before the corresponding START_LOADING action is
reduced. This leads to a START_LOADING that never stops. This revision
stores STOP_LOADING actions in a pending queue in the store, which
blocks the corresopnding START_LOADING action from being added to the
active loaders

[Delivers #142145903]