### PR TITLE
 [F] Remember page and filter in backend project list

### DIFF
--- a/client/src/components/backend/Layout/Header.js
+++ b/client/src/components/backend/Layout/Header.js
@@ -20,19 +20,9 @@ export default class LayoutHeader extends Component {
     location: PropTypes.object,
     authentication: PropTypes.object,
     commonActions: PropTypes.object,
-    settings: PropTypes.object
+    settings: PropTypes.object,
+    isProjects: PropTypes.func
   };
-
-  isProjects(match, location) {
-    if (!match) {
-      return false;
-    }
-    const { pathname } = location;
-    if (pathname === "/backend") return true;
-    if (startsWith(pathname, "/backend/project")) return true;
-    if (startsWith(pathname, "/backend/resource")) return true;
-    return startsWith(pathname, "/backend/text");
-  }
 
   isSubjects(match, location) {
     if (!match) {
@@ -62,7 +52,7 @@ export default class LayoutHeader extends Component {
             <ul>
               <li>
                 <NavLink
-                  isActive={this.isProjects}
+                  isActive={this.props.isProjects}
                   activeClassName="active"
                   to={lh.link("backend")}
                 >

--- a/client/src/components/backend/List/Searchable.js
+++ b/client/src/components/backend/List/Searchable.js
@@ -46,7 +46,9 @@ export class ListSearchable extends PureComponent {
     filterOptions: PropTypes.object,
     destroyHandler: PropTypes.func,
     filterChangeHandler: PropTypes.func,
-    currentUser: PropTypes.object
+    currentUser: PropTypes.object,
+    initialFilter: PropTypes.object, // Initial filter is to set filter state from an existing state
+    defaultFilter: PropTypes.object // Default filter is what filter is set to when resetSearch() is called
   };
 
   static defaultProps = {
@@ -54,12 +56,13 @@ export class ListSearchable extends PureComponent {
     newButton: null,
     secondaryButton: null,
     paginationPadding: 3,
-    requireAbility: null
+    requireAbility: null,
+    initialFilter: null
   };
 
   constructor(props) {
     super(props);
-    this.state = { filter: {} };
+    this.state = this.initialState(props);
     this.authorization = new Authorization();
   }
 
@@ -78,6 +81,11 @@ export class ListSearchable extends PureComponent {
     this.setState({ filter });
   };
 
+  initialState(props) {
+    if (props.initialFilter) return { filter: props.initialFilter };
+    return { filter: {} };
+  }
+
   toggleOptions = event => {
     event.preventDefault();
     this.setState({ showOptions: !this.state.showOptions });
@@ -85,7 +93,8 @@ export class ListSearchable extends PureComponent {
 
   resetSearch = event => {
     event.preventDefault();
-    this.setState({ filter: {} });
+    const resetState = this.props.defaultFilter ? this.props.defaultFilter : {};
+    this.setState({ filter: resetState });
   };
 
   handleSubmit = event => {

--- a/client/src/containers/backend/Dashboard.js
+++ b/client/src/containers/backend/Dashboard.js
@@ -1,9 +1,15 @@
 import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
 import { HigherOrder } from "containers/global";
 import { Dashboards } from "containers/backend";
 import lh from "helpers/linkHandler";
 
 export default class DashboardContainer extends PureComponent {
+  static propTypes = {
+    projectListSnapshot: PropTypes.object,
+    snapshotCreator: PropTypes.func
+  };
+
   render() {
     // This will be the entry point to the author dashboard too, when built out more
     return (
@@ -19,7 +25,10 @@ export default class DashboardContainer extends PureComponent {
         failureRedirect={lh.link("frontend")}
         failureNotification
       >
-        <Dashboards.Admin />
+        <Dashboards.Admin
+          projectListSnapshot={this.props.projectListSnapshot}
+          snapshotCreator={this.props.snapshotCreator}
+        />
       </HigherOrder.Authorize>
     );
   }

--- a/client/src/containers/backend/Dashboards/__tests__/Admin-test.js
+++ b/client/src/containers/backend/Dashboards/__tests__/Admin-test.js
@@ -21,6 +21,7 @@ describe("Backend Dashboards Admin Container", () => {
           projectsMeta={projectsMeta}
           recentProjects={recentProjects}
           dispatch={store.dispatch}
+          projectListSnapshot={{ page: 1 }}
           authentication={{
             authenticated: true,
             currentUser: build.entity.user("5", {

--- a/client/src/containers/backend/__tests__/__snapshots__/Backend-test.js.snap
+++ b/client/src/containers/backend/__tests__/__snapshots__/Backend-test.js.snap
@@ -15,7 +15,7 @@ exports[`Backend Backend Container renders correctly 1`] = `
               </withRouter(ScrollToTop)>
               <ScrollAware threshold={200} topClass=\\"top\\" notTopClass=\\"not-top\\" startPinned={true} pinnedClass=\\"pinned\\" notPinnedClass=\\"not-pinned\\" pinThreshold={50}>
                 <div className=\\"scroll-aware top pinned\\">
-                  <Layout.Header visibility={{...}} location={[undefined]} authentication={{...}} commonActions={{...}} settings={[undefined]} scrollAware={{...}}>
+                  <Layout.Header visibility={{...}} location={[undefined]} authentication={{...}} commonActions={{...}} settings={[undefined]} isProjects={[Function]} scrollAware={{...}}>
                     <header className=\\"header-app dark\\">
                       <div className=\\"header-container\\">
                         <Link to=\\"/\\" className=\\"logo\\" replace={false}>
@@ -35,7 +35,7 @@ exports[`Backend Backend Container renders correctly 1`] = `
                         <nav className=\\"text-nav\\">
                           <ul>
                             <li>
-                              <NavLink isActive={[Function: isProjects]} activeClassName=\\"active\\" to=\\"/backend\\" ariaCurrent=\\"true\\">
+                              <NavLink isActive={[Function]} activeClassName=\\"active\\" to=\\"/backend\\" ariaCurrent=\\"true\\">
                                 <Route path=\\"/backend\\" exact={[undefined]} strict={[undefined]} location={[undefined]}>
                                   <Link to=\\"/backend\\" className={[undefined]} style={[undefined]} aria-current={false} replace={false}>
                                     <a className={[undefined]} style={[undefined]} aria-current={false} onClick={[Function]} href=\\"/backend\\">


### PR DESCRIPTION
Let me know how you feel about the `isProjects()` move.  I moved it into the `Backend` container so we know when to reset the snapshot.  It felt weird that the project list state persisted even after going to other pages outside of projects.