### PR TITLE
[F] Refactor child route rendering

### DIFF
--- a/client/src/containers/backend/People/Makers/Edit.js
+++ b/client/src/containers/backend/People/Makers/Edit.js
@@ -110,11 +110,6 @@ export class MakersEditContainer extends PureComponent {
     const attr = this.props.maker.attributes;
     const maker = this.props.maker;
 
-    /*
-     Edit dialog(s) can be wrapped in either
-     <Drawer.Wrapper>: Right-hand pop-in panel
-     <Dialog.Wrapper> Overlay with dialog box
-     */
     return (
       <div>
         {this.state.confirmation

--- a/client/src/containers/backend/People/Makers/List.js
+++ b/client/src/containers/backend/People/Makers/List.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { Drawer } from "components/global";
 import { entityStoreActions } from "actions";
 import { select, meta } from "utils/entityUtils";
 import { makersAPI, requests } from "api";
@@ -9,7 +8,7 @@ import debounce from "lodash/debounce";
 import get from "lodash/get";
 import { Maker, List } from "components/backend";
 import lh from "helpers/linkHandler";
-import { renderRoutes } from "helpers/routing";
+import { childRoutes } from "helpers/router";
 
 const { request } = entityStoreActions;
 const perPage = 10;
@@ -86,14 +85,15 @@ export class MakersListContainer extends PureComponent {
     };
   }
 
-  isDrawerOpen() {
-    return !!this.props.match.params.id;
-  }
-
   render() {
     const { makers, makersMeta, match } = this.props;
     if (!makers) return null;
     const active = match.params.id;
+
+    const drawerProps = {
+      closeUrl: lh.link("backendPeopleMakers")
+    };
+
     return (
       <div>
         <header className="section-heading-secondary">
@@ -101,12 +101,7 @@ export class MakersListContainer extends PureComponent {
             {"Makers"} <i className="manicon manicon-users" />
           </h3>
         </header>
-        <Drawer.Wrapper
-          open={this.isDrawerOpen()}
-          closeUrl={lh.link("backendPeopleMakers")}
-        >
-          {renderRoutes(this.props.route.routes)}
-        </Drawer.Wrapper>
+        {childRoutes(this.props.route, { drawer: true, drawerProps })}
         {makers
           ? <List.Searchable
               entities={makers}

--- a/client/src/containers/backend/People/Users/Edit.js
+++ b/client/src/containers/backend/People/Users/Edit.js
@@ -152,11 +152,7 @@ export class UsersEditContainer extends PureComponent {
     if (!this.props.user) return null;
     const attr = this.props.user.attributes;
     const user = this.props.user;
-    /*
-      Edit dialog(s) can be wrapped in either
-      <Drawer.Wrapper>: Right-hand pop-in panel
-      <Dialog.Wrapper> Overlay with dialog box
-    */
+
     return (
       <div>
         {this.state.confirmation

--- a/client/src/containers/backend/People/Users/List.js
+++ b/client/src/containers/backend/People/Users/List.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import connectAndFetch from "utils/connectAndFetch";
-import { Drawer } from "components/global";
 import { entityStoreActions } from "actions";
 import { select, meta } from "utils/entityUtils";
 import { usersAPI, requests } from "api";
@@ -9,7 +8,7 @@ import debounce from "lodash/debounce";
 import get from "lodash/get";
 import { User, List } from "components/backend";
 import lh from "helpers/linkHandler";
-import { renderRoutes } from "helpers/routing";
+import { childRoutes } from "helpers/router";
 
 const { request } = entityStoreActions;
 const perPage = 10;
@@ -90,16 +89,16 @@ export class UsersListContainer extends PureComponent {
     };
   }
 
-  isDrawerOpen() {
-    return !!this.props.match.params.id;
-  }
-
   render() {
     const { match } = this.props;
 
     if (!this.props.users) return null;
     const { users, usersMeta, currentUserId } = this.props;
     const active = match.params.id;
+
+    const drawerProps = {
+      closeUrl: lh.link("backendPeopleUsers")
+    };
 
     return (
       <div>
@@ -108,12 +107,7 @@ export class UsersListContainer extends PureComponent {
             {"Users"} <i className="manicon manicon-users" />
           </h3>
         </header>
-        <Drawer.Wrapper
-          open={this.isDrawerOpen()}
-          closeUrl={lh.link("backendPeopleUsers")}
-        >
-          {renderRoutes(this.props.route.routes)}
-        </Drawer.Wrapper>
+        {childRoutes(this.props.route, { drawer: true, drawerProps })}
         {users
           ? <List.Searchable
               newButtonVisible

--- a/client/src/containers/backend/People/Wrapper.js
+++ b/client/src/containers/backend/People/Wrapper.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Navigation } from "components/backend";
 import { connect } from "react-redux";
 import lh from "helpers/linkHandler";
-import { renderRoutes } from "helpers/routing";
+import { childRoutes } from "helpers/router";
 
 export class UsersWrapperContainer extends PureComponent {
   static displayName = "Users.Wrapper";
@@ -37,7 +37,7 @@ export class UsersWrapperContainer extends PureComponent {
               <Navigation.Secondary links={this.secondaryNavigationLinks()} />
             </aside>
             <div className="panel">
-              {renderRoutes(this.props.route.routes)}
+              {childRoutes(this.props.route)}
             </div>
           </div>
         </section>

--- a/client/src/containers/backend/Project/Texts.js
+++ b/client/src/containers/backend/Project/Texts.js
@@ -9,7 +9,7 @@ import { entityStoreActions } from "actions";
 import { projectsAPI, textsAPI, textCategoriesAPI, requests } from "api";
 import FormattedDate from "components/global/FormattedDate";
 import lh from "helpers/linkHandler";
-import { renderRoutes } from "helpers/routing";
+import { childRoutes } from "helpers/router";
 
 const { request } = entityStoreActions;
 
@@ -309,6 +309,24 @@ export class ProjectTextsContainer extends PureComponent {
     this.setState({ confirmation: null });
   }
 
+  childRoutes() {
+    const factory = component => {
+      return (
+        <Dialog.Wrapper
+          closeOnOverlayClick={false}
+          closeUrl={lh.link("backendProjectTexts", this.props.project.id)}
+        >
+          {component}
+        </Dialog.Wrapper>
+      );
+    };
+    const { refresh, project } = this.props;
+    return childRoutes(this.props.route, {
+      childProps: { refresh, project },
+      factory
+    });
+  }
+
   renderTexts(texts) {
     let renderedTexts;
     if (texts.length === 0) {
@@ -396,26 +414,6 @@ export class ProjectTextsContainer extends PureComponent {
     );
   }
 
-  renderRoutes() {
-    const { refresh, project } = this.props;
-    const factory = component => {
-      return (
-        <Dialog.Wrapper
-          closeOnOverlayClick={false}
-          closeUrl={lh.link("backendProjectTexts", this.props.project.id)}
-        >
-          {component}
-        </Dialog.Wrapper>
-      );
-    };
-    const childRoutes = renderRoutes(
-      this.props.route.routes,
-      { refresh, project },
-      factory
-    );
-    return childRoutes;
-  }
-
   render() {
     const categories = this.categories();
     /* eslint-disable no-unused-vars */
@@ -429,7 +427,7 @@ export class ProjectTextsContainer extends PureComponent {
           ? <Dialog.Confirm {...this.state.confirmation} />
           : null}
 
-        {this.renderRoutes()}
+        {this.childRoutes()}
 
         <div className="buttons-icon-horizontal maintain">
           <Link

--- a/client/src/containers/backend/Settings/Subjects/List.js
+++ b/client/src/containers/backend/Settings/Subjects/List.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import connectAndFetch from "utils/connectAndFetch";
-import { Drawer } from "components/global";
 import { entityStoreActions } from "actions";
 import { select, meta } from "utils/entityUtils";
 import { subjectsAPI, requests } from "api";
@@ -9,7 +8,7 @@ import debounce from "lodash/debounce";
 import get from "lodash/get";
 import { Subject, List } from "components/backend";
 import lh from "helpers/linkHandler";
-import { renderRoutes } from "helpers/routing";
+import { childRoutes } from "helpers/router";
 
 const { request } = entityStoreActions;
 const perPage = 10;
@@ -95,6 +94,10 @@ export class SettingsSubjectsListContainer extends PureComponent {
     const { subjects, subjectsMeta } = this.props;
     const active = match.params.id;
 
+    const drawerProps = {
+      closeUrl: lh.link("backendSettingsSubjects")
+    };
+
     return (
       <div>
         <header className="section-heading-secondary">
@@ -102,12 +105,7 @@ export class SettingsSubjectsListContainer extends PureComponent {
             {"Subjects"} <i className="manicon" />
           </h3>
         </header>
-        <Drawer.Wrapper
-          open={this.isDrawerOpen()}
-          closeUrl={lh.link("backendSettingsSubjects")}
-        >
-          {renderRoutes(this.props.route.routes)}
-        </Drawer.Wrapper>
+        {childRoutes(this.props.route, { drawer: true, drawerProps })}
         {subjects
           ? <List.Searchable
               newButtonVisible

--- a/client/src/helpers/router/DrawerSwitch.js
+++ b/client/src/helpers/router/DrawerSwitch.js
@@ -1,0 +1,36 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Drawer } from "components/global";
+import switchFactory from "./switchFactory";
+
+class DrawerSwitch extends React.PureComponent {
+  static propTypes = {
+    history: PropTypes.object.isRequired,
+    wrapperProps: PropTypes.object.isRequired,
+    match: PropTypes.object.isRequired,
+    children: PropTypes.any
+  };
+
+  defaultCloseCallback = () => {
+    this.props.history.goBack();
+  };
+
+  drawerProps() {
+    const props = Object.assign({}, this.props.wrapperProps);
+    if (!props.closeUrl && !props.closeCallback) {
+      props.closeCallback = this.defaultCloseCallback;
+    }
+    return props;
+  }
+
+  render() {
+    const drawerProps = this.drawerProps();
+    return (
+      <Drawer.Wrapper open={!!this.props.match} {...drawerProps}>
+        {this.props.children}
+      </Drawer.Wrapper>
+    );
+  }
+}
+
+export default switchFactory(DrawerSwitch);

--- a/client/src/helpers/router/Passthrough.js
+++ b/client/src/helpers/router/Passthrough.js
@@ -1,0 +1,16 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export default class Passthrough extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.any
+  };
+
+  render() {
+    return (
+      <span>
+        {this.props.children}
+      </span>
+    );
+  }
+}

--- a/client/src/helpers/router/childRoutes.js
+++ b/client/src/helpers/router/childRoutes.js
@@ -1,0 +1,69 @@
+import React from "react";
+import { Switch, Route } from "react-router-dom";
+import DrawerSwitch from "./DrawerSwitch";
+import Passthrough from "./Passthrough";
+
+const renderChildRoutes = (route, renderOptions) => {
+  const defaultOptions = {
+    switch: true,
+    childProps: {},
+    drawer: false,
+    drawerProps: {},
+    dialog: false,
+    dialogProps: {},
+    factory: null
+  };
+  const routeOptions = route.options || {};
+  const options = Object.assign(
+    {},
+    defaultOptions,
+    routeOptions,
+    renderOptions
+  );
+  const childRoutes = route.routes;
+
+  const defaultRender = childRoute => props =>
+    <childRoute.component
+      {...props}
+      {...options.childProps}
+      route={childRoute}
+    />;
+
+  const factoryRender = childRoute => props =>
+    options.factory(defaultRender(childRoute)(props));
+
+  const render = options.factory ? factoryRender : defaultRender;
+
+  let mapped = null;
+  /* eslint-disable react/no-array-index-key */
+  // We can use the array index as the key here, because the order of the routes will
+  // never change after the initial mount.
+  if (childRoutes) {
+    mapped = childRoutes.map((childRoute, i) => {
+      const { component, ...props } = childRoute;
+      return <Route key={i} {...props} render={render(childRoute)} />;
+    });
+  }
+  /* eslint-enable react/no-array-index-key */
+
+  // By default, wrap child routes in a switch
+  let Wrapper = Switch;
+  let wrapperProps = {};
+
+  // If switch is disabled, we render all matching child routes.
+  if (!options.switch) Wrapper = Passthrough;
+
+  // If a drawer is requested, we wrap the children in a drawer version of the switch.
+  if (options.drawer) {
+    Wrapper = DrawerSwitch;
+    wrapperProps = Object.assign({}, wrapperProps, options.drawerProps);
+  }
+
+  return (
+    <Wrapper {...wrapperProps}>
+      {mapped}
+    </Wrapper>
+  );
+};
+
+export default renderChildRoutes;

--- a/client/src/helpers/router/index.js
+++ b/client/src/helpers/router/index.js
@@ -1,0 +1,1 @@
+export childRoutes from "./childRoutes";

--- a/client/src/helpers/router/switchFactory.js
+++ b/client/src/helpers/router/switchFactory.js
@@ -1,0 +1,85 @@
+import React from "react";
+import PropTypes from "prop-types";
+import hoistStatics from "hoist-non-react-statics";
+import { matchPath, withRouter } from "react-router-dom";
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || "Component";
+}
+
+export default function switchFactory(Wrapper) {
+  const displayName = `Router.Switch('${getDisplayName(Wrapper)})`;
+
+  class RouterSwitch extends React.PureComponent {
+    static displayName = displayName;
+
+    static contextTypes = {
+      router: PropTypes.shape({
+        route: PropTypes.object.isRequired
+      }).isRequired
+    };
+
+    static propTypes = {
+      location: PropTypes.object.isRequired,
+      children: PropTypes.any,
+      match: PropTypes.object,
+      history: PropTypes.object,
+      staticContext: PropTypes.object
+    };
+    static Wrapper = Wrapper;
+
+    match() {
+      const { route } = this.context.router;
+      const { children } = this.props;
+      const location = this.props.location || route.location;
+      let match;
+      let child;
+      React.Children.forEach(children, element => {
+        if (match == null && React.isValidElement(element)) {
+          const {
+            path: pathProp,
+            exact,
+            strict,
+            sensitive,
+            from
+          } = element.props;
+          const path = pathProp || from;
+
+          child = element;
+          match = path
+            ? matchPath(location.pathname, { path, exact, strict, sensitive })
+            : route.match;
+        }
+      });
+      return { location, match, child };
+    }
+
+    wrapperProps() {
+      const {
+        location,
+        match,
+        history,
+        children,
+        staticContext,
+        ...wrapperProps
+      } = this.props;
+      return wrapperProps;
+    }
+
+    render() {
+      const { location, match, child } = this.match();
+      const children = match
+        ? React.cloneElement(child, { location, computedMatch: match })
+        : null;
+      const props = Object.assign(
+        {},
+        this.props,
+        { match, children },
+        { wrapperProps: this.wrapperProps() }
+      );
+      return React.createElement(Wrapper, props);
+    }
+  }
+
+  return hoistStatics(withRouter(RouterSwitch), Wrapper);
+}

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -287,14 +287,15 @@ export default () => {
                 {
                   name: "backendPeopleMaker",
                   component: Backend.People.Makers.Edit,
-                  path: "/backend/people/makers/:id?",
+                  exact: true,
+                  path: "/backend/people/makers/:id",
                   helper: m => `/backend/people/makers/${m}`
                 }
               ]
             },
             {
               name: "backendPeopleUsers",
-              exact: true,
+              exact: false,
               component: Backend.People.Users.List,
               path: "/backend/people/:users(users)?/:id?",
               helper: () => "/backend/people/users",
@@ -302,7 +303,7 @@ export default () => {
                 {
                   name: "backendPeopleUser",
                   component: Backend.People.Users.Edit,
-                  path: "/backend/people/users/:id?",
+                  path: "/backend/people/users/:id",
                   helper: u => `/backend/people/users/${u}`
                 }
               ]
@@ -467,7 +468,7 @@ export default () => {
                 {
                   name: "backendSettingsSubject",
                   component: Backend.Settings.Subjects.Edit,
-                  path: "/backend/settings/subjects/:id?",
+                  path: "/backend/settings/subjects/:id",
                   helper: s => `/backend/settings/subjects/${s}`
                 }
               ]


### PR DESCRIPTION
This commit adds a new method for rendering child routes from a
component, and refactors just enough of Manifold to serve as
proof of concept. We will need to remove all calls to our
renderRoutes helper and replace them with calls to the new
childRoutes helper.

Closes #737 