### PR TITLE
[C] Remove assertion in response to loofah update

### DIFF
--- a/api/spec/services/validator/html_spec.rb
+++ b/api/spec/services/validator/html_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Validator::Html do
     pointer = File.open(Rails.root.join('spec','data','ingestion','fragments','ascii_section.html'))
     doc = Nokogiri::XML(pointer, nil)
     fragment = doc.css("body").children.to_s.strip
-    expect(fragment.encoding).to be(Encoding::ASCII_8BIT)
     expect(validator.validate(fragment)).to_not eq ""
   end
 


### PR DESCRIPTION
Previous verisons of Loofah/Nokogiri were not converting ASCII encoded
content to UTF8 as we'd expect them to. Recent updates to these
libraries also included updates to libxml, and the behavior seems to
have changed, which means this assertion is no longer necessary.