### PR TITLE
[B] Make BE secondary nav scrollable

### DIFF
--- a/client/src/theme/Components/_base.scss
+++ b/client/src/theme/Components/_base.scss
@@ -21,6 +21,8 @@ html {
   // It seems that the width of the element is computed prior to kerning
   // https://code.google.com/p/chromium/issues/detail?id=189755
   // text-rendering: optimizeLegibility;
+  // Autohide scrollbars when not in use on Edge
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
 body {

--- a/client/src/theme/Components/backend/_panel.scss
+++ b/client/src/theme/Components/backend/_panel.scss
@@ -70,7 +70,7 @@
   // Scrollable top version of aside nav
   // Scopes and modifies panel nav
   .scrollable {
-    overflow: hidden;
+    overflow: scroll;
     background-color: $neutral80;
 
     @include respond($break40) {


### PR DESCRIPTION
[Fixes #293]
Also auto-hide scrollbars in IE11/Edge