### PR TITLE
[B] Swap resource cube inline svgs for icon font

### DIFF
--- a/client/src/components/reader/Notation/Marker.js
+++ b/client/src/components/reader/Notation/Marker.js
@@ -83,8 +83,8 @@ class NotationMarker extends Component {
                 if (!touch) this.setActiveAnnotation(null);
               }}
             >
-              <i className="manicon notation-cube-fill">
-                &nbsp;&nbsp;&nbsp;&nbsp;
+              <i className="manicon manicon-cube-fill">
+
               </i>
             </span>
           );

--- a/client/src/components/reader/Notation/__tests__/__snapshots__/Marker-test.js.snap
+++ b/client/src/components/reader/Notation/__tests__/__snapshots__/Marker-test.js.snap
@@ -11,10 +11,8 @@ exports[`Reader.Notation.Marker component renders correctly 1`] = `
     title="1"
   >
     <i
-      className="manicon notation-cube-fill"
-    >
-          
-    </i>
+      className="manicon manicon-cube-fill"
+    />
   </span>
 </span>
 `;

--- a/client/src/theme/Components/reader/_text-section.scss
+++ b/client/src/theme/Components/reader/_text-section.scss
@@ -93,9 +93,15 @@
   // Link with notation marker cube
   .notation-marker {
     cursor: pointer;
-
+    font-size: 1em;
+    display: inline-flex;
+    align-self: center;
+    margin: 0 0.18em;
+    text-decoration: none;
+    letter-spacing: normal;
+    text-indent: 0;
     i {
-      display: inline;
+      position: relative;
     }
   }
 

--- a/client/src/theme/Components/reader/notation/_marker.scss
+++ b/client/src/theme/Components/reader/notation/_marker.scss
@@ -1,13 +1,10 @@
 .notation-marker {
-
-  &.active .notation-cube-fill {
-    background-image: url('data:image/svg+xml;charset=US-ASCII,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22utf-8%22%3F%3E%0A%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%2054.5%2064%22%20enable-background%3D%22new%200%200%2054.5%2064%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cpolygon%20fill%3D%22%23#{$accentPrimaryHex}%22%20points%3D%220%2C50.4%2025.4%2C65.1%2025.5%2C34.3%200.1%2C19.6%20%22/%3E%0A%3Cpolygon%20fill%3D%22%23#{$accentPrimaryHex}%22%20points%3D%2254.4%2C19.6%2028.9%2C34.3%2029%2C65.1%2054.5%2C50.4%20%22/%3E%0A%3Cpolygon%20fill%3D%22%23#{$accentPrimaryHex}%22%20points%3D%2227.2%2C1.1%201.7%2C16.5%2027.2%2C31.2%2052.7%2C16.5%20%22/%3E%0A%3C/svg%3E%0A');
+  &.active .manicon-cube-fill {
+    color: $accentPrimary;
   }
 
-  .notation-cube-fill {
-    background-image: url('data:image/svg+xml;charset=US-ASCII,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22utf-8%22%3F%3E%0A%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%2054.5%2064%22%20enable-background%3D%22new%200%200%2054.5%2064%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cpolygon%20fill%3D%22%23#{$neutral40hex}%22%20points%3D%220%2C50.4%2025.4%2C65.1%2025.5%2C34.3%200.1%2C19.6%20%22/%3E%0A%3Cpolygon%20fill%3D%22%23#{$neutral40hex}%22%20points%3D%2254.4%2C19.6%2028.9%2C34.3%2029%2C65.1%2054.5%2C50.4%20%22/%3E%0A%3Cpolygon%20fill%3D%22%23#{$neutral40hex}%22%20points%3D%2227.2%2C1.1%201.7%2C16.5%2027.2%2C31.2%2052.7%2C16.5%20%22/%3E%0A%3C/svg%3E%0A');
-    background-position: 50% 50%;
-    background-repeat: no-repeat;
-    background-size: 80% 80%;
+  .manicon-cube-fill {
+    color: $neutral40;
+    transition: color $duration $timing;
   }
 }


### PR DESCRIPTION
Closes #636 

This replaces the long standing inline `&nbsp` with svg background with an icon-font glyph nested in an inline-flex span element. This seems to work great in all contexts and is a cleaner strategy overall that uses color transitions instead of swapping svgs. The icons look crisper and aren't cut off in Edge or Chrome.