### PR TITLE
[C] Add explicit tail-hover to popup buttons

### DIFF
--- a/client/src/components/reader/Annotation/Popup/Annotate.js
+++ b/client/src/components/reader/Annotation/Popup/Annotate.js
@@ -16,6 +16,33 @@ export default class AnnotationPopupAnnotate extends PureComponent {
     direction: PropTypes.string
   };
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      tailHighlight: false
+    };
+
+    this.handleTailHighlight = this.handleTailHighlight.bind(this);
+    this.handleTailBlur = this.handleTailBlur.bind(this);
+  }
+
+  handleTailHighlight(condition) {
+    if (condition) {
+      this.setState({
+        tailHighlight: true
+      });
+    }
+  }
+
+  handleTailBlur(condition) {
+    if (condition) {
+      this.setState({
+        tailHighlight: false
+      });
+    }
+  }
+
   render() {
     const pageClass = classNames({
       'popup-page': true,
@@ -28,6 +55,7 @@ export default class AnnotationPopupAnnotate extends PureComponent {
       tail: true,
       'tail-down': this.props.direction === 'up',
       'tail-up': this.props.direction === 'down',
+      highlight: this.state.tailHighlight
     });
 
     return (
@@ -46,7 +74,11 @@ export default class AnnotationPopupAnnotate extends PureComponent {
 
         <HigherOrder.RequireRole requiredRole="any">
           <div className="button-group">
-            <button onClick={this.props.highlight}>
+            <button
+              onClick={this.props.highlight}
+              onMouseEnter={() => { this.handleTailHighlight(this.props.direction === 'down'); }}
+              onMouseLeave={() => { this.handleTailBlur(true); }}
+            >
               <i className="manicon manicon-pencil-simple"></i>
               Highlight
             </button>

--- a/client/src/components/reader/Annotation/Popup/Share.js
+++ b/client/src/components/reader/Annotation/Popup/Share.js
@@ -19,8 +19,12 @@ export default class AnnotationPopupShare extends PureComponent {
     super(props);
 
     this.state = {
-      inBrowser: false
+      inBrowser: false,
+      tailHighlight: false
     };
+
+    this.handleTailHighlight = this.handleTailHighlight.bind(this);
+    this.handleTailBlur = this.handleTailBlur.bind(this);
   }
 
   componentDidMount() {
@@ -29,6 +33,22 @@ export default class AnnotationPopupShare extends PureComponent {
     if (this.state.inBrowser === false) {
       this.setState({ // eslint-disable-line react/no-did-mount-set-state
         inBrowser: true
+      });
+    }
+  }
+
+  handleTailHighlight(condition) {
+    if (condition) {
+      this.setState({
+        tailHighlight: true
+      });
+    }
+  }
+
+  handleTailBlur(condition) {
+    if (condition) {
+      this.setState({
+        tailHighlight: false
       });
     }
   }
@@ -50,6 +70,7 @@ export default class AnnotationPopupShare extends PureComponent {
       tail: true,
       'tail-down': this.props.direction === 'up',
       'tail-up': this.props.direction === 'down',
+      highlight: this.state.tailHighlight
     });
 
     return (
@@ -60,7 +81,16 @@ export default class AnnotationPopupShare extends PureComponent {
          Cite
          </button>
         */}
-        <SocialButtons text={this.props.text} url={this.url()} />
+        <SocialButtons
+          text={this.props.text}
+          url={this.url()}
+          handleTailHighlight={
+            () => {
+              this.handleTailHighlight(this.props.direction === 'down');
+            }
+          }
+          handleTailBlur={() => { this.handleTailBlur(true); }}
+        />
         <button onClick={this.props.back} className="dark">
           <i className="manicon manicon-arrow-bold-left"></i>
           Back

--- a/client/src/components/reader/Annotation/Popup/SocialButtons.js
+++ b/client/src/components/reader/Annotation/Popup/SocialButtons.js
@@ -37,6 +37,8 @@ class AnnotationPopupShareSocialButtons extends PureComponent {
           url={this.props.url}
           message={shareMessage}
           windowOptions={twitterWindowOptions}
+          onMouseEnter={this.props.handleTailHighlight}
+          onMouseLeave={this.props.handleTailBlur}
         >
           <i className="manicon manicon-twitter"></i>
           {'Twitter'}

--- a/client/src/theme/Components/reader/_annotation-popup.scss
+++ b/client/src/theme/Components/reader/_annotation-popup.scss
@@ -188,11 +188,11 @@
     }
   }
 
-  button:hover + .tail-down {
+  .tail-down.highlight, button:hover + .tail-down {
     border-color: $accentPrimary transparent transparent;
   }
 
-  button:first-child:hover ~ .tail-up {
+  .tail-up.highlight, button:first-child:hover ~ .tail-up {
     border-color: transparent transparent $accentPrimary;
   }
 }


### PR DESCRIPTION
This is a minor fix to add some of the more complex hover styles back to the annotation popup. Because some of the buttons are in groups, we can't use simple sibling selectors to highlight the tail when the button next to it is hovered.