### PR TITLE
[B] Allow 404 API requests to bubble up

### DIFF
--- a/client/src/api/client.js
+++ b/client/src/api/client.js
@@ -142,7 +142,10 @@ export default class ApiClient {
       const payload = {
         status: response.status,
         statusText: response.statusText,
-        body: null
+        body: {
+          status: response.status,
+          error: response.statusText
+        }
       };
       response.json().then(
         json => {

--- a/client/src/components/global/HigherOrder/fetchData.js
+++ b/client/src/components/global/HigherOrder/fetchData.js
@@ -76,6 +76,16 @@ export default function fetchData(WrappedComponent) {
         props.location,
         props.match
       );
+      if (isPromise(result)) {
+        result.catch(() => {
+          ch.error(
+            `Unable to fetch route data for ${getDisplayName(
+              WrappedComponent
+            )}`,
+            "rain_cloud"
+          );
+        });
+      }
       this.addFetchResultToStaticContext(result);
       this.log(props);
     };

--- a/client/src/store/reducers/notifications.js
+++ b/client/src/store/reducers/notifications.js
@@ -59,11 +59,8 @@ const removeAllNotifications = state => {
 };
 
 const notificationReducer = (state = initialState, action) => {
-  if (
-    ((action.type && action.type.startsWith("API_REQUEST")) ||
-      action.type === "ROUTE_UPDATE") &&
-    state.fatalError
-  ) {
+  if (action.type === "ROUTE_UPDATE" && state.fatalError) {
+    console.log("clearing?");
     return clearFatalError(state, action);
   }
 


### PR DESCRIPTION
Fixes #639.

If an API request returns a 404, in almost every case we want the
client to also return a 404 to the user. This was the case
previously, only they were being cleared to agressively, sometimes
before the client-side app could respond with the correct header.