### PR TITLE
[B] Update comment editor with icons/label

### DIFF
--- a/client/src/components/frontend/Resource/Detail.js
+++ b/client/src/components/frontend/Resource/Detail.js
@@ -70,6 +70,7 @@ export default class ResourceDetail extends Component {
                 <div className="resource-comments">
                   <CommentContainer.Thread subject={resource} />
                   <CommentContainer.Editor
+                    label={"Add Comment"}
                     subject={resource}
                     cancel={event => this.cancelComment(event)}
                   />

--- a/client/src/components/frontend/Resource/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/components/frontend/Resource/__tests__/__snapshots__/Detail-test.js.snap
@@ -289,6 +289,14 @@ exports[`Frontend.Resource.Detail component renders correctly 1`] = `
             <div
               className="comment-editor"
             >
+              <h3
+                className="editor-label"
+              >
+                <i
+                  className="manicon manicon-pencil"
+                />
+                Add Comment
+              </h3>
               <div
                 className="placeholder"
               >

--- a/client/src/containers/frontend/__tests__/__snapshots__/CollectionResourceDetail-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/CollectionResourceDetail-test.js.snap
@@ -307,6 +307,14 @@ exports[`Frontend CollectionResourceDetail Container renders correctly 1`] = `
               <div
                 className="comment-editor"
               >
+                <h3
+                  className="editor-label"
+                >
+                  <i
+                    className="manicon manicon-pencil"
+                  />
+                  Add Comment
+                </h3>
                 <div
                   className="placeholder"
                 >

--- a/client/src/containers/frontend/__tests__/__snapshots__/ResourceDetail-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/ResourceDetail-test.js.snap
@@ -307,6 +307,14 @@ exports[`Frontend ResourceDetail Container renders correctly 1`] = `
               <div
                 className="comment-editor"
               >
+                <h3
+                  className="editor-label"
+                >
+                  <i
+                    className="manicon manicon-pencil"
+                  />
+                  Add Comment
+                </h3>
                 <div
                   className="placeholder"
                 >

--- a/client/src/containers/global/Comment/Editor.js
+++ b/client/src/containers/global/Comment/Editor.js
@@ -22,6 +22,7 @@ export class CommentEditor extends PureComponent {
 
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
+    label: PropTypes.string,
     comment: PropTypes.object,
     placeholder: PropTypes.string,
     body: PropTypes.string,
@@ -159,6 +160,12 @@ export class CommentEditor extends PureComponent {
 
     return (
       <div className="comment-editor">
+        {this.props.label
+          ? <h3 className="editor-label">
+              <i className="manicon manicon-pencil" />
+              {this.props.label}
+            </h3>
+          : null}
         <HigherOrder.RequireRole requiredRole="none">
           <div className="placeholder">
             <button onClick={showLogin}>Login to post a comment</button>
@@ -192,6 +199,7 @@ export class CommentEditor extends PureComponent {
                     className="button-secondary"
                     disabled={!this.state.body}
                   >
+                    <i className="manicon manicon-word-bubble-lines" />
                     {this.buttonLabel(this.props)}
                   </button>
                 </div>

--- a/client/src/containers/global/Comment/__tests__/__snapshots__/Editor-test.js.snap
+++ b/client/src/containers/global/Comment/__tests__/__snapshots__/Editor-test.js.snap
@@ -34,6 +34,9 @@ exports[`Global Comment Editor Container renders correctly when logged in 1`] = 
             className="button-secondary"
             disabled={false}
           >
+            <i
+              className="manicon manicon-word-bubble-lines"
+            />
             Update
           </button>
         </div>

--- a/client/src/theme/Components/reader/annotation/comment/_editor.scss
+++ b/client/src/theme/Components/reader/annotation/comment/_editor.scss
@@ -2,6 +2,31 @@
   @include drawerIndent(padding-left);
   padding-top: 18px;
 
+  .editor-label {
+    @include utilityPrimary;
+    display: flex;
+    align-items: center;
+    margin: 0; // OD
+    margin-bottom: 1.313em;
+    font-size: 14px;
+    color: $neutral70;
+    
+    @include respond($break60) {
+      font-size: 16px;
+    }
+
+    .manicon {
+      margin-right: 13px;
+      font-size: 2em;
+      color: $neutral40;
+
+      @include respond($break60) {
+        margin-right: 15px;
+        font-size: 2.313em;
+      }
+    }
+  }
+
   textarea {
     @include templateHead;
     display: block;
@@ -30,12 +55,23 @@
     }
 
     .buttons {
-      display: inline-block;
+      display: flex;
+      justify-content: flex-end;
+      margin: 0;
     }
 
     .button-secondary, .button-secondary-dull {
       min-width: 98px;
       transition: background-color $duration $timing;
+    }
+
+    .button-secondary {
+      padding: 1.188em 1.875em 1em;
+
+      .manicon-word-bubble-lines {
+        margin-right: 0.469em;
+        font-size: 2em;
+      }
     }
 
     .button-secondary-dull {


### PR DESCRIPTION
Delivers #560 
Note that this feature merges some design styles between the annotation comments and the resource comments. It adds a word-bubble icon to the "Post" button.

An optional label prop has been added that automatically contains a relatively sized pencil icon.

There are some inconsistencies between the resource detail content area and master that were not addressed:
- Publish vs. Post button text (this can be addressed but wasn't part of the issue. Personally I think having separate text for the same function isn't helpful)
- Button Font size (it's a little bigger on the resource detail but I don't think it needs to be)

These are easy to address of course, so let me know if we want to adjust and I can make it part of this PR.