### PR TITLE
[B] Generate hashtag on project import

### DIFF
--- a/api/app/services/importer/project.rb
+++ b/api/app/services/importer/project.rb
@@ -26,8 +26,10 @@ module Importer
     private
 
     def find_project
+      hashtag = @project_json[:attributes][:hashtag] ||
+                @project_json[:attributes][:title].parameterize
       ::Project.find_or_initialize_by(
-        hashtag: @project_json[:attributes][:hashtag]
+        hashtag: hashtag
       )
     end
 


### PR DESCRIPTION
Fixes an issue where projects will be overwritten if there is no hashtag in the `project.json`.