### PR TITLE
[B] Footer text nav has incorrect top margin

### DIFF
--- a/api/app/serializers/page_partial_serializer.rb
+++ b/api/app/serializers/page_partial_serializer.rb
@@ -2,5 +2,5 @@
 class PagePartialSerializer < ActiveModel::Serializer
   meta(partial: true)
 
-  attributes :id, :slug, :title, :nav_title
+  attributes :id, :slug, :title, :nav_title, :show_in_footer
 end

--- a/client/src/components/frontend/Layout/Footer.js
+++ b/client/src/components/frontend/Layout/Footer.js
@@ -42,12 +42,14 @@ export default class LayoutFooter extends Component {
   buildContentPages() {
     let pages = [];
     if (this.props.pages) {
-      pages = this.props.pages.map((page) => {
-        return (
-          <Link to={`/browse/page/${page.attributes.slug}`}>
-            {page.attributes.navTitle}
-          </Link>
-        );
+      this.props.pages.forEach((page) => {
+        if (page.showInFooter) {
+          pages.push((
+            <Link to={`/browse/page/${page.attributes.slug}`}>
+              {page.attributes.navTitle ? page.attributes.navTitle : page.attributes.title}
+            </Link>
+          ));
+        }
       });
     }
     return pages;

--- a/client/src/components/frontend/Layout/Footer.js
+++ b/client/src/components/frontend/Layout/Footer.js
@@ -43,7 +43,8 @@ export default class LayoutFooter extends Component {
     let pages = [];
     if (this.props.pages) {
       this.props.pages.forEach((page) => {
-        if (page.showInFooter) {
+        console.log(page.attributes.showInFooter, page.attributes.title);
+        if (page.attributes.showInFooter) {
           pages.push((
             <Link to={`/browse/page/${page.attributes.slug}`}>
               {page.attributes.navTitle ? page.attributes.navTitle : page.attributes.title}


### PR DESCRIPTION
[Fixes #308]

This is a view level fix that prevents Page records from appearing in the site footer unless they have `show_in_footer` set on the instance. The fix serializes show_in_footer so that it is accessible though JSX. This also displays links that don’t have a `nav_title` set using the `title` attribute as a fallback.