### PR TITLE
[B] Don't show page nav buttons at mobile sizes

### DIFF
--- a/client/src/components/frontend/Layout/ButtonNavigation.js
+++ b/client/src/components/frontend/Layout/ButtonNavigation.js
@@ -19,6 +19,7 @@ export default class LayoutButtonNavigation extends Component {
     grayBg: PropTypes.bool,
     showBrowse: PropTypes.bool,
     showFollowing: PropTypes.bool,
+    hideAtNarrow: PropTypes.bool,
     authenticated: PropTypes.bool
   };
 
@@ -89,6 +90,7 @@ export default class LayoutButtonNavigation extends Component {
 
   render() {
     const sectionClass = classNames({
+      "show-50": this.props.hideAtNarrow === true,
       "bg-neutral05": this.props.grayBg === true
     });
 

--- a/client/src/components/frontend/Layout/MobileNav.js
+++ b/client/src/components/frontend/Layout/MobileNav.js
@@ -11,11 +11,24 @@ export default class MobileNav extends Component {
     location: PropTypes.object
   };
 
+  getActiveLink(props) {
+    const path = props.location.pathname;
+    let out = null;
+    switch (path) {
+      case lh.link("frontend"):
+        out = "browse";
+        break;
+      case lh.link("frontendFollowing"):
+        out = "following";
+        break;
+      default:
+        break;
+    }
+    return out;
+  }
+
   render() {
-    const path = this.props.location.pathname;
-    const active = startsWith(path, lh.link("frontendFollowing"))
-      ? "following"
-      : "browse";
+    const active = this.getActiveLink(this.props);
 
     return (
       <nav className="footer-fixed">

--- a/client/src/components/frontend/Layout/__tests__/MobileNav-test.js
+++ b/client/src/components/frontend/Layout/__tests__/MobileNav-test.js
@@ -6,7 +6,7 @@ import { wrapWithRouter } from "test/helpers/routing";
 describe("Frontend.Layout.MobileNav component", () => {
   it("renders correctly", () => {
     const component = renderer.create(
-      wrapWithRouter(<MobileNav location={{}} />)
+      wrapWithRouter(<MobileNav location={{ pathname: "/" }} />)
     );
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();

--- a/client/src/containers/frontend/Following.js
+++ b/client/src/containers/frontend/Following.js
@@ -165,7 +165,11 @@ export class FollowingContainer extends Component {
           />
           {this.renderFeaturedProjects()}
           {this.props.followedProjects && this.props.followedProjects.length > 0
-            ? <Layout.ButtonNavigation grayBg showFollowing={false} />
+            ? <Layout.ButtonNavigation
+                hideAtNarrow
+                grayBg
+                showFollowing={false}
+              />
             : null}
         </div>
       </HigherOrder.RequireRole>

--- a/client/src/containers/frontend/Home.js
+++ b/client/src/containers/frontend/Home.js
@@ -232,6 +232,7 @@ export class HomeContainer extends Component {
           </div>
         </section>
         <Layout.ButtonNavigation
+          hideAtNarrow
           grayBg={false}
           showBrowse={false}
           authenticated={this.props.authentication.authenticated}

--- a/client/src/containers/frontend/__tests__/__snapshots__/Home-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/Home-test.js.snap
@@ -227,7 +227,7 @@ exports[`Frontend Home Container renders correctly 1`] = `
     </div>
   </section>
   <section
-    className=""
+    className="show-50"
   >
     <div
       className="container"

--- a/client/src/theme/Components/browse/layout/_button-nav.scss
+++ b/client/src/theme/Components/browse/layout/_button-nav.scss
@@ -7,3 +7,4 @@
     vertical-align: top;
   }
 }
+

--- a/client/src/theme/STACSS/_structure.scss
+++ b/client/src/theme/STACSS/_structure.scss
@@ -50,9 +50,14 @@
   @include hide($break60);
 }
 
+.show-50 {
+  @include show($break50);
+}
+
 .show-60 {
   @include show($break60);
 }
+
 
 .rel {
   position: relative;


### PR DESCRIPTION
Fixes #512

Also makes footer nav active states to be more specific to prevent "Projects" being active on featured page.