### PR TITLE
Hide featured projects section when there are none

### DIFF
--- a/client/src/containers/frontend/Following.js
+++ b/client/src/containers/frontend/Following.js
@@ -111,6 +111,35 @@ export class FollowingContainer extends Component {
     );
   }
 
+  renderFeaturedProjects() {
+    if (!this.props.featuredProjects.length > 0) return null;
+    return (
+      <section>
+        <div className="container">
+          <header className="section-heading utility-right">
+            <h4 className="title">
+              <i className="manicon manicon-lamp" />
+              {"Featured Projects"}
+            </h4>
+            {this.renderFeaturedButton(featuredLimit)}
+          </header>
+          {this.props.featuredProjects
+            ? <ProjectList.Grid
+                authenticated={this.props.authentication.authenticated}
+                favorites={get(
+                  this.props.authentication,
+                  "currentUser.favorites"
+                )}
+                dispatch={this.props.dispatch}
+                projects={this.props.featuredProjects}
+                limit={featuredLimit}
+              />
+            : null}
+        </div>
+      </section>
+    );
+  }
+
   render() {
     const boundSetFilters = bindActionCreators(
       setProjectFilters,
@@ -132,30 +161,10 @@ export class FollowingContainer extends Component {
             handleUpdate={boundSetFilters}
             dispatch={this.props.dispatch}
           />
-          <section>
-            <div className="container">
-              <header className="section-heading utility-right">
-                <h4 className="title">
-                  <i className="manicon manicon-lamp" />
-                  {"Featured Projects"}
-                </h4>
-                {this.renderFeaturedButton(featuredLimit)}
-              </header>
-              {this.props.featuredProjects
-                ? <ProjectList.Grid
-                    authenticated={this.props.authentication.authenticated}
-                    favorites={get(
-                      this.props.authentication,
-                      "currentUser.favorites"
-                    )}
-                    dispatch={this.props.dispatch}
-                    projects={this.props.featuredProjects}
-                    limit={featuredLimit}
-                  />
-                : null}
-            </div>
-          </section>
-          <Layout.ButtonNavigation grayBg showFollowing={false} />
+          {this.renderFeaturedProjects()}
+          {this.props.followedProjects && this.props.followedProjects.length > 0
+            ? <Layout.ButtonNavigation grayBg showFollowing={false} />
+            : null}
         </div>
       </HigherOrder.RequireRole>
     );

--- a/client/src/containers/frontend/Home.js
+++ b/client/src/containers/frontend/Home.js
@@ -10,6 +10,7 @@ import { select } from "utils/entityUtils";
 import { projectsAPI, requests } from "api";
 import get from "lodash/get";
 import lh from "helpers/linkHandler";
+import classNames from "classnames";
 
 const { setProjectFilters } = uiFilterActions;
 const { request } = entityStoreActions;
@@ -109,6 +110,15 @@ export class HomeContainer extends Component {
   }
 
   render() {
+    const headerClass = classNames({
+      "section-heading": true,
+      "utility-right": this.renderFeaturedProjects(),
+      "utility-under": !this.renderFeaturedProjects()
+    });
+    const utilityHeader = classNames({
+      "section-heading-utility-right": this.renderFeaturedProjects(),
+      "section-heading-utility-under": !this.renderFeaturedProjects()
+    });
     return (
       <div
         style={{
@@ -128,12 +138,12 @@ export class HomeContainer extends Component {
         {this.renderFeaturedProjects()}
         <section className="bg-neutral05">
           <div className="container">
-            <header className="section-heading utility-right">
+            <header className={headerClass}>
               <h4 className="title">
                 <i className="manicon manicon-books-on-shelf" />
                 {"Our Projects"}
               </h4>
-              <div className="section-heading-utility-right">
+              <div className={utilityHeader}>
                 {/*
                  Note that we're using a different dumb component to render this.
                  Note, too, that the parent component delivers all the data the child

--- a/client/src/containers/frontend/Home.js
+++ b/client/src/containers/frontend/Home.js
@@ -84,6 +84,30 @@ export class HomeContainer extends Component {
     );
   }
 
+  renderFeaturedProjects() {
+    if (!this.props.featuredProjects.length > 0) return null;
+    return (
+      <section>
+        <div className="container">
+          <header className="section-heading">
+            <h4 className="title">
+              <i className="manicon manicon-lamp" />
+              {"Featured Projects"}
+            </h4>
+          </header>
+          <ProjectList.Grid
+            authenticated={this.props.authentication.authenticated}
+            favorites={get(this.props.authentication, "currentUser.favorites")}
+            projects={this.props.featuredProjects}
+            dispatch={this.props.dispatch}
+            limit={featuredLimit}
+          />
+          {this.renderFeaturedButton(featuredLimit)}
+        </div>
+      </section>
+    );
+  }
+
   render() {
     return (
       <div
@@ -101,29 +125,7 @@ export class HomeContainer extends Component {
           "featured projects" set of entities instead so as to
           showcase/debug the markup for this type of list.
         */}
-        <section>
-          <div className="container">
-            <header className="section-heading">
-              <h4 className="title">
-                <i className="manicon manicon-lamp" />
-                {"Featured Projects"}
-              </h4>
-            </header>
-            {this.props.featuredProjects
-              ? <ProjectList.Grid
-                  authenticated={this.props.authentication.authenticated}
-                  favorites={get(
-                    this.props.authentication,
-                    "currentUser.favorites"
-                  )}
-                  projects={this.props.featuredProjects}
-                  dispatch={this.props.dispatch}
-                  limit={featuredLimit}
-                />
-              : null}
-            {this.renderFeaturedButton(featuredLimit)}
-          </div>
-        </section>
+        {this.renderFeaturedProjects()}
         <section className="bg-neutral05">
           <div className="container">
             <header className="section-heading utility-right">

--- a/client/src/theme/Components/shared/_section-heading.scss
+++ b/client/src/theme/Components/shared/_section-heading.scss
@@ -10,6 +10,10 @@
     }
   }
 
+  &.utility-under {
+    margin-bottom: 37px;
+  }
+
   .title {
     @include headingPrimary;
     color: $neutral80;


### PR DESCRIPTION
Also includes a CSS fix to move the project filter dropdown when featured projects are not present.  Avoids clipping with Manifold heading image.