### PR TITLE
[B] Fix non-human name parsing

### DIFF
--- a/api/app/controllers/concerns/validation.rb
+++ b/api/app/controllers/concerns/validation.rb
@@ -237,7 +237,7 @@ module Validation
   def maker_params
     params.require(:data)
     attributes = [:first_name, :last_name, :middle_name, :suffix, attachment(:avatar),
-                  :remove_avatar]
+                  :remove_avatar, :name]
     relationships = [:users]
     param_config = structure_params(attributes: attributes, relationships: relationships)
     params.permit(param_config)

--- a/api/app/models/concerns/with_parsed_name.rb
+++ b/api/app/models/concerns/with_parsed_name.rb
@@ -3,6 +3,7 @@ module WithParsedName
 
   KEY_MAP = {
     given: :first_name,
+    particle: :middle_name,
     family: :last_name,
     suffix: :suffix
   }.freeze

--- a/client/src/components/backend/Maker/ListItem.js
+++ b/client/src/components/backend/Maker/ListItem.js
@@ -41,7 +41,7 @@ export default class MakerListItem extends PureComponent {
             </figure>
             <div className="meta">
               <h3 className="name large">
-                {attr.firstName} {attr.lastName}
+                {attr.fullName}
               </h3>
             </div>
           </header>

--- a/client/src/components/backend/Maker/__tests__/__snapshots__/ListItem-test.js.snap
+++ b/client/src/components/backend/Maker/__tests__/__snapshots__/ListItem-test.js.snap
@@ -26,9 +26,7 @@ exports[`Backend.Maker.ListItem component renders correctly 1`] = `
         <h3
           className="name large"
         >
-          Rowan
-           
-          Ida
+          Rowan Ida
         </h3>
       </div>
     </header>

--- a/client/src/containers/backend/Form/Collaborators.js
+++ b/client/src/containers/backend/Form/Collaborators.js
@@ -60,12 +60,10 @@ export class FormCollaborators extends Component {
   };
 
   newMaker = (value, key) => {
-    const parts = value.split(" ");
     const maker = {
       type: "makers",
       attributes: {
-        firstName: parts[0],
-        lastName: parts[1]
+        name: value
       }
     };
     const call = makersAPI.create(maker);

--- a/client/src/containers/backend/People/Makers/Edit.js
+++ b/client/src/containers/backend/People/Makers/Edit.js
@@ -117,7 +117,7 @@ export class MakersEditContainer extends PureComponent {
           : null}
         <header className="drawer-header">
           <h2 className="heading-quaternary">
-            {`${attr.firstName} ${attr.lastName}`}
+            {attr.fullName}
           </h2>
           <div className="buttons-bare-vertical">
             <button

--- a/client/src/containers/backend/People/Makers/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/containers/backend/People/Makers/__tests__/__snapshots__/List-test.js.snap
@@ -97,9 +97,7 @@ exports[`Backend People Makers List Container renders correctly 1`] = `
                     <h3
                       className="name large"
                     >
-                      Rowan
-                       
-                      Ida
+                      Rowan Ida
                     </h3>
                   </div>
                 </header>


### PR DESCRIPTION
This was an issue with non-human name parts causing errors on Maker create.  The Namae gem uses capital letters to delineate name parts and assigns mid-name lowercase words to `:particle`.  This PR maps `:particle` to `:middle_name`.  

The name parsing seems like it may be an ever-evolving issue, though I think we're still in a better starting position here than our previous splitting methods.

![screen shot 2018-01-30 at 3 10 15 pm](https://user-images.githubusercontent.com/8389445/35597223-47a3a1d4-05d2-11e8-8ce0-3448ad5849ed.png)

Fixes #766