### PR TITLE
 [F] Attempt to reassign annotation start/end nodes when section changes

### DIFF
--- a/api/app/controllers/concerns/validation.rb
+++ b/api/app/controllers/concerns/validation.rb
@@ -325,7 +325,9 @@ module Validation
   def annotation_filter_params
     coerce_filter_to_hash(:filter, :ids)
     coerce_filter_to_hash(:filter, :formats)
-    params.permit(filter: [{ ids: [] }, [{ formats: [] }], :text, :text_section])[:filter]
+    params.permit(filter: [:orphaned,
+                           { ids: [] },
+                           [{ formats: [] }], :text, :text_section])[:filter]
   end
 
   def subject_filter_params

--- a/api/app/jobs/annotation_jobs/adopt_or_orphan_job.rb
+++ b/api/app/jobs/annotation_jobs/adopt_or_orphan_job.rb
@@ -1,0 +1,8 @@
+module AnnotationJobs
+  class AdoptOrOrphanJob < ApplicationJob
+
+    def perform(annotation)
+      Annotations::AdoptOrOrphan.run annotation: annotation
+    end
+  end
+end

--- a/api/app/jobs/text_section_jobs/enqueue_adopt_annotations_job.rb
+++ b/api/app/jobs/text_section_jobs/enqueue_adopt_annotations_job.rb
@@ -1,0 +1,11 @@
+module TextSectionJobs
+  class EnqueueAdoptAnnotationsJob < ApplicationJob
+
+    def perform(annotations_ids)
+      return unless annotations_ids.present?
+      Annotation.where(id: annotations_ids).each do |annotation|
+        AnnotationJobs::AdoptOrOrphanJob.perform_later annotation
+      end
+    end
+  end
+end

--- a/api/app/models/annotation.rb
+++ b/api/app/models/annotation.rb
@@ -35,6 +35,10 @@ class Annotation < ApplicationRecord
     return all unless formats.present?
     where(format: formats)
   }
+  scope :with_orphaned, lambda { |orphaned|
+    next all if orphaned.blank?
+    where.not(text_section: nil).where(orphaned: orphaned)
+  }
 
   # Constants
   TYPE_ANNOTATION = "annotation".freeze
@@ -78,6 +82,8 @@ class Annotation < ApplicationRecord
   # Delegations
   delegate :text, to: :text_section, allow_nil: true
   delegate :project, to: :text, allow_nil: true
+  delegate :text_node_for, to: :text_section, prefix: true
+  delegate :text_nodes, to: :text_section, prefix: true
 
   # Search
   searchkick(callbacks: :async,
@@ -131,6 +137,14 @@ class Annotation < ApplicationRecord
 
   def author_created
     creator.project_author_of? project
+  end
+
+  def start_text_node
+    text_section_text_node_for start_node
+  end
+
+  def end_text_node
+    text_section_text_node_for end_node
   end
 
 end

--- a/api/app/serializers/annotation_serializer.rb
+++ b/api/app/serializers/annotation_serializer.rb
@@ -9,6 +9,9 @@ class AnnotationSerializer < ApplicationSerializer
   attributes :created_at, :end_char, :end_node, :id, :start_char, :start_node,
              :text_section_id, :updated_at, :format, :subject, :abilities, :resource_id,
              :creator_id, :body, :private, :comments_count, :collection_id,
-             :author_created, :current_user_is_creator
+             :author_created, :current_user_is_creator, :orphaned
 
+  def orphaned
+    object.orphaned?
+  end
 end

--- a/api/app/services/annotations/adopt_or_orphan.rb
+++ b/api/app/services/annotations/adopt_or_orphan.rb
@@ -1,0 +1,104 @@
+# This service attempts to reassign an annotation's start/end positions based on
+# subject content. To keep things sane, we only assume a node is correct
+# if a block of its content is is an exact match to a piece of the subject.
+module Annotations
+  class AdoptOrOrphan < ActiveInteraction::Base
+    object :annotation
+
+    def execute
+      candidates = determine_parent_candidates
+
+      return annotation if valid_parents? current_parents
+
+      if valid_parents? candidates
+        adopt_annotation candidates
+      else
+        orphan_annotation
+      end
+
+      annotation.save
+      annotation
+    end
+
+    private
+
+    def orphan_annotation
+      annotation.assign_attributes orphaned: true
+    end
+
+    def adopt_annotation(candidates)
+      annotation.assign_attributes candidates.merge(orphaned: false)
+    end
+
+    # A set of nodes is only considered valid if all are present and
+    # the content spanning the nodes contains an exact match to the
+    # annotation subject.
+    def valid_parents?(candidates)
+      candidates_present?(candidates) && valid_content?(candidates)
+    end
+
+    # We only consider this a success if everything has been matched
+    def candidates_present?(candidates)
+      candidates.values.all?(&:present?)
+    end
+
+    # We compile the content from the start node to the end node and
+    # see if the complete subject is included.  If not, we consider
+    # this annotation changed and orphan it.
+    def valid_content?(candidates)
+      start_node, end_node = candidates.values
+      node_range = annotation.text_section.text_node_range start_node, end_node
+      content = node_range.map { |n| n[:content] }.join
+      content.include? annotation.subject
+    end
+
+    def current_parents
+      {
+        start_node: annotation.start_node,
+        end_node: annotation.end_node,
+        start_char: annotation.start_char,
+        end_char: annotation.end_char
+      }
+    end
+
+    # Here we create an array of letters for every node's content.  For every
+    # letter we look forward to the content end and backwards from the content
+    # end to the letter.  We then try to match those chunks to either the start
+    # or end of the subject.
+    #
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def determine_parent_candidates
+      candidates = {
+        start_node: nil,
+        end_node: nil,
+        start_char: nil,
+        end_char: nil
+      }.with_indifferent_access
+
+      # We have to check every text section in case there are multiple matches, so
+      # we can't abort out of this early.
+      # If we have multiple matches for any node, we cannot assume that either is the
+      # correct one and therefore abort and orphan the annotation.
+      annotation.text_section_text_nodes.each do |node|
+        content = node[:content]
+        content.split(//).each_with_index do |_letter, index|
+          from_start = content[index..content.length - 1]
+          from_end = content[0..index]
+
+          if annotation.subject.start_with? from_start
+            return {} if candidates[:start_node].present?
+            candidates[:start_node] = node[:node_uuid]
+            candidates[:start_char] = index + 1
+          elsif annotation.subject.end_with? from_end
+            return {} if candidates[:end_node].present?
+            candidates[:end_node] = node[:node_uuid]
+            candidates[:end_char] = index
+          end
+        end
+      end
+
+      candidates
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+  end
+end

--- a/api/db/migrate/20180511173451_add_orphaned_to_annotations.rb
+++ b/api/db/migrate/20180511173451_add_orphaned_to_annotations.rb
@@ -1,0 +1,5 @@
+class AddOrphanedToAnnotations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :annotations, :orphaned, :boolean, default: false, null: false
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180510161730) do
+ActiveRecord::Schema.define(version: 20180511173451) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20180510161730) do
     t.integer  "comments_count",  default: 0
     t.uuid     "collection_id"
     t.integer  "events_count",    default: 0
+    t.boolean  "orphaned",        default: false, null: false
     t.index ["created_at"], name: "index_annotations_on_created_at", using: :brin
     t.index ["format"], name: "index_annotations_on_format", using: :btree
   end

--- a/api/spec/models/annotation_spec.rb
+++ b/api/spec/models/annotation_spec.rb
@@ -109,5 +109,4 @@ RSpec.describe Annotation, type: :model do
       expect(@annotation).to be_valid
     end
   end
-
 end

--- a/api/spec/services/annotations/adopt_or_orphan_spec.rb
+++ b/api/spec/services/annotations/adopt_or_orphan_spec.rb
@@ -1,0 +1,122 @@
+RSpec.describe Annotations::AdoptOrOrphan do
+  let(:text_section) do
+    body_json = {
+      "node_uuid" => "A",
+      "tag" => "section",
+      "node_type" => "element",
+      "children" => [
+        {
+          "node_uuid" => "B",
+          "tag" => "p",
+          "node_type" => "text",
+          "content" => "One, two, blue, "
+        },
+        {
+          "node_uuid" => "C",
+          "tag" => "p",
+          "node_type" => "text",
+          "content" => "three, four, "
+        },
+        {
+          "node_uuid" => "D",
+          "tag" => "p",
+          "node_type" => "text",
+          "content" => "five, six. blue."
+        }
+      ]
+    }
+
+    FactoryBot.create(:text_section, body_json: body_json)
+  end
+
+  describe "determines the start/end nodes by subject content" do
+    before(:each) do
+      @annotation = FactoryBot.create(:annotation,
+                                  text_section: text_section,
+                                  start_node: "F",
+                                  end_node: "G",
+                                  subject: "three, four, five,")
+      Annotations::AdoptOrOrphan.run annotation: @annotation
+    end
+
+    it "has the correct start node" do
+      expect(@annotation.start_node).to eq "C"
+    end
+
+    it "has the correct end node" do
+      expect(@annotation.end_node).to eq "D"
+    end
+
+    it "has the correct start char" do
+      expect(@annotation.start_char).to eq 1
+    end
+
+    it "has the correct end char" do
+      expect(@annotation.end_char).to eq 4
+    end
+  end
+
+  context "when parent nodes are still present" do
+    context "when content in range has not changed" do
+      it "maintains the current parent nodes" do
+        annotation = FactoryBot.create(:annotation,
+                                       text_section: text_section,
+                                       start_node: "B",
+                                       end_node: "C",
+                                       subject: "One, two, blue, three, four, ")
+        Annotations::AdoptOrOrphan.run annotation: annotation
+        expect(annotation.attributes.slice("start_node", "end_node").values).to eq %w(B C)
+      end
+    end
+
+    context "when content in range has changed" do
+      it "marks the annotation as orphaned" do
+        annotation = FactoryBot.create(:annotation,
+                                       text_section: text_section,
+                                       start_node: "B",
+                                       end_node: "D",
+                                       subject: "One, two, blue, five, six.")
+        Annotations::AdoptOrOrphan.run annotation: annotation
+        expect(annotation.orphaned).to eq true
+      end
+    end
+
+    context "when nodes have duplicate content" do
+      it "maintains the current parent nodes" do
+        annotation = FactoryBot.create(:annotation,
+                                       text_section: text_section,
+                                       start_node: "D",
+                                       end_node: "D",
+                                       subject: "blue")
+        Annotations::AdoptOrOrphan.run annotation: annotation
+        expect(annotation.attributes.slice("start_node", "end_node").values).to eq %w(D D)
+      end
+    end
+  end
+
+  context "when new nodes are found" do
+    context "when nodes have duplicate content" do
+      it "marks the annotation as orphaned" do
+        annotation = FactoryBot.create(:annotation,
+                                       text_section: text_section,
+                                       start_node: "F",
+                                       end_node: "F",
+                                       subject: "blue")
+        Annotations::AdoptOrOrphan.run annotation: annotation
+        expect(annotation.orphaned).to eq true
+      end
+    end
+  end
+
+  context "when no parent nodes are found" do
+    it "marks the annotation as orphaned" do
+      annotation = FactoryBot.create(:annotation,
+                                      text_section: text_section,
+                                      start_node: "H",
+                                      end_node: "E",
+                                      subject: "Seven, eight.")
+      Annotations::AdoptOrOrphan.run annotation: annotation
+      expect(annotation.orphaned).to eq true
+    end
+  end
+end

--- a/client/src/api/resources/annotations.js
+++ b/client/src/api/resources/annotations.js
@@ -1,10 +1,13 @@
 export default {
   forSection(sectionId, filter = {}, page = {}) {
+    const filterParams = Object.assign({}, filter);
+    filterParams.orphaned = false;
+
     return {
       endpoint: `/api/v1/text_sections/${sectionId}/relationships/annotations`,
       method: "GET",
       options: {
-        params: { filter, page }
+        params: { filter: filterParams, page }
       }
     };
   },

--- a/client/src/containers/reader/ReaderNotes.js
+++ b/client/src/containers/reader/ReaderNotes.js
@@ -79,6 +79,7 @@ export class ReaderNotesContainer extends Component {
   setInitialState = props => {
     return {
       filter: {
+        orphaned: false,
         text: props.text.id,
         formats: [...INITIAL_FORMATS]
       }


### PR DESCRIPTION
The behavior of this change ends up being relatively small.  Effectively, the only addition coming from this PR is that annotations will detect their new start and end nodes when the UUIDs change.  The cases/outcomes of annotation reassignment is below.  Both of these cases has the same application when the section nodes are reordered.

- **Node content unchanged**: If the annotation subject remains stable, we use the existing start/end nodes.  If there are additional, new nodes between the start and end nodes, we orphan the annotation.

- **Node content changed**: We find the start and end nodes (new uuids because content has changed) and then see if the content spanning from start to end contains the annotation subject _exactly_.  We reassign to those nodes if it does or orphan if it does not.  If we encounter two nodes that match either the start or end nodes, we mark the annotation as orphaned because we cannot declare either the parent with any certainty.

Additionally on the frontend, we only fetch annotations that have not been orphaned in both the reader and the reader notes drawer.