### PR TITLE
[B] Focus on textarea when annotation editor mounts

### DIFF
--- a/client/src/components/reader/Annotation/Editor.js
+++ b/client/src/components/reader/Annotation/Editor.js
@@ -29,6 +29,7 @@ export default class AnnotationSelectionEditor extends PureComponent {
     this.handlePrivacyChange = this.handlePrivacyChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleCancel = this.handleCancel.bind(this);
+    this.focusTimeout = setTimeout(() => this.ci.focus(), 0);
 
     this.state = {
       body: "",
@@ -40,9 +41,8 @@ export default class AnnotationSelectionEditor extends PureComponent {
     if (props.private) this.state.isPrivate = props.private;
   }
 
-  componentDidMount() {
-    if (!this.ci) return null;
-    this.ci.focus();
+  componentWillUnmount() {
+    clearTimeout(this.focusTimeout);
   }
 
   handleSubmit(event) {


### PR DESCRIPTION
Fixes #495

For information about original info/why we're using a timeout:
[https://stackoverflow.com/questions/35522220/react-ref-with-focus-doesnt-work-without-settimeout-my-example#answer-35522475](https://stackoverflow.com/questions/35522220/react-ref-with-focus-doesnt-work-without-settimeout-my-example#answer-35522475)