### PR TITLE
[B] Prevent sign in overlay from updating on authentication

### DIFF
--- a/client/src/components/global/SignInUp/Create.js
+++ b/client/src/components/global/SignInUp/Create.js
@@ -15,8 +15,7 @@ class CreateContainer extends Component {
     response: PropTypes.object,
     user: PropTypes.object,
     authentication: PropTypes.object,
-    showLogin: PropTypes.func.isRequired,
-    showCreateUpdate: PropTypes.func.isRequired
+    handleViewChange: PropTypes.func.isRequired
   };
 
   static mapStateToProps = state => {
@@ -47,9 +46,6 @@ class CreateContainer extends Component {
     if (nextProps.user && !this.props.user) {
       this.authenticateUser();
     }
-    if (nextProps.authentication.authenticated) {
-      this.props.showCreateUpdate();
-    }
   }
 
   componentWillUnmount() {
@@ -69,12 +65,16 @@ class CreateContainer extends Component {
 
   createUser(event) {
     event.preventDefault(event.target);
-    this.props.dispatch(
-      request(
-        usersAPI.create({ attributes: this.state.user }),
-        requests.gCreateUser
+    this.props
+      .dispatch(
+        request(
+          usersAPI.create({ attributes: this.state.user }),
+          requests.gCreateUser
+        )
       )
-    );
+      .promise.then(() => {
+        this.props.handleViewChange("account-create-update");
+      });
   }
 
   handleInputChange(event) {
@@ -200,7 +200,12 @@ class CreateContainer extends Component {
           }
         </p>
         <p className="login-links">
-          <a href="#" onClick={this.props.showLogin} data-id="show-login">
+          <a
+            href="#"
+            onClick={event =>
+              this.props.handleViewChange("account-login", event)}
+            data-id="show-login"
+          >
             {"Already have an account?"}
           </a>
         </p>

--- a/client/src/components/global/SignInUp/Login.js
+++ b/client/src/components/global/SignInUp/Login.js
@@ -10,8 +10,7 @@ import { SignInUp } from "components/global";
 export default class Login extends Component {
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
-    showForgot: PropTypes.func.isRequired,
-    showCreate: PropTypes.func.isRequired,
+    handleViewChange: PropTypes.func.isRequired,
     authentication: PropTypes.shape({
       currentUser: PropTypes.object
     }),
@@ -110,10 +109,20 @@ export default class Login extends Component {
           </div>
         </form>
         <p className="login-links">
-          <a href="#" onClick={this.props.showForgot} data-id="show-forgot">
+          <a
+            href="#"
+            onClick={event =>
+              this.props.handleViewChange("account-password-forgot", event)}
+            data-id="show-forgot"
+          >
             {"Forgot your password?"}
           </a>
-          <a href="#" onClick={this.props.showCreate} data-id="show-create">
+          <a
+            href="#"
+            onClick={event =>
+              this.props.handleViewChange("account-create", event)}
+            data-id="show-create"
+          >
             {"Need to sign up?"}
           </a>
         </p>

--- a/client/src/components/global/SignInUp/Overlay.js
+++ b/client/src/components/global/SignInUp/Overlay.js
@@ -14,10 +14,12 @@ export default class Overlay extends Component {
     dispatch: PropTypes.func
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
-      view: null
+      view: props.authentication.authenticated
+        ? "account-update"
+        : "account-login"
     };
     this.updateView = this.updateView.bind(this);
     this.childProps = this.childProps.bind(this);
@@ -28,7 +30,9 @@ export default class Overlay extends Component {
       this.props.authentication.authenticated === false &&
       nextProps.authentication.authenticated === true
     ) {
-      this.props.hideSignInUpOverlay();
+      if (this.state.view !== "account-create-update") {
+        this.props.hideSignInUpOverlay();
+      }
     }
   }
 
@@ -39,22 +43,7 @@ export default class Overlay extends Component {
 
   childProps() {
     return {
-      updateView: this.updateView,
-      showLogin: e => {
-        this.updateView("account-login", e);
-      },
-      showCreate: e => {
-        this.updateView("account-create", e);
-      },
-      showForgot: e => {
-        this.updateView("account-password-forgot", e);
-      },
-      showReset: e => {
-        this.updateView("account-password-reset", e);
-      },
-      showCreateUpdate: e => {
-        this.updateView("account-create-update", e);
-      },
+      handleViewChange: this.updateView,
       dispatch: this.props.dispatch,
       hideSignInUpOverlay: this.props.hideSignInUpOverlay,
       authentication: this.props.authentication
@@ -81,11 +70,7 @@ export default class Overlay extends Component {
         child = <Login {...childProps} />;
         break;
       default:
-        if (this.props.authentication.authenticated) {
-          child = <Update {...childProps} />;
-        } else {
-          child = <Login {...childProps} />;
-        }
+        child = null;
         break;
     }
     return child;

--- a/client/src/components/global/SignInUp/PasswordForgot.js
+++ b/client/src/components/global/SignInUp/PasswordForgot.js
@@ -13,8 +13,7 @@ class PasswordForgotContainer extends Component {
   static displayName = "PasswordForgotContainer";
 
   static propTypes = {
-    showLogin: PropTypes.func.isRequired,
-    showCreate: PropTypes.func.isRequired,
+    handleViewChange: PropTypes.func.isRequired,
     hideSignInUpOverlay: PropTypes.func,
     dispatch: PropTypes.func,
     response: PropTypes.object
@@ -137,10 +136,20 @@ class PasswordForgotContainer extends Component {
           </div>
         </form>
         <p className="login-links">
-          <a href="#" onClick={this.props.showLogin} data-id="show-login">
+          <a
+            href="#"
+            onClick={event =>
+              this.props.handleViewChange("account-login", event)}
+            data-id="show-login"
+          >
             {"Remember your password?"}
           </a>
-          <a href="#" onClick={this.props.showCreate} data-id="show-create">
+          <a
+            href="#"
+            onClick={event =>
+              this.props.handleViewChange("account-create", event)}
+            data-id="show-create"
+          >
             {"Need to sign up?"}
           </a>
         </p>

--- a/client/src/components/global/SignInUp/__tests__/Create-test.js
+++ b/client/src/components/global/SignInUp/__tests__/Create-test.js
@@ -9,18 +9,14 @@ import { wrapWithRouter, renderWithRouter } from "test/helpers/routing";
 describe("Global.SignInUp.Create component", () => {
   const store = build.store();
 
-  const showForgot = jest.fn();
-  const showLogin = jest.fn();
-  const showCreateUpdate = jest.fn();
+  const handleViewChange = jest.fn();
   const user = build.entity.user("1");
 
   const root = wrapWithRouter(
     <Provider store={store}>
       <Create
         dispatch={store.dispatch}
-        showForgot={showForgot}
-        showLogin={showLogin}
-        showCreateUpdate={showCreateUpdate}
+        handleViewChange={handleViewChange}
         user={user}
       />
     </Provider>
@@ -32,10 +28,10 @@ describe("Global.SignInUp.Create component", () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it("should trigger showLogin callback when show login is clicked", () => {
+  it("should trigger handleViewChange callback when show login is clicked", () => {
     const wrapper = mount(wrapWithRouter(root));
-    showLogin.mockClear();
+    handleViewChange.mockClear();
     wrapper.find('[data-id="show-login"]').first().simulate("click");
-    expect(showLogin).toHaveBeenCalled();
+    expect(handleViewChange).toHaveBeenCalled();
   });
 });

--- a/client/src/components/global/SignInUp/__tests__/Login-test.js
+++ b/client/src/components/global/SignInUp/__tests__/Login-test.js
@@ -8,18 +8,14 @@ import { Provider } from "react-redux";
 describe("Global.SignInUp.Login component", () => {
   const store = build.store();
 
-  const showForgot = jest.fn();
-  const showLogin = jest.fn();
-  const showCreate = jest.fn();
+  const handleViewChange = jest.fn();
   const user = build.entity.user("1");
 
   const root = (
     <Provider store={store}>
       <Login
         dispatch={store.dispatch}
-        showForgot={showForgot}
-        showLogin={showLogin}
-        showCreate={showCreate}
+        handleViewChange={handleViewChange}
         user={user}
         authentication={{
           currentUser: user
@@ -34,17 +30,17 @@ describe("Global.SignInUp.Login component", () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it("should trigger showForgot callback when show forgot is clicked", () => {
+  it("should trigger handleViewChange callback when show forgot is clicked", () => {
     const wrapper = mount(root);
-    showForgot.mockClear();
+    handleViewChange.mockClear();
     wrapper.find('[data-id="show-forgot"]').first().simulate("click");
-    expect(showForgot).toHaveBeenCalled();
+    expect(handleViewChange).toHaveBeenCalled();
   });
 
-  it("should trigger showCreate callback when show create is clicked", () => {
+  it("should trigger handleViewChange callback when show create is clicked", () => {
     const wrapper = mount(root);
-    showCreate.mockClear();
+    handleViewChange.mockClear();
     wrapper.find('[data-id="show-create"]').first().simulate("click");
-    expect(showCreate).toHaveBeenCalled();
+    expect(handleViewChange).toHaveBeenCalled();
   });
 });

--- a/client/src/components/global/SignInUp/__tests__/PasswordForgot-test.js
+++ b/client/src/components/global/SignInUp/__tests__/PasswordForgot-test.js
@@ -9,15 +9,13 @@ import { wrapWithRouter, renderWithRouter } from "test/helpers/routing";
 describe("Global.SignInUp.PasswordForgot component", () => {
   const store = build.store();
 
-  const showCreate = jest.fn();
-  const showLogin = jest.fn();
+  const handleViewChange = jest.fn();
 
   const root = wrapWithRouter(
     <Provider store={store}>
       <PasswordForgot
         dispatch={store.dispatch}
-        showCreate={showCreate}
-        showLogin={showLogin}
+        handleViewChange={handleViewChange}
       />
     </Provider>
   );
@@ -28,17 +26,17 @@ describe("Global.SignInUp.PasswordForgot component", () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it("should trigger showLogin callback when show login is clicked", () => {
+  it("should trigger handleViewChange callback when show login is clicked", () => {
     const wrapper = mount(root);
-    showLogin.mockClear();
+    handleViewChange.mockClear();
     wrapper.find('[data-id="show-login"]').first().simulate("click");
-    expect(showLogin).toHaveBeenCalled();
+    expect(handleViewChange).toHaveBeenCalled();
   });
 
-  it("should trigger showCreate callback when show create is clicked", () => {
+  it("should trigger handleViewChange callback when show create is clicked", () => {
     const wrapper = mount(root);
-    showCreate.mockClear();
+    handleViewChange.mockClear();
     wrapper.find('[data-id="show-create"]').first().simulate("click");
-    expect(showCreate).toHaveBeenCalled();
+    expect(handleViewChange).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #473 

This bug was caused by the component updating after it's props changed before the `hideSignInUpOverlay` function was called.  There is never a case where the component should transition from `login => update` or vice-versa, so we don't have to try and determine which of those to use after it's created.  Instead, we can initialize the component state with the view we want, rather than deferring to the default case of the `renderChild` function.

Additionally, rather than passing down function props for each view change, this commit refactors the `childProps` function to only pass down a single function to handle changing views.