### PR TITLE
[B] Fix project thumbnail usage and style

### DIFF
--- a/api/app/serializers/project_partial_serializer.rb
+++ b/api/app/serializers/project_partial_serializer.rb
@@ -7,7 +7,7 @@ class ProjectPartialSerializer < ActiveModel::Serializer
              :purchase_price_currency, :purchase_price, :purchase_version_label,
              :twitter_id, :instagram_id, :facebook_id, :hero_styles, :cover_styles,
              :avatar_styles, :recently_updated, :updated, :description_formatted, :slug,
-             :resource_kinds, :resource_tags, :avatar_color
+             :resource_kinds, :resource_tags, :avatar_color, :avatar_meta
 
   has_many :creators, serializer: MakerSerializer
   has_many :contributors, serializer: MakerSerializer

--- a/api/db/migrate/20170606175305_add_avatar_meta_to_projects.rb
+++ b/api/db/migrate/20170606175305_add_avatar_meta_to_projects.rb
@@ -1,0 +1,13 @@
+class AddAvatarMetaToProjects < ActiveRecord::Migration[5.0]
+  def change
+    add_column :projects, :avatar_meta, :jsonb, null: false, default: {}
+
+    Project.reset_column_information
+
+    say_with_time "Populating avatar_meta for projects" do
+      Project.where("avatar_meta = '{}'").find_each do |project|
+        project.avatar.reprocess!
+      end
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170512190317) do
+ActiveRecord::Schema.define(version: 20170606175305) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -249,8 +249,9 @@ ActiveRecord::Schema.define(version: 20170512190317) do
     t.jsonb    "tweet_fetch_config",      default: {}
     t.date     "publication_date"
     t.string   "slug"
-    t.string   "avatar_color",            default: "primary"
     t.jsonb    "citations",               default: {}
+    t.string   "avatar_color",            default: "primary"
+    t.jsonb    "avatar_meta",             default: {},        null: false
     t.index ["slug"], name: "index_projects_on_slug", unique: true, using: :btree
   end
 

--- a/client/src/components/frontend/Project/Cover.js
+++ b/client/src/components/frontend/Project/Cover.js
@@ -9,11 +9,14 @@ export default class ProjectCover extends Component {
     project: PropTypes.object
   };
 
-  renderCoverImage(project) {
-    if (!project.attributes.avatarStyles.small) return null;
+  renderAvatarImage(project) {
+    if (!project.attributes.avatarMeta.original) return null;
+    const meta = project.attributes.avatarMeta.original;
+    const imageStyle = meta.width >= meta.height ? project.attributes.avatarStyles.smallSquare
+      : project.attributes.avatarStyles.small;
     return (
       <img
-        src={project.attributes.avatarStyles.small}
+        src={imageStyle}
         alt={`Click to view ${project.attributes.title}`}
       />
     );
@@ -33,8 +36,8 @@ export default class ProjectCover extends Component {
     if (!project) return null;
 
     return (
-      project.attributes.avatarStyles.small ?
-        this.renderCoverImage(project)
+      project.attributes.avatarStyles.original ?
+        this.renderAvatarImage(project)
         : this.renderPlaceholderImage(project)
     );
   }


### PR DESCRIPTION
This PR address bug #378, but also includes a usage change.  We previously were using the project's avatar image on the home grid, while it seems we should be looking for Cover -> Avatar -> Placeholder.

[Fixes #378]