### PR TITLE
[B] Fix text clipping through container

### DIFF
--- a/client/src/theme/Components/_base.scss
+++ b/client/src/theme/Components/_base.scss
@@ -32,7 +32,10 @@ body {
   min-width: $containerWidthMin;
   font-size: 1em;
   font-weight: $regular;
+  hyphens: auto;
   line-height: $baseLineHeight;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
   // color: $something;
   &.no-scroll {
     overflow: hidden;

--- a/client/src/theme/Components/browse/event/_events.scss
+++ b/client/src/theme/Components/browse/event/_events.scss
@@ -126,6 +126,10 @@
       padding-left: 36px;
     }
 
+    > div {
+      width: 100%;
+    }
+
     .manicon {
       position: absolute;
       top: 0;

--- a/client/src/theme/Components/reader/_text-section.scss
+++ b/client/src/theme/Components/reader/_text-section.scss
@@ -16,6 +16,7 @@
 }
 
 .reader-window {
+  @include resetWordWrap;
   padding: 60px 0 120px;
   overflow: hidden;
   color: $neutralOffBlack;

--- a/client/src/theme/Components/reader/annotation/_detail.scss
+++ b/client/src/theme/Components/reader/annotation/_detail.scss
@@ -108,8 +108,6 @@
     @include drawerIndent(padding-left);
     font-weight: $regular;
     line-height: 1.375;
-    overflow-wrap: break-word;
-    word-wrap: break-word;
   }
 
   // Direct scoping because nested comments also have utility

--- a/client/src/theme/STACSS/_typography.scss
+++ b/client/src/theme/STACSS/_typography.scss
@@ -82,6 +82,12 @@
   @include utilityPrimary;
 }
 
+@mixin resetWordWrap {
+  overflow-wrap: normal;
+  word-wrap: normal;
+  hyphens: none;
+}
+
 
 // Labels
 // --------------------------------------------------------


### PR DESCRIPTION
Fixes wrapping in several places:
- Project grid titles
- Event card titles
- Project text titles

[Fixes #401]
