### PR TITLE
[B] Adjust reader TOC/footer z-indices

### DIFF
--- a/client/src/theme/Components/reader/notation/_preview.scss
+++ b/client/src/theme/Components/reader/notation/_preview.scss
@@ -7,7 +7,7 @@
   border-top: 1px solid $neutral50;
   // This gets overwritten during a show/hide
   transition: margin $duration $timing;
-  
+
   @include respond($break50) {
     bottom: 0;
   }
@@ -69,7 +69,7 @@
       align-items: center;
       justify-content: space-between;
       width: 100%;
-      padding: 10px $containerPaddingResp;
+      padding: 17px $containerPaddingResp;
 
       .scheme-dark & {
         color: $neutralWhite;

--- a/client/src/theme/_z-stack.scss
+++ b/client/src/theme/_z-stack.scss
@@ -35,24 +35,12 @@
   z-index: 400;
 }
 
-.drawer-reader {
-  z-index: 150;
-}
-
 .dialog-primary {
   z-index: 600;
 }
 
-.notation-preview-footer {
-  z-index: 180;
-}
-
 .reader-footer-menu {
   z-index: 200;
-}
-
-.section-category-label.fixed {
-  z-index: 180;
 }
 
 .header-app {
@@ -73,6 +61,14 @@
 
 .footer-fixed {
   z-index: 200;
+}
+
+.drawer-reader {
+  z-index: 150;
+}
+
+.notation-preview-footer {
+  z-index: 140;
 }
 
 .predictive-list {


### PR DESCRIPTION
Fixes #1025
Also adjusts the mobile resource viewer footer so it matches the height of the section label.
![full](https://user-images.githubusercontent.com/8389445/39841190-cf395d52-5396-11e8-8891-ddc92c8159b0.gif)
![mobile](https://user-images.githubusercontent.com/8389445/39841191-cf4d5672-5396-11e8-8b21-c771bb78ad99.gif)
