### PR TITLE
Text wrap by block on back link and breadcrumb

### DIFF
--- a/client/src/components/backend/Layout/Header.js
+++ b/client/src/components/backend/Layout/Header.js
@@ -40,7 +40,7 @@ export default class LayoutHeader extends Component {
     return (
       <header className={"header-app dark"}>
         <div className="header-container">
-          <Link to={lh.link("backend")} className="logo">
+          <Link to={lh.link("frontend")} className="logo">
             <PressLogo
               url={get(this.props.settings, "attributes.pressLogoStyles.small")}
             />

--- a/client/src/components/backend/Layout/__tests__/__snapshots__/Header-test.js.snap
+++ b/client/src/components/backend/Layout/__tests__/__snapshots__/Header-test.js.snap
@@ -9,7 +9,7 @@ exports[`Backend.Layout.Header component renders correctly 1`] = `
   >
     <a
       className="logo"
-      href="/backend"
+      href="/"
       onClick={[Function]}
     >
       <figure

--- a/client/src/components/backend/Navigation/Breadcrumb.js
+++ b/client/src/components/backend/Navigation/Breadcrumb.js
@@ -11,8 +11,8 @@ export default class Breadcrumb extends PureComponent {
 
   render() {
     return (
-      <div className="container flush">
-        <nav className="breadcrumb-primary">
+      <nav className="breadcrumb-primary">
+        <div className="container flush">
           <Link to={this.props.links[0].path} className="initial">
             <i className="manicon manicon-arrow-left" />
             {"Back to:"}
@@ -28,8 +28,8 @@ export default class Breadcrumb extends PureComponent {
               );
             })}
           </ul>
-        </nav>
-      </div>
+        </div>
+      </nav>
     );
   }
 }

--- a/client/src/components/backend/Navigation/__tests__/__snapshots__/Breadcrumb-test.js.snap
+++ b/client/src/components/backend/Navigation/__tests__/__snapshots__/Breadcrumb-test.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Backend.Navigation.Breadcrumb component renders correctly 1`] = `
-<div
-  className="container flush"
+<nav
+  className="breadcrumb-primary"
 >
-  <nav
-    className="breadcrumb-primary"
+  <div
+    className="container flush"
   >
     <a
       className="initial"
@@ -37,6 +37,6 @@ exports[`Backend.Navigation.Breadcrumb component renders correctly 1`] = `
         </a>
       </li>
     </ul>
-  </nav>
-</div>
+  </div>
+</nav>
 `;

--- a/client/src/components/backend/Navigation/__tests__/__snapshots__/DetailHeader-test.js.snap
+++ b/client/src/components/backend/Navigation/__tests__/__snapshots__/DetailHeader-test.js.snap
@@ -4,11 +4,11 @@ exports[`Backend.Navigation.DetailHeader component renders correctly 1`] = `
 <section
   className="bg-neutral95"
 >
-  <div
-    className="container flush"
+  <nav
+    className="breadcrumb-primary"
   >
-    <nav
-      className="breadcrumb-primary"
+    <div
+      className="container flush"
     >
       <a
         className="initial"
@@ -31,8 +31,8 @@ exports[`Backend.Navigation.DetailHeader component renders correctly 1`] = `
           </a>
         </li>
       </ul>
-    </nav>
-  </div>
+    </div>
+  </nav>
   <div
     className="container flush"
   >

--- a/client/src/containers/backend/CollectionDetail/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/CollectionDetail/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -5,11 +5,11 @@ exports[`Backend CollectionDetail Wrapper Container renders correctly 1`] = `
   <section
     className="bg-neutral95"
   >
-    <div
-      className="container flush"
+    <nav
+      className="breadcrumb-primary"
     >
-      <nav
-        className="breadcrumb-primary"
+      <div
+        className="container flush"
       >
         <a
           className="initial"
@@ -41,8 +41,8 @@ exports[`Backend CollectionDetail Wrapper Container renders correctly 1`] = `
             </a>
           </li>
         </ul>
-      </nav>
-    </div>
+      </div>
+    </nav>
     <div
       className="container flush"
     >

--- a/client/src/containers/backend/NewCollection/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/NewCollection/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -5,11 +5,11 @@ exports[`Backend NewCollection Wrapper Container renders correctly 1`] = `
   <section
     className="bg-neutral95"
   >
-    <div
-      className="container flush"
+    <nav
+      className="breadcrumb-primary"
     >
-      <nav
-        className="breadcrumb-primary"
+      <div
+        className="container flush"
       >
         <a
           className="initial"
@@ -32,8 +32,8 @@ exports[`Backend NewCollection Wrapper Container renders correctly 1`] = `
             </a>
           </li>
         </ul>
-      </nav>
-    </div>
+      </div>
+    </nav>
     <div
       className="container flush"
     >

--- a/client/src/containers/backend/NewProject/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/NewProject/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -5,11 +5,11 @@ exports[`Backend NewProject Wrapper Container renders correctly 1`] = `
   <section
     className="bg-neutral95"
   >
-    <div
-      className="container flush"
+    <nav
+      className="breadcrumb-primary"
     >
-      <nav
-        className="breadcrumb-primary"
+      <div
+        className="container flush"
       >
         <a
           className="initial"
@@ -32,8 +32,8 @@ exports[`Backend NewProject Wrapper Container renders correctly 1`] = `
             </a>
           </li>
         </ul>
-      </nav>
-    </div>
+      </div>
+    </nav>
     <div
       className="container flush"
     >

--- a/client/src/containers/backend/NewResource/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/NewResource/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -5,11 +5,11 @@ exports[`Backend NewResource Wrapper Container renders correctly 1`] = `
   <section
     className="bg-neutral95"
   >
-    <div
-      className="container flush"
+    <nav
+      className="breadcrumb-primary"
     >
-      <nav
-        className="breadcrumb-primary"
+      <div
+        className="container flush"
       >
         <a
           className="initial"
@@ -32,8 +32,8 @@ exports[`Backend NewResource Wrapper Container renders correctly 1`] = `
             </a>
           </li>
         </ul>
-      </nav>
-    </div>
+      </div>
+    </nav>
     <div
       className="container flush"
     >

--- a/client/src/containers/backend/NewUser/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/NewUser/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -5,11 +5,11 @@ exports[`Backend NewUser Wrapper Container renders correctly 1`] = `
   <section
     className="bg-neutral95"
   >
-    <div
-      className="container flush"
+    <nav
+      className="breadcrumb-primary"
     >
-      <nav
-        className="breadcrumb-primary"
+      <div
+        className="container flush"
       >
         <a
           className="initial"
@@ -32,8 +32,8 @@ exports[`Backend NewUser Wrapper Container renders correctly 1`] = `
             </a>
           </li>
         </ul>
-      </nav>
-    </div>
+      </div>
+    </nav>
     <div
       className="container flush"
     >

--- a/client/src/containers/backend/ProjectDetail/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/ProjectDetail/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -5,11 +5,11 @@ exports[`Backend ProjectDetail Wrapper Container renders correctly 1`] = `
   <section
     className="bg-neutral95"
   >
-    <div
-      className="container flush"
+    <nav
+      className="breadcrumb-primary"
     >
-      <nav
-        className="breadcrumb-primary"
+      <div
+        className="container flush"
       >
         <a
           className="initial"
@@ -32,8 +32,8 @@ exports[`Backend ProjectDetail Wrapper Container renders correctly 1`] = `
             </a>
           </li>
         </ul>
-      </nav>
-    </div>
+      </div>
+    </nav>
     <div
       className="container flush"
     >

--- a/client/src/containers/backend/ResourceDetail/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/ResourceDetail/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -5,11 +5,11 @@ exports[`Backend ResourceDetail Wrapper Container renders correctly 1`] = `
   <section
     className="bg-neutral95"
   >
-    <div
-      className="container flush"
+    <nav
+      className="breadcrumb-primary"
     >
-      <nav
-        className="breadcrumb-primary"
+      <div
+        className="container flush"
       >
         <a
           className="initial"
@@ -41,8 +41,8 @@ exports[`Backend ResourceDetail Wrapper Container renders correctly 1`] = `
             </a>
           </li>
         </ul>
-      </nav>
-    </div>
+      </div>
+    </nav>
     <div
       className="container flush"
     >

--- a/client/src/containers/backend/TextDetail/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/TextDetail/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -5,11 +5,11 @@ exports[`Backend TextDetail Wrapper Container renders correctly 1`] = `
   <section
     className="bg-neutral95"
   >
-    <div
-      className="container flush"
+    <nav
+      className="breadcrumb-primary"
     >
-      <nav
-        className="breadcrumb-primary"
+      <div
+        className="container flush"
       >
         <a
           className="initial"
@@ -41,8 +41,8 @@ exports[`Backend TextDetail Wrapper Container renders correctly 1`] = `
             </a>
           </li>
         </ul>
-      </nav>
-    </div>
+      </div>
+    </nav>
     <div
       className="container flush"
     >

--- a/client/src/containers/backend/__tests__/__snapshots__/Backend-test.js.snap
+++ b/client/src/containers/backend/__tests__/__snapshots__/Backend-test.js.snap
@@ -13,8 +13,8 @@ exports[`Backend Backend Container renders correctly 1`] = `
                   <Layout.Header visibility={{...}} location={[undefined]} authentication={{...}} notifications={{...}} commonActions={{...}} settings={[undefined]} scrollAware={{...}}>
                     <header className=\\"header-app dark\\">
                       <div className=\\"header-container\\">
-                        <Link to=\\"/backend\\" className=\\"logo\\" replace={false}>
-                          <a className=\\"logo\\" onClick={[Function]} href=\\"/backend\\">
+                        <Link to=\\"/\\" className=\\"logo\\" replace={false}>
+                          <a className=\\"logo\\" onClick={[Function]} href=\\"/\\">
                             <PressLogo url={[undefined]}>
                               <figure className=\\"\\">
                                 <div>

--- a/client/src/theme/Components/_header-app.scss
+++ b/client/src/theme/Components/_header-app.scss
@@ -16,6 +16,11 @@
 
     .logo {
       color: $neutral50;
+      transition: color $duration $timing;
+
+      &:hover {
+        color: $accentPrimary;
+      }
     }
 
     .text-nav .active {

--- a/client/src/theme/Components/backend/project/_header.scss
+++ b/client/src/theme/Components/backend/project/_header.scss
@@ -10,11 +10,17 @@
   }
 
   figure {
+    display: none;
     float: left;
     width: 68px;
+    margin-bottom: 15px;
 
     @include respond($break30) {
       width: 75px;
+    }
+
+    @include respond($break40) {
+      display: block;
     }
 
     @include respond($break65) {
@@ -43,11 +49,14 @@
     h1, h2, h3, h4, h5, h6 {
       @include templateHead;
       float: left;
-      max-width: calc(100% - 75px);
-      margin-top: 0;
-      font-size: 22px;
+      margin: 0 0 15px;
+      font-size: 21px;
       font-weight: $medium;
       color: $neutral20;
+
+      @include respond($break40) {
+        max-width: calc(100% - 75px);
+      }
 
       @include respond($break30) {
         max-width: calc(100% - 86px);

--- a/client/src/theme/Components/browse/layout/_footer-browse.scss
+++ b/client/src/theme/Components/browse/layout/_footer-browse.scss
@@ -1,9 +1,13 @@
 .footer-browse {
-  padding: 40px 0 57px;
+  padding: 32px 0 57px;
   background-color: $neutral80;
 
+  @include respond($break50) {
+    padding: 40px 0 65px;
+  }
+
   @include respond($break65) {
-    padding: 67px 0 57px;
+    padding: 67px 0 65px;
   }
 
   // <a>
@@ -79,7 +83,11 @@
   }
 
   .footer-secondary {
-    padding-top: 60px;
+    padding-top: 30px;
+
+    @include respond($break50) {
+      padding-top: 60px;
+    }
 
     @include respond($break65) {
       padding-top: 90px;

--- a/client/src/theme/Components/shared/_breadcrumb-primary.scss
+++ b/client/src/theme/Components/shared/_breadcrumb-primary.scss
@@ -1,28 +1,43 @@
 .breadcrumb-primary {
   @include utilityPrimary;
-  display: inline-block;
+  display: block;
   padding: 20px 0 18px;
   font-size: 14px;
+  line-height: 1.4;
   color: $neutral70;
   text-decoration: none;
+
+  .container {
+    position: relative;
+    padding-left: calc(#{$containerPaddingResp} + 26px);
+
+    @include respond($break100) {
+      padding-left: $containerPaddingFull;
+    }
+  }
 
   .initial {
     color: $neutral70;
     text-decoration: none;
   }
 
+
   // Breadcrumb list
   ul {
     @include listHorizontal;
-    display: inline-block;
+    display: inline;
     padding-left: 8px;
 
-    li + li {
-      &::before {
+    li {
+      &::after {
         display: inline-block;
         padding: 0 11px;
         color: $neutral50;
         content: '/';
+      }
+
+      &:last-child::after {
+        display: none;
       }
     }
 
@@ -38,9 +53,13 @@
   }
 
   .manicon {
-    display: inline-block;
-    margin-right: 10px;
+    position: absolute;
+    top: 0.28em;
+    left: $containerPaddingResp;
     font-size: 13px;
-    vertical-align: middle;
+
+    @include respond($break100) {
+      left: $containerPaddingFull;
+    }
   }
 }

--- a/client/src/theme/Components/shared/_breadcrumb-primary.scss
+++ b/client/src/theme/Components/shared/_breadcrumb-primary.scss
@@ -2,17 +2,21 @@
   @include utilityPrimary;
   display: block;
   padding: 20px 0 18px;
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.4;
   color: $neutral70;
   text-decoration: none;
+
+  @include respond($break40) {
+    font-size: 14px;
+  }
 
   .container {
     position: relative;
     padding-left: calc(#{$containerPaddingResp} + 26px);
 
     @include respond($break100) {
-      padding-left: $containerPaddingFull;
+      padding-left: calc(#{$containerPaddingFull} + 26px);
     }
   }
 

--- a/client/src/theme/Components/shared/_buttons.scss
+++ b/client/src/theme/Components/shared/_buttons.scss
@@ -563,6 +563,7 @@
   display: inline-block;
   padding: 20px 0 18px;
   font-size: 14px;
+  line-height: 1.4;
   color: $neutral70;
   text-decoration: none;
   background-color: $neutral05;
@@ -587,11 +588,24 @@
     background-color: $neutral10;
   }
 
+  .container {
+    position: relative;
+    padding-left: calc(#{$containerPaddingResp} + 26px);
+
+    @include respond($break100) {
+      padding-left: $containerPaddingFull;
+    }
+  }
+
   .manicon {
-    display: inline-block;
-    margin-right: 10px;
+    position: absolute;
+    top: 0.28em;
+    left: $containerPaddingResp;
     font-size: 13px;
-    vertical-align: middle;
+
+    @include respond($break100) {
+      left: $containerPaddingFull;
+    }
   }
 
   span {

--- a/client/src/theme/Components/shared/_buttons.scss
+++ b/client/src/theme/Components/shared/_buttons.scss
@@ -562,13 +562,17 @@
   @include utilityPrimary;
   display: inline-block;
   padding: 20px 0 18px;
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.4;
   color: $neutral70;
   text-decoration: none;
   background-color: $neutral05;
   transition: color $duration $timing,
     background-color $duration $timing;
+
+  @include respond($break40) {
+    font-size: 14px;
+  }
 
   &.full {
     display: block;
@@ -593,7 +597,7 @@
     padding-left: calc(#{$containerPaddingResp} + 26px);
 
     @include respond($break100) {
-      padding-left: $containerPaddingFull;
+      padding-left: calc(#{$containerPaddingFull} + 26px);
     }
   }
 


### PR DESCRIPTION
This addresses wrapping on project back links and also ports these updates to the backend breadcrumb:
![manifold scholarship 2017-09-12 12-49-05](https://user-images.githubusercontent.com/1628239/30345107-c53aa0a8-97b8-11e7-93a1-bad994a17db2.png)
