### PR TITLE
[B] Fix notification reduce initial state mutation

### DIFF
--- a/client/src/containers/reader/Section.js
+++ b/client/src/containers/reader/Section.js
@@ -7,6 +7,7 @@ import { grab, isEntityLoaded } from "utils/entityUtils";
 import { entityStoreActions } from "actions";
 import uniq from "lodash/uniq";
 import difference from "lodash/difference";
+import get from "lodash/get";
 import { renderRoutes } from "helpers/routing";
 import { HeadContent } from "components/global";
 
@@ -107,9 +108,9 @@ export class SectionContainer extends Component {
 
   showLabel() {
     const text = this.props.text;
-    return (
-      !text.attributes.published && text.relationships.category.attributes.title
-    );
+    if (text.attributes.published) return false;
+    if (get(text, "relationships.category.attributes.title")) return true;
+    return false;
   }
 
   render() {
@@ -146,7 +147,7 @@ export class SectionContainer extends Component {
         </div>
         {this.showLabel()
           ? <Section.Label
-              label={text.relationships.category.attributes.title}
+              label={get(text, "relationships.category.attributes.title")}
             />
           : null}
       </div>

--- a/client/src/store/reducers/notifications.js
+++ b/client/src/store/reducers/notifications.js
@@ -4,13 +4,14 @@ const initialState = {
 };
 
 const addNotification = (state, action) => {
-  const index = state.notifications.findIndex(n => n.id === action.payload.id);
+  const notifications = state.notifications.slice(0);
+  const index = notifications.findIndex(n => n.id === action.payload.id);
   if (index >= 0) {
-    const notifications = state.notifications.slice(0);
     notifications[index] = action.payload;
     return Object.assign({}, state, { notifications });
   }
-  return Object.assign({}, state, state.notifications.unshift(action.payload));
+  notifications.unshift(action.payload);
+  return Object.assign({}, state, { notifications });
 };
 
 const setFatalError = (state, action) => {


### PR DESCRIPTION
The notification reducer was mutating the initial state, which was
causing notifications to persist between requests to the node
renderer service.

Fixes #504