### PR TITLE
[F] Improvements to bulk resource import

### DIFF
--- a/api/app/models/resource_import.rb
+++ b/api/app/models/resource_import.rb
@@ -51,7 +51,7 @@ class ResourceImport < ApplicationRecord
     %w(
       title kind sub_kind created_at caption description fingerprint external_url
       external_id external_type allow_download slug
-      minimum_width minimum_height tag_list
+      minimum_width minimum_height tag_list collections
     )
   end
 
@@ -62,7 +62,11 @@ class ResourceImport < ApplicationRecord
   def self.available_columns
     metadata_columns = ResourceImport.metadata_columns.map { |m| "metadata.#{m}" }
     attachment_columns = ResourceImport.attachment_columns.map { |c| "attachment.#{c}" }
-    attribute_columns + metadata_columns + attachment_columns + non_model_attributes
+
+    attribute_columns +
+      metadata_columns +
+      attachment_columns +
+      non_model_attributes
   end
 
   def available_columns

--- a/api/app/models/resource_import.rb
+++ b/api/app/models/resource_import.rb
@@ -55,10 +55,14 @@ class ResourceImport < ApplicationRecord
     )
   end
 
+  def self.non_model_attributes
+    %w(special_instructions)
+  end
+
   def self.available_columns
     metadata_columns = ResourceImport.metadata_columns.map { |m| "metadata.#{m}" }
     attachment_columns = ResourceImport.attachment_columns.map { |c| "attachment.#{c}" }
-    attribute_columns + metadata_columns + attachment_columns
+    attribute_columns + metadata_columns + attachment_columns + non_model_attributes
   end
 
   def available_columns

--- a/api/app/models/resource_import_row.rb
+++ b/api/app/models/resource_import_row.rb
@@ -64,6 +64,12 @@ class ResourceImportRow < ApplicationRecord
     resource is_a? Resource
   end
 
+  def skip?
+    value = value_for("special_instructions")
+    return false if value.blank?
+    value.split(";").map(&:strip).include?("skip")
+  end
+
   def mapped_result
     {
       resource_id: resource_id,

--- a/api/app/services/resource_import_rows/import.rb
+++ b/api/app/services/resource_import_rows/import.rb
@@ -117,6 +117,15 @@ module ResourceImportRows
       set_from_google_drive_storage(attribute, value) if row.google_drive_storage?
     end
 
+    def set_collections(attribute, value)
+      return set_default(attribute, []) if value.blank?
+      titles = value.split(/[,;]/).map(&:strip).reject(&:empty?)
+      collections = titles.map do |title|
+        resource.project.collections.find_or_initialize_by title: title
+      end
+      set_default(attribute, collections)
+    end
+
     def set_from_google_drive_storage(attribute, value)
       adjusted = attribute.split(".").last
       file = fetch_google_drive_file(value)

--- a/api/app/services/resource_import_rows/import.rb
+++ b/api/app/services/resource_import_rows/import.rb
@@ -50,6 +50,7 @@ module ResourceImportRows
 
     def update_resource
       row.column_map.each do |position, attribute|
+        next unless resource.respond_to? attribute
         set_attribute(attribute, row.value(position))
       end
     end

--- a/api/app/services/resource_imports/parse_csv.rb
+++ b/api/app/services/resource_imports/parse_csv.rb
@@ -20,6 +20,7 @@ module ResourceImports
     private
 
     def make_row!(row)
+      return unless row.any?(&:present?)
       compose ResourceImports::MakeRow,
               resource_import: resource_import,
               raw_row: row,

--- a/api/app/services/resource_imports/parse_google_sheet.rb
+++ b/api/app/services/resource_imports/parse_google_sheet.rb
@@ -14,6 +14,7 @@ module ResourceImports
     private
 
     def make_row!(row)
+      return unless row.any?(&:present?)
       compose ResourceImports::MakeRow,
               resource_import: resource_import,
               raw_row: row,

--- a/api/app/services/resource_imports/state_machine.rb
+++ b/api/app/services/resource_imports/state_machine.rb
@@ -3,6 +3,8 @@ module ResourceImports
   class StateMachine
     include Statesman::Machine
 
+    COMPLETE_STATES = %I{imported failed skipped}.freeze
+
     state :pending, initial: true
     state :parsing
     state :parsed
@@ -34,7 +36,7 @@ module ResourceImports
     guard_transition(to: :imported) do |resource_import|
       count = resource_import
               .data_rows
-              .not_in_state([:imported, :failed])
+              .not_in_state(COMPLETE_STATES)
               .count
       count.zero?
     end

--- a/api/spec/models/resource_import_row_spec.rb
+++ b/api/spec/models/resource_import_row_spec.rb
@@ -58,7 +58,9 @@ RSpec.describe ResourceImportRow, type: :model, slow: true do
       "attachment.variant_thumbnail" => "",
       "attachment.variant_poster" => "",
       "attachment.variant_format_one" => "",
-      "attachment.variant_format_two" => ""
+      "attachment.variant_format_two" => "",
+      "collections" => "",
+      "special_instructions" => ""
     }
   }
 
@@ -173,6 +175,11 @@ RSpec.describe ResourceImportRow, type: :model, slow: true do
     make_row(interactive_values, column_map)
   end
 
+  let(:skip_row) do
+    values = base.merge("special_instructions" => "super special instructions.; skip;").values
+    make_row values, column_map
+  end
+
   it "has a valid factory" do
     expect(FactoryBot.create(:resource_import_row)).to be_valid
   end
@@ -259,7 +266,14 @@ RSpec.describe ResourceImportRow, type: :model, slow: true do
         expect(row.state_machine.in_state?(:failed)).to be true
       end
 
+    end
 
+    context "when the resource row is marked skip" do
+      it "its state changes to skipped after queue" do
+        row = skip_row
+        row.state_machine.transition_to(:queued)
+        expect(row.state_machine.in_state?(:skipped)).to be true
+      end
     end
 
   end

--- a/client/src/containers/backend/ResourceImport/Results.js
+++ b/client/src/containers/backend/ResourceImport/Results.js
@@ -88,6 +88,9 @@ export class ResourceImportResults extends PureComponent {
     if (state === "queued" || state === "importing") {
       return <i className="manicon manicon-plus small" />;
     }
+    if (state === "skipped") {
+      return <i className="manicon manicon-arrow-right small" />;
+    }
     if (state === "failed") {
       return <i className="manicon manicon-x small" />;
     }
@@ -139,6 +142,9 @@ export class ResourceImportResults extends PureComponent {
       return (
         <span>{`Row #${row.lineNumber} will create a new resource.`}</span>
       );
+    }
+    if (row.state === "skipped") {
+      return <span>{`Row #${row.lineNumber} is marked as skip.`}</span>;
     }
     if (row.state === "importing") {
       return <span>{`Row #${row.lineNumber} is being imported.`}</span>;

--- a/client/src/theme/Components/backend/forms/_results-list.scss
+++ b/client/src/theme/Components/backend/forms/_results-list.scss
@@ -60,6 +60,10 @@
         }
       }
 
+      &.state-skipped {
+        color: $neutral70;
+      }
+
       &.state-imported {
         color: $accentPrimaryDull;
 


### PR DESCRIPTION
Per @tsmyre's comments about how the "Special instructions" column is being used, individual statements in the column should be delimited with a semi-colon.  The import will then skip any row that is indicated as such in this column.

```
Special Instructions
Author wants this image to be set inline and not at the top or bottom of the page.; skip;
```

Closes #944