### PR TITLE
[B] Fix annotation popup bugs in ie

### DIFF
--- a/client/src/containers/reader/Annotation/Annotatable.js
+++ b/client/src/containers/reader/Annotation/Annotatable.js
@@ -74,6 +74,28 @@ class Annotatable extends Component {
     }
   };
 
+  nodeContainNode(parent, child) {
+    if (
+      child.anchorNode instanceof HTMLElement &&
+      child.focusNode instanceof HTMLElement
+    ) {
+      if (parent.contains(child.anchorNode)) return true;
+      if (parent.contains(child.focusNode)) return true;
+    } else if (
+      child.anchorNode instanceof Node &&
+      child.focusNode instanceof Node
+    ) {
+      if (parent.compareDocumentPosition(child.anchorNode) & 16) {
+        return true;
+      }
+      if (parent.compareDocumentPosition(child.focusNode) & 16) {
+        return true;
+      }
+    } else {
+      return false;
+    }
+  }
+
   // The native selection is read only, so we'll map it to a similar selection object
   // that we have more control over.
   updateStateSelection = (nativeSelection, selectionClickEvent = null) => {
@@ -83,8 +105,7 @@ class Annotatable extends Component {
     // if there's no native selection, return
     if (!nativeSelection) return;
     // does the native selection start and end in our document?
-    if (!this.annotatable.contains(nativeSelection.anchorNode)) return;
-    if (!this.annotatable.contains(nativeSelection.focusNode)) return;
+    if (!this.nodeContainNode(this.annotatable, nativeSelection)) return;
     // normalize the native selection
     const selection = this.mapNativeSelectionToState(nativeSelection);
     // if it changed, return

--- a/client/src/theme/Components/reader/_annotation-popup.scss
+++ b/client/src/theme/Components/reader/_annotation-popup.scss
@@ -82,6 +82,7 @@
     color: $neutralWhite;
     text-align: left;
     background-color: $neutral80;
+    background-clip: padding-box;
     transition: color $duration $timing, background-color $duration $timing;
 
     &.dark {


### PR DESCRIPTION
RESOLVES #637 

After much investigation and experimentation I came upon this little used css property used to stipulate where the background image or color gets clipped in regard to the element's content-box, border-box, padding-box, etc.  I feel like in the mordern-era this distinction is usually moot but in THIS case it ended up being crucial.  Background-clip it is doing the job of never ever letting the background color creep under (gasp) or past (double gasp gasp) the border.  So now it looks all neat and tidy (as it does in other browsers).  Once #678 is fixed this kind of issue should be checked in ie11 too.