### PR TITLE
[F] Toggle button elements work like real buttons in screen readers

### DIFF
--- a/client/src/components/backend/Form/Switch.js
+++ b/client/src/components/backend/Form/Switch.js
@@ -64,7 +64,13 @@ class FormSwitch extends Component {
         {this.props.labelPos === "above" ? label : null}
         <div className="toggle-indicator">
           {/* Add .checked to .boolean-primary to change visual state */}
-          <div onClick={this.handleClick} className={classes} />
+          <div
+            onClick={this.handleClick}
+            role="button"
+            aria-pressed="false"
+            className={classes}
+            tabIndex="0"
+          />
         </div>
         {this.props.labelPos === "below" ? label : null}
       </div>

--- a/client/src/components/backend/Form/__tests__/__snapshots__/Switch-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/Switch-test.js.snap
@@ -13,8 +13,11 @@ exports[`Backend.Form.Switch component renders correctly 1`] = `
     className="toggle-indicator"
   >
     <div
+      aria-pressed="false"
       className="boolean-primary"
       onClick={[Function]}
+      role="button"
+      tabIndex="0"
     />
   </div>
 </div>

--- a/client/src/components/backend/Form/__tests__/__snapshots__/SwitchArray-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/SwitchArray-test.js.snap
@@ -27,8 +27,11 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
         className="toggle-indicator"
       >
         <div
+          aria-pressed="false"
           className="boolean-primary"
           onClick={[Function]}
+          role="button"
+          tabIndex="0"
         />
       </div>
     </div>
@@ -44,8 +47,11 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
         className="toggle-indicator"
       >
         <div
+          aria-pressed="false"
           className="boolean-primary"
           onClick={[Function]}
+          role="button"
+          tabIndex="0"
         />
       </div>
     </div>

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Video-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Video-test.js.snap
@@ -16,8 +16,11 @@ exports[`Backend.Resource.Form.Video component renders correctly 1`] = `
       className="toggle-indicator"
     >
       <div
+        aria-pressed="false"
         className="boolean-primary"
         onClick={[Function]}
+        role="button"
+        tabIndex="0"
       />
     </div>
   </div>
@@ -91,8 +94,11 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
       className="toggle-indicator"
     >
       <div
+        aria-pressed="false"
         className="boolean-primary"
         onClick={[Function]}
+        role="button"
+        tabIndex="0"
       />
     </div>
   </div>

--- a/client/src/components/backend/TwitterQuery/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/components/backend/TwitterQuery/__tests__/__snapshots__/Form-test.js.snap
@@ -82,8 +82,11 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
         className="toggle-indicator"
       >
         <div
+          aria-pressed="false"
           className="boolean-primary checked"
           onClick={[Function]}
+          role="button"
+          tabIndex="0"
         />
       </div>
     </div>

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/Edit-test.js.snap
@@ -60,8 +60,11 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
                 className="toggle-indicator"
               >
                 <div
+                  aria-pressed="false"
                   className="boolean-primary"
                   onClick={[Function]}
+                  role="button"
+                  tabIndex="0"
                 />
               </div>
             </div>
@@ -77,8 +80,11 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
                 className="toggle-indicator"
               >
                 <div
+                  aria-pressed="false"
                   className="boolean-primary"
                   onClick={[Function]}
+                  role="button"
+                  tabIndex="0"
                 />
               </div>
             </div>
@@ -94,8 +100,11 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
                 className="toggle-indicator"
               >
                 <div
+                  aria-pressed="false"
                   className="boolean-primary"
                   onClick={[Function]}
+                  role="button"
+                  tabIndex="0"
                 />
               </div>
             </div>

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/Form-test.js.snap
@@ -70,8 +70,11 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
               className="toggle-indicator"
             >
               <div
+                aria-pressed="false"
                 className="boolean-primary"
                 onClick={[Function]}
+                role="button"
+                tabIndex="0"
               />
             </div>
           </div>
@@ -87,8 +90,11 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
               className="toggle-indicator"
             >
               <div
+                aria-pressed="false"
                 className="boolean-primary"
                 onClick={[Function]}
+                role="button"
+                tabIndex="0"
               />
             </div>
           </div>
@@ -104,8 +110,11 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
               className="toggle-indicator"
             >
               <div
+                aria-pressed="false"
                 className="boolean-primary"
                 onClick={[Function]}
+                role="button"
+                tabIndex="0"
               />
             </div>
           </div>

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/New-test.js.snap
@@ -80,8 +80,11 @@ exports[`Backend Permission New Container renders correctly 1`] = `
                 className="toggle-indicator"
               >
                 <div
+                  aria-pressed="false"
                   className="boolean-primary"
                   onClick={[Function]}
+                  role="button"
+                  tabIndex="0"
                 />
               </div>
             </div>
@@ -97,8 +100,11 @@ exports[`Backend Permission New Container renders correctly 1`] = `
                 className="toggle-indicator"
               >
                 <div
+                  aria-pressed="false"
                   className="boolean-primary"
                   onClick={[Function]}
+                  role="button"
+                  tabIndex="0"
                 />
               </div>
             </div>
@@ -114,8 +120,11 @@ exports[`Backend Permission New Container renders correctly 1`] = `
                 className="toggle-indicator"
               >
                 <div
+                  aria-pressed="false"
                   className="boolean-primary"
                   onClick={[Function]}
+                  role="button"
+                  tabIndex="0"
                 />
               </div>
             </div>

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/General-test.js.snap
@@ -89,8 +89,11 @@ exports[`Backend Project General Container renders correctly 1`] = `
             className="toggle-indicator"
           >
             <div
+              aria-pressed="false"
               className="boolean-primary"
               onClick={[Function]}
+              role="button"
+              tabIndex="0"
             />
           </div>
           <label
@@ -106,8 +109,11 @@ exports[`Backend Project General Container renders correctly 1`] = `
             className="toggle-indicator"
           >
             <div
+              aria-pressed="false"
               className="boolean-primary"
               onClick={[Function]}
+              role="button"
+              tabIndex="0"
             />
           </div>
           <label

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/ProjectPage-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/ProjectPage-test.js.snap
@@ -292,8 +292,11 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           className="toggle-indicator"
         >
           <div
+            aria-pressed="false"
             className="boolean-primary"
             onClick={[Function]}
+            role="button"
+            tabIndex="0"
           />
         </div>
       </div>

--- a/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/Edit-test.js.snap
@@ -121,8 +121,11 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
             className="toggle-indicator"
           >
             <div
+              aria-pressed="false"
               className="boolean-primary checked"
               onClick={[Function]}
+              role="button"
+              tabIndex="0"
             />
           </div>
         </div>

--- a/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/New-test.js.snap
@@ -92,8 +92,11 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
           className="toggle-indicator"
         >
           <div
+            aria-pressed="false"
             className="boolean-primary checked"
             onClick={[Function]}
+            role="button"
+            tabIndex="0"
           />
         </div>
       </div>


### PR DESCRIPTION
Resolves #1045

Adds a role and aria atttributes to treat toggle buttons (div elements) as clickable buttons by screen readers