### PR TITLE
[B] Fix text section not reindexing searchable nodes on create

### DIFF
--- a/api/app/jobs/text_section_jobs/reindex_searchable_nodes.rb
+++ b/api/app/jobs/text_section_jobs/reindex_searchable_nodes.rb
@@ -1,0 +1,12 @@
+module TextSectionJobs
+  class ReindexSearchableNodes < ApplicationJob
+
+    def perform(text_section)
+      return unless text_section.present?
+      SearchableNode.searchkick_index.bulk_delete(text_section.searchable_nodes)
+      text_section.searchable_nodes.clear
+      SearchableNode.import(text_section.properties_for_searchable_nodes)
+      text_section.searchable_nodes.reload.reindex
+    end
+  end
+end

--- a/api/spec/models/text_section_spec.rb
+++ b/api/spec/models/text_section_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe TextSection, type: :model do
     expect(text_section.ingestion_source).to be ingestion_source
   end
 
+  describe "enqueues a job to reindex searchable nodes" do
+    it "when creating" do
+      expect { FactoryBot.create(:text_section) }.to have_enqueued_job(TextSectionJobs::ReindexSearchableNodes)
+    end
+
+    it "when body_json changes" do
+      text_section = FactoryBot.create(:text_section)
+      expect do
+        text_section.body_json = {"node_uuid" => "A", "tag" => "section", "node_type" => "element" }
+        text_section.save
+      end.to have_enqueued_job(TextSectionJobs::ReindexSearchableNodes)
+    end
+  end
+
   context "collapses body_json into searchable text nodes" do
 
     let(:text_section) {


### PR DESCRIPTION
Fixes #1033
This also moves the contents of `text_section#update_text_index` to
a background job.