### PR TITLE
[B] Bump active background on BE list to the right

### DIFF
--- a/client/src/theme/Components/backend/_vertical-list.scss
+++ b/client/src/theme/Components/backend/_vertical-list.scss
@@ -62,7 +62,7 @@
       &.active {
         background-color: $neutral95;
         border-color: $neutral95;
-        box-shadow: -21px 0 0 $neutral95;
+        box-shadow: -21px 0 0 $neutral95, 21px 0 0 $neutral95;
 
         a {
           color: $accentPrimary;


### PR DESCRIPTION
[Fixes #313]

Preview of active state without drawer:
![manifold scholarship 2017-05-04 14-56-59](https://cloud.githubusercontent.com/assets/1628239/25726692/3a431538-30da-11e7-95ab-82ee03839a76.png)
