### PR TITLE
[B] Use values instead of placeholders in edit form

### DIFF
--- a/client/src/components/global/SignInUp/Login.js
+++ b/client/src/components/global/SignInUp/Login.js
@@ -77,7 +77,7 @@ export default class Login extends Component {
                 value={this.state.email}
                 onChange={this.updateEmail}
                 id="login-email"
-                placeholder="Username"
+                placeholder="Email"
               />
             </div>
           </div>

--- a/client/src/components/global/SignInUp/UpdateForm.js
+++ b/client/src/components/global/SignInUp/UpdateForm.js
@@ -191,7 +191,7 @@ class UpdateFormContainer extends Component {
               name="nickname"
               id="update-nickname"
               onChange={this.handleInputChange}
-              placeholder="nickname"
+              placeholder="Nickname"
             />
           </Form.Errorable>
         </div>

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/CreateUpdate-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/CreateUpdate-test.js.snap
@@ -41,7 +41,7 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
         id="update-nickname"
         name="nickname"
         onChange={[Function]}
-        placeholder="Nickname"
+        placeholder="nickname"
         type="text"
         value=""
       />
@@ -66,9 +66,9 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
         id="update-firstName"
         name="firstName"
         onChange={[Function]}
-        placeholder="Rowan"
+        placeholder="First name"
         type="text"
-        value=""
+        value="Rowan"
       />
     </div>
     <div
@@ -82,9 +82,9 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
         id="update-lastName"
         name="lastName"
         onChange={[Function]}
-        placeholder="Ida"
+        placeholder="Last name"
         type="text"
-        value=""
+        value="Ida"
       />
     </div>
     <div
@@ -98,9 +98,9 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
         id="update-email"
         name="email"
         onChange={[Function]}
-        placeholder="test@cic-fake.gotcha"
+        placeholder="Email"
         type="text"
-        value=""
+        value="test@cic-fake.gotcha"
       />
     </div>
     <div

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/CreateUpdate-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/CreateUpdate-test.js.snap
@@ -41,7 +41,7 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
         id="update-nickname"
         name="nickname"
         onChange={[Function]}
-        placeholder="nickname"
+        placeholder="Nickname"
         type="text"
         value=""
       />

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/Login-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/Login-test.js.snap
@@ -18,7 +18,7 @@ exports[`Global.SignInUp.Login component renders correctly 1`] = `
         <input
           id="login-email"
           onChange={[Function]}
-          placeholder="Username"
+          placeholder="Email"
           type="text"
           value=""
         />

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/Overlay-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/Overlay-test.js.snap
@@ -56,7 +56,7 @@ exports[`Global.SignInUp.Overlay component renders correctly 1`] = `
               <input
                 id="login-email"
                 onChange={[Function]}
-                placeholder="Username"
+                placeholder="Email"
                 type="text"
                 value=""
               />

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/Update-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/Update-test.js.snap
@@ -37,7 +37,7 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
         id="update-nickname"
         name="nickname"
         onChange={[Function]}
-        placeholder="Nickname"
+        placeholder="nickname"
         type="text"
         value=""
       />
@@ -62,9 +62,9 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
         id="update-firstName"
         name="firstName"
         onChange={[Function]}
-        placeholder="Rowan"
+        placeholder="First name"
         type="text"
-        value=""
+        value="Rowan"
       />
     </div>
     <div
@@ -78,9 +78,9 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
         id="update-lastName"
         name="lastName"
         onChange={[Function]}
-        placeholder="Ida"
+        placeholder="Last name"
         type="text"
-        value=""
+        value="Ida"
       />
     </div>
     <div
@@ -94,9 +94,9 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
         id="update-email"
         name="email"
         onChange={[Function]}
-        placeholder="test@cic-fake.gotcha"
+        placeholder="Email"
         type="text"
-        value=""
+        value="test@cic-fake.gotcha"
       />
     </div>
     <div

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/Update-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/Update-test.js.snap
@@ -37,7 +37,7 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
         id="update-nickname"
         name="nickname"
         onChange={[Function]}
-        placeholder="nickname"
+        placeholder="Nickname"
         type="text"
         value=""
       />

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/UpdateForm-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/UpdateForm-test.js.snap
@@ -37,7 +37,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
         id="update-nickname"
         name="nickname"
         onChange={[Function]}
-        placeholder="Nickname"
+        placeholder="nickname"
         type="text"
         value=""
       />
@@ -62,9 +62,9 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
         id="update-firstName"
         name="firstName"
         onChange={[Function]}
-        placeholder="Rowan"
+        placeholder="First name"
         type="text"
-        value=""
+        value="Rowan"
       />
     </div>
     <div
@@ -78,9 +78,9 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
         id="update-lastName"
         name="lastName"
         onChange={[Function]}
-        placeholder="Ida"
+        placeholder="Last name"
         type="text"
-        value=""
+        value="Ida"
       />
     </div>
     <div
@@ -94,9 +94,9 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
         id="update-email"
         name="email"
         onChange={[Function]}
-        placeholder="test@cic-fake.gotcha"
+        placeholder="Email"
         type="text"
-        value=""
+        value="test@cic-fake.gotcha"
       />
     </div>
     <div
@@ -189,7 +189,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
         id="update-nickname"
         name="nickname"
         onChange={[Function]}
-        placeholder="Nickname"
+        placeholder="nickname"
         type="text"
         value=""
       />
@@ -214,9 +214,9 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
         id="update-firstName"
         name="firstName"
         onChange={[Function]}
-        placeholder="Rowan"
+        placeholder="First name"
         type="text"
-        value=""
+        value="Rowan"
       />
     </div>
     <div
@@ -230,9 +230,9 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
         id="update-lastName"
         name="lastName"
         onChange={[Function]}
-        placeholder="Ida"
+        placeholder="Last name"
         type="text"
-        value=""
+        value="Ida"
       />
     </div>
     <div
@@ -246,9 +246,9 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
         id="update-email"
         name="email"
         onChange={[Function]}
-        placeholder="test@cic-fake.gotcha"
+        placeholder="Email"
         type="text"
-        value=""
+        value="test@cic-fake.gotcha"
       />
     </div>
     <div

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/UpdateForm-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/UpdateForm-test.js.snap
@@ -37,7 +37,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
         id="update-nickname"
         name="nickname"
         onChange={[Function]}
-        placeholder="nickname"
+        placeholder="Nickname"
         type="text"
         value=""
       />
@@ -189,7 +189,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
         id="update-nickname"
         name="nickname"
         onChange={[Function]}
-        placeholder="nickname"
+        placeholder="Nickname"
         type="text"
         value=""
       />

--- a/client/src/theme/Components/shared/forms/_form-inputs-primary.scss
+++ b/client/src/theme/Components/shared/forms/_form-inputs-primary.scss
@@ -46,6 +46,11 @@
     outline: 0;
     transition: border-color $duration $timing;
     appearance: none;
+    color: $neutral80;
+
+    &::placeholder {
+      color: $neutral50;
+    }
 
     &:focus {
       border-color: $accentPrimary;


### PR DESCRIPTION
This PR also includes a small fix for text inputs.  The placeholder colors in these are darker than the value colors.  After touching base with @naomiyaki, we decided on added a global default value to the `.form-input input` selector for text and password inputs.

![colors](https://user-images.githubusercontent.com/8389445/34444608-252473b6-ec84-11e7-84e6-4f3eedf6ca99.jpg)
