### PR TITLE
[B] Move citable children update to a job

### DIFF
--- a/api/app/jobs/update_citatable_children.rb
+++ b/api/app/jobs/update_citatable_children.rb
@@ -1,0 +1,8 @@
+class UpdateCitatableChildren < ApplicationJob
+  queue_as :default
+
+  def perform(parent)
+    return unless parent.citable_children.any?
+    parent.citable_children.each { |child| parent.send(child).each(&:save) }
+  end
+end

--- a/api/app/models/concerns/citable.rb
+++ b/api/app/models/concerns/citable.rb
@@ -39,7 +39,7 @@ module Citable
 
   def update_citable_children
     return unless citations != citations_was
-    citable_children.each { |child| send(child).each(&:save) }
+    UpdateCitatableChildren.perform_later(self)
   end
 
   # rubocop:disable Metrics/BlockLength


### PR DESCRIPTION
Fixes #802 

We still have to use the `after_save` callback instead of `after_commit` so we can compare the citations to know if we should update the children or not. Let me know if you want to look at changing that so we can use the `after_commit` callback instead.