### PR TITLE
[B] Allow HEAD <title> to be set by installation

### DIFF
--- a/api/app/controllers/concerns/validation.rb
+++ b/api/app/controllers/concerns/validation.rb
@@ -198,7 +198,8 @@ module Validation
           :social_share_message,
           :contact_url,
           :copyright,
-          :terms_url
+          :terms_url,
+          :head_title
         ]
       },
       {

--- a/client/src/components/frontend/Project/Events.js
+++ b/client/src/components/frontend/Project/Events.js
@@ -20,11 +20,10 @@ export default class ProjectEvents extends Component {
     return (
       <div>
         <HeadContent
-          title={`Manifold Scholarship | ${
-            this.props.project.attributes.title
-          } | Events`}
+          title={`${this.props.project.attributes.title} | Events`}
           description={this.props.project.attributes.description}
           image={this.props.project.attributes.avatarStyles.mediumSquare}
+          appendTitle
         />
         <section className="bg-neutral05">
           <Utility.BackLinkPrimary

--- a/client/src/components/global/HeadContent.js
+++ b/client/src/components/global/HeadContent.js
@@ -7,7 +7,8 @@ export default class HeadContent extends Component {
   static propTypes = {
     title: PropTypes.string,
     image: PropTypes.string,
-    description: PropTypes.string
+    description: PropTypes.string,
+    appendTitle: PropTypes.bool
   };
 
   readPropValue(key) {
@@ -51,6 +52,12 @@ export default class HeadContent extends Component {
 
   render() {
     const meta = this.buildMetaContent();
-    return <Helmet meta={meta} title={this.props.title} />;
+    const props = {
+      meta,
+      title: this.props.title
+    };
+    if (!this.props.appendTitle) props.titleTemplate = null;
+
+    return <Helmet {...props} />;
   }
 }

--- a/client/src/containers/Manifold.js
+++ b/client/src/containers/Manifold.js
@@ -157,6 +157,18 @@ class ManifoldContainer extends PureComponent {
     return null;
   }
 
+  headTitleProps(props) {
+    let title = config.app.head.defaultTitle;
+    if (get(props.settings, "attributes.general.headTitle")) {
+      title = get(props.settings, "attributes.general.headTitle");
+    }
+
+    return {
+      titleTemplate: `${title} | %s`,
+      defaultTitle: title
+    };
+  }
+
   renderTypekit() {
     const tkId = get(this.props.settings, "attributes.theme.typekitId");
     const tkEnabled = !!tkId;
@@ -176,7 +188,7 @@ class ManifoldContainer extends PureComponent {
         <div id="global-overlay-container" />
         {this.renderTypekit()}
         {this.props.confirm}
-        <Helmet {...config.app.head} />
+        <Helmet {...config.app.head} {...this.headTitleProps(this.props)} />
         <LoadingBar loading={this.props.loading} />
         <ReactCSSTransitionGroup
           transitionName={"overlay-login"}

--- a/client/src/containers/backend/Settings/General.js
+++ b/client/src/containers/backend/Settings/General.js
@@ -43,6 +43,12 @@ export class SettingsGeneralContainer extends PureComponent {
             }
           />
           <Form.TextInput
+            label="Default Page Title"
+            name="attributes[general][headTitle]"
+            placeholder="Enter page title"
+            instructions="This field will be used as the page title on the home page, and will be appended to the page title on core Manifold pages. Defaults to 'Manifold Scholarship'."
+          />
+          <Form.TextInput
             label="Default Publisher"
             name="attributes[general][defaultPublisher]"
             placeholder="Enter Default Publisher"

--- a/client/src/containers/backend/Settings/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Settings/__tests__/__snapshots__/General-test.js.snap
@@ -34,6 +34,27 @@ exports[`Backend Settings General Container renders correctly 1`] = `
         style={Object {}}
       >
         <label
+          className="has-instructions"
+        >
+          Default Page Title
+        </label>
+        <span
+          className="instructions"
+        >
+          This field will be used as the page title on the home page, and will be appended to the page title on core Manifold pages. Defaults to 'Manifold Scholarship'.
+        </span>
+        <input
+          onChange={[Function]}
+          placeholder="Enter page title"
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        className="form-input"
+        style={Object {}}
+      >
+        <label
           className=""
         >
           Default Publisher

--- a/client/src/containers/frontend/Featured.js
+++ b/client/src/containers/frontend/Featured.js
@@ -81,7 +81,7 @@ export class FeaturedContainer extends Component {
           overflowX: "hidden"
         }}
       >
-        <HeadContent title="Manifold Scholarship | Featured" />
+        <HeadContent title="Featured" appendTitle />
         <section className="bg-neutral05">
           <div className="container">
             <header className="section-heading utility-right">

--- a/client/src/containers/frontend/Following.js
+++ b/client/src/containers/frontend/Following.js
@@ -160,7 +160,7 @@ export class FollowingContainer extends Component {
         {...this.props}
       >
         <div>
-          <HeadContent title="Manifold Scholarship | Following" />
+          <HeadContent title="Following" appendTitle />
           <ProjectList.Following
             followedProjects={this.props.followedProjects}
             authentication={this.props.authentication}


### PR DESCRIPTION
The fix here has a few parts:
- Expose a `headTitle` attribute on settings.
- Pick that title up at the top level (`ManifoldContainer`) or use the default as specified in the config file.
- Set a `titleTemplate` prop for helmet by default.  The `titleTemplate` potentially also uses the title from settings, so it must be defined when helmet is first used (again in `ManifoldContainer`).  
- Expose a prop `nested` on the `HeadContent` component.  When included, the page will use the `titleTemplate`, which is defined at the higher scope.  When `nested` is not included as a prop, we pass `titleTemplate: false` to helmet to override the setting.

Please also review the language in the backend form.  I feel like it's a little unclear, but was struggling with naming/describing it.

Fixes #1024