### PR TITLE
[B] Update select group input padding

### DIFF
--- a/client/src/components/frontend/Project/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/components/frontend/Project/__tests__/__snapshots__/Resources-test.js.snap
@@ -40,7 +40,7 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
         />
       </div>
       <div
-        className="select-group"
+        className="select-group inline"
       >
         <div
           className="select"

--- a/client/src/components/frontend/ResourceCollection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/components/frontend/ResourceCollection/__tests__/__snapshots__/Detail-test.js.snap
@@ -267,7 +267,7 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
         />
       </div>
       <div
-        className="select-group"
+        className="select-group inline"
       >
         <div
           className="select"

--- a/client/src/components/frontend/ResourceList/Filters.js
+++ b/client/src/components/frontend/ResourceList/Filters.js
@@ -94,7 +94,7 @@ export default class ResourceListFilters extends Component {
             placeholder="Search"
           />
         </div>
-        <div className="select-group">
+        <div className="select-group inline">
           <div className="select">
             <select
               onChange={event => this.setFilters(event, "kind")}

--- a/client/src/components/frontend/ResourceList/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/components/frontend/ResourceList/__tests__/__snapshots__/Filters-test.js.snap
@@ -24,7 +24,7 @@ exports[`Frontend.ResourceList.Filters Component renders correctly 1`] = `
     />
   </div>
   <div
-    className="select-group"
+    className="select-group inline"
   >
     <div
       className="select"

--- a/client/src/containers/frontend/__tests__/__snapshots__/CollectionDetail-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/CollectionDetail-test.js.snap
@@ -296,7 +296,7 @@ exports[`Frontend CollectionDetail Container renders correctly 1`] = `
           />
         </div>
         <div
-          className="select-group"
+          className="select-group inline"
         >
           <div
             className="select"

--- a/client/src/containers/frontend/__tests__/__snapshots__/ProjectResources-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/ProjectResources-test.js.snap
@@ -62,7 +62,7 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
           />
         </div>
         <div
-          className="select-group"
+          className="select-group inline"
         >
           <div
             className="select"

--- a/client/src/theme/Components/shared/forms/_list-filter.scss
+++ b/client/src/theme/Components/shared/forms/_list-filter.scss
@@ -49,6 +49,7 @@
 
   .select-group {
     display: block;
+    width: 100%;
     margin-top: 12px;
     margin-left: -11px;
 
@@ -56,11 +57,13 @@
       margin-top: 14px;
     }
 
-    @include respond($break75) {
-      display: inline-block;
-      width: calc(60% + 11px);
-      padding-left: 12px;
-      margin-top: 0;
+    &.inline {
+      @include respond($break75) {
+        display: inline-block;
+        width: calc(60% + 11px);
+        padding-left: 12px;
+        margin-top: 0;
+      }
     }
 
     .select {
@@ -74,7 +77,7 @@
         @include utilityPrimary;
         width: 100%;
         height: $inputHeight;
-        padding-right: 16px;
+        padding-right: 32px;
         padding-left: 13px;
         font-size: 14px;
         color: $neutral50;


### PR DESCRIPTION
Starts #556 

This addresses an issue where a dropdown arrow collides with text in the dropdown. That said, the maximum size of this select is small enough on most sizes that the longest text string (in this case "Project Created") still gets cut off. (See screenshot)

It's inevitable for some longer selects to get cut off, but the width of this select group is being truncated due to style used in the resource/collection filter (screenshot 2).
To mitigate this, I've added an inline class that allows the filters to sit aside the search input in just these cases.

![screen shot 2017-09-13 at 1 36 35 pm](https://user-images.githubusercontent.com/1628239/30399673-5daadcec-9889-11e7-8cf8-70b892daff2b.png)

![screen shot 2017-09-13 at 1 50 09 pm](https://user-images.githubusercontent.com/1628239/30400030-7ae1cb3a-988a-11e7-9c85-5b3080cbc89f.png)

Please have a quick QA and let me know if I missed any cases where the inline property needs to be applied.