### PR TITLE
[B] Fix video slider overlay artifacts

### DIFF
--- a/client/src/theme/Components/browse/resource/_slide.scss
+++ b/client/src/theme/Components/browse/resource/_slide.scss
@@ -36,39 +36,39 @@
 
   // Transition classes
   .slide-left-enter figure {
-    left: 100%;
+    transform: translate3d(100%, 0, 0);
   }
 
   .slide-left-enter-active figure {
-    left: 0;
-    transition: left 0.4s $timing;
+    transform: translate3d(0, 0, 0);
+    transition: transform 0.4s $timing;
   }
 
   .slide-left-leave figure {
-    left: 0;
+    transform: translate3d(0, 0, 0);
   }
 
   .slide-left-leave-active figure {
-    left: -100%;
-    transition: left 0.4s $timing;
+    transform: translate3d(-100%, 0, 0);
+    transition: transform 0.4s $timing;
   }
 
   .slide-right-enter figure {
-    left: -100%;
+    transform: translate3d(-100%, 0, 0);
   }
 
   .slide-right-enter-active figure {
-    left: 0;
-    transition: left 0.4s $timing;
+    transform: translate3d(0, 0, 0);
+    transition: transform 0.4s $timing;
   }
 
   .slide-right-leave figure {
-    left: 0;
+    transform: translate3d(0, 0, 0);
   }
 
   .slide-right-leave-active figure {
-    left: 100%;
-    transition: left 0.4s $timing;
+    transform: translate3d(100%, 0, 0);
+    transition: transform 0.4s $timing;
   }
 
   //.figure-enter figure {


### PR DESCRIPTION
Closes #933 

This swaps the transition CSS from a position transition to a translate3d one, which is generally more compatible when used. The `translate3d` (instead of translateX) parameter ensures the GPU will be used to perform the transition if there is one on the machine. In my testing on Chrome, Firefox, and Safari, this mitigated the bug with video flickering, and didn't cause any variation on photo slideshow pages.