### PR TITLE
[B] Fix FormContainer session initializing with null model

### DIFF
--- a/client/src/components/backend/Form/setter.js
+++ b/client/src/components/backend/Form/setter.js
@@ -162,5 +162,7 @@ export default function setter(WrappedComponent) {
     }
   }
 
-  return hoistStatics(Setter, WrappedComponent);
+  return hoistStatics(Setter, WrappedComponent, {
+    getDerivedStateFromProps: true
+  });
 }

--- a/client/src/containers/backend/Form/Form.js
+++ b/client/src/containers/backend/Form/Form.js
@@ -87,11 +87,12 @@ export class FormContainer extends PureComponent {
   }
 
   maybeOpenSession(props, prevProps = {}) {
+    const model = props.model || {};
+
     if (prevProps.model !== props.model) {
-      return this.openSession(props.name, props.model);
+      return this.openSession(props.name, model);
     }
     if (props.session) return null;
-    const model = props.model || {};
     this.openSession(props.name, model);
   }
 


### PR DESCRIPTION
Fixes #1068

FormContainer change: `props.model` was `null` and being passed to the `open` entityEditor function.  That function uses the model argument to instantiate the model, so it need to be an empty hash by default.

setter change: This is because `ColumnMap` implements the new lifecycle function `getDerivedStateFromProps`, which is a static function.  When wrapped with the `setter` component, `getDerivedStateFromProps` is hoisted and requires state to be initialized.  The fix here is ignoring `getDerivedStateFromProps` when static functions are hoisted in the `setter` component.