### PR TITLE
[F] Interactive elements should have appropriate roles

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -103,10 +103,16 @@
     "jsx-a11y/alt-text": 2,
     "jsx-a11y/img-redundant-alt": 2,
 
-    // Rules for WCAG we should eventually enable
+    // Rules for WCAG related to interactive/non-interactive/static element roles
+    "jsx-a11y/no-interactive-element-to-noninteractive-role": 2,
+    "jsx-a11y/no-noninteractive-element-interactions": 2,
+    "jsx-a11y/no-noninteractive-element-to-interactive-role": 2,
+    "jsx-a11y/no-static-element-interactions": 2,
     "jsx-a11y/href-no-hash": 0,
-    "jsx-a11y/anchor-has-content": 0,
-    "jsx-a11y/anchor-is-valid": 0,
+    "jsx-a11y/anchor-has-content": 2,
+    "jsx-a11y/anchor-is-valid": 2,
+
+    // Rules for WCAG we should eventually enable
     "jsx-a11y/aria-activedescendant-has-tabindex": 0,
     "jsx-a11y/click-events-have-key-events": 0,
     "jsx-a11y/heading-has-content": 0,
@@ -117,12 +123,8 @@
     "jsx-a11y/no-access-key": 0,
     "jsx-a11y/no-autofocus": 0,
     "jsx-a11y/no-distracting-elements": 0,
-    "jsx-a11y/no-interactive-element-to-noninteractive-role": 0,
-    "jsx-a11y/no-noninteractive-element-interactions": 0,
-    "jsx-a11y/no-noninteractive-element-to-interactive-role": 0,
     "jsx-a11y/no-noninteractive-tabindex": 0,
     "jsx-a11y/no-onchange": 0,
-    "jsx-a11y/no-static-element-interactions": 0,
     "jsx-a11y/scope": 0,
 
   },

--- a/client/src/components/backend/Dashboard/Notifications.js
+++ b/client/src/components/backend/Dashboard/Notifications.js
@@ -33,7 +33,10 @@ export default class Notifications extends Component {
             </button>
           </li>
         </ul>
-        <a href="#" className="button-bare-primary">
+        <a
+          href="https://en.wikipedia.org/wiki/Placeholder"
+          className="button-bare-primary"
+        >
           {"Notification History"}
         </a>
       </nav>

--- a/client/src/components/backend/Dashboard/__tests__/__snapshots__/Notifications-test.js.snap
+++ b/client/src/components/backend/Dashboard/__tests__/__snapshots__/Notifications-test.js.snap
@@ -46,7 +46,7 @@ exports[`Backend.Dashboard.Notification component renders correctly 1`] = `
   </ul>
   <a
     className="button-bare-primary"
-    href="#"
+    href="https://en.wikipedia.org/wiki/Placeholder"
   >
     Notification History
   </a>

--- a/client/src/components/backend/Dialog/Wrapper.js
+++ b/client/src/components/backend/Dialog/Wrapper.js
@@ -115,7 +115,11 @@ class DialogWrapper extends PureComponent {
       >
         {this.state.leaving ? null : (
           <div key="dialog" className="dialog-primary dialog-appear">
-            <div className="dialog-overlay" onClick={this.handleOverlayClick} />
+            <div
+              className="dialog-overlay"
+              onClick={this.handleOverlayClick}
+              role="button"
+            />
             <div
               className={classnames(
                 "dialog-box",
@@ -128,6 +132,7 @@ class DialogWrapper extends PureComponent {
                 <div
                   onClick={this.handleCloseClick}
                   className="close-button-primary"
+                  role="button"
                 >
                   <i className="manicon manicon-x" aria-hidden="true" />
                   <span className="screen-reader-text">Close Dialog</span>

--- a/client/src/components/backend/Dialog/__tests__/__snapshots__/Confirm-test.js.snap
+++ b/client/src/components/backend/Dialog/__tests__/__snapshots__/Confirm-test.js.snap
@@ -12,7 +12,7 @@ exports[`Backend.Dialog.Confirm Component renders correctly 1`] = `
                 <span>
                   <CSSTransitionGroupChild name=\\"dialog\\" appear={true} enter={false} leave={true} appearTimeout={1} enterTimeout={[undefined]} leaveTimeout={200}>
                     <div className=\\"dialog-primary dialog-appear\\">
-                      <div className=\\"dialog-overlay\\" onClick={[Function]} />
+                      <div className=\\"dialog-overlay\\" onClick={[Function]} role=\\"button\\" />
                       <div className=\\"dialog-box dialog-confirm\\" style={{...}}>
                         <header className=\\"dialog-header-small\\">
                           <h2>

--- a/client/src/components/backend/Dialog/__tests__/__snapshots__/ResetPassword-test.js.snap
+++ b/client/src/components/backend/Dialog/__tests__/__snapshots__/ResetPassword-test.js.snap
@@ -14,7 +14,7 @@ exports[`Backend.Dialog.ResetPassword Component renders correctly 1`] = `
                     <span>
                       <CSSTransitionGroupChild name=\\"dialog\\" appear={true} enter={false} leave={true} appearTimeout={1} enterTimeout={[undefined]} leaveTimeout={200}>
                         <div className=\\"dialog-primary dialog-appear\\">
-                          <div className=\\"dialog-overlay\\" onClick={[Function]} />
+                          <div className=\\"dialog-overlay\\" onClick={[Function]} role=\\"button\\" />
                           <div className=\\"dialog-box dialog-reset\\" style={{...}}>
                             <div>
                               <header className=\\"dialog-header-small\\">

--- a/client/src/components/backend/Dialog/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/components/backend/Dialog/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -11,9 +11,9 @@ exports[`Backend.Dialog.Wrapper Component renders correctly 1`] = `
               <span>
                 <CSSTransitionGroupChild name=\\"dialog\\" appear={true} enter={false} leave={true} appearTimeout={1} enterTimeout={[undefined]} leaveTimeout={200}>
                   <div className=\\"dialog-primary dialog-appear\\">
-                    <div className=\\"dialog-overlay\\" onClick={[Function]} />
+                    <div className=\\"dialog-overlay\\" onClick={[Function]} role=\\"button\\" />
                     <div className=\\"dialog-box dialog-confirm\\" style={{...}}>
-                      <div onClick={[Function]} className=\\"close-button-primary\\">
+                      <div onClick={[Function]} className=\\"close-button-primary\\" role=\\"button\\">
                         <i className=\\"manicon manicon-x\\" aria-hidden=\\"true\\" />
                         <span className=\\"screen-reader-text\\">
                           Close Dialog

--- a/client/src/components/backend/Event/__tests__/__snapshots__/ListItem-test.js.snap
+++ b/client/src/components/backend/Event/__tests__/__snapshots__/ListItem-test.js.snap
@@ -42,6 +42,7 @@ exports[`Event.ListItem component renders correctly 1`] = `
     className="utility"
     data-id="destroy"
     onClick={[Function]}
+    role="button"
   >
     <i
       aria-hidden="true"

--- a/client/src/components/backend/Form/Switch.js
+++ b/client/src/components/backend/Form/Switch.js
@@ -50,21 +50,37 @@ class FormSwitch extends Component {
   }
 
   render() {
+    const checked = this.determineChecked(this.props.value);
     const classes = classnames({
       "boolean-primary": true,
-      checked: this.determineChecked(this.props.value)
+      checked
     });
 
-    const labelClasses = classnames(this.props.labelPos, this.props.labelClass);
+    const labelClasses = classnames(
+      "form-input-heading",
+      this.props.labelPos,
+      this.props.labelClass
+    );
     const wrapperClasses = classnames("form-input", this.props.className);
-    const label = <label className={labelClasses}>{this.props.label}</label>;
+    const label = (
+      <label aria-hidden="true" className={labelClasses}>
+        {this.props.label}
+      </label>
+    );
 
     return (
       <div className={wrapperClasses}>
         {this.props.labelPos === "above" ? label : null}
         <div className="toggle-indicator">
           {/* Add .checked to .boolean-primary to change visual state */}
-          <div onClick={this.handleClick} className={classes} />
+          <div
+            onClick={this.handleClick}
+            className={classes}
+            role="button"
+            aria-pressed={checked}
+          >
+            <span className="screen-reader-text">{this.props.label}</span>
+          </div>
         </div>
         {this.props.labelPos === "below" ? label : null}
       </div>

--- a/client/src/components/backend/Form/__tests__/__snapshots__/Switch-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/Switch-test.js.snap
@@ -5,7 +5,8 @@ exports[`Backend.Form.Switch component renders correctly 1`] = `
   className="form-input"
 >
   <label
-    className="above"
+    aria-hidden="true"
+    className="form-input-heading above"
   >
     Label this
   </label>
@@ -13,9 +14,17 @@ exports[`Backend.Form.Switch component renders correctly 1`] = `
     className="toggle-indicator"
   >
     <div
+      aria-pressed={false}
       className="boolean-primary"
       onClick={[Function]}
-    />
+      role="button"
+    >
+      <span
+        className="screen-reader-text"
+      >
+        Label this
+      </span>
+    </div>
   </div>
 </div>
 `;

--- a/client/src/components/backend/Form/__tests__/__snapshots__/SwitchArray-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/SwitchArray-test.js.snap
@@ -19,7 +19,8 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
       className="form-input"
     >
       <label
-        className="above"
+        aria-hidden="true"
+        className="form-input-heading above"
       >
         Option one
       </label>
@@ -27,16 +28,25 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
         className="toggle-indicator"
       >
         <div
+          aria-pressed={false}
           className="boolean-primary"
           onClick={[Function]}
-        />
+          role="button"
+        >
+          <span
+            className="screen-reader-text"
+          >
+            Option one
+          </span>
+        </div>
       </div>
     </div>
     <div
       className="form-input"
     >
       <label
-        className="above"
+        aria-hidden="true"
+        className="form-input-heading above"
       >
         Option two
       </label>
@@ -44,9 +54,17 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
         className="toggle-indicator"
       >
         <div
+          aria-pressed={false}
           className="boolean-primary"
           onClick={[Function]}
-        />
+          role="button"
+        >
+          <span
+            className="screen-reader-text"
+          >
+            Option two
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Video-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Video-test.js.snap
@@ -8,7 +8,8 @@ exports[`Backend.Resource.Form.Video component renders correctly 1`] = `
     className="form-input"
   >
     <label
-      className="above"
+      aria-hidden="true"
+      className="form-input-heading above"
     >
       Is this an externally linked video?
     </label>
@@ -16,9 +17,17 @@ exports[`Backend.Resource.Form.Video component renders correctly 1`] = `
       className="toggle-indicator"
     >
       <div
+        aria-pressed={false}
         className="boolean-primary"
         onClick={[Function]}
-      />
+        role="button"
+      >
+        <span
+          className="screen-reader-text"
+        >
+          Is this an externally linked video?
+        </span>
+      </div>
     </div>
   </div>
   <div
@@ -85,7 +94,8 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
     className="form-input"
   >
     <label
-      className="above"
+      aria-hidden="true"
+      className="form-input-heading above"
     >
       Is this an externally linked video?
     </label>
@@ -93,9 +103,17 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
       className="toggle-indicator"
     >
       <div
+        aria-pressed={false}
         className="boolean-primary"
         onClick={[Function]}
-      />
+        role="button"
+      >
+        <span
+          className="screen-reader-text"
+        >
+          Is this an externally linked video?
+        </span>
+      </div>
     </div>
   </div>
   <div

--- a/client/src/components/backend/Resource/Form/KindPicker.js
+++ b/client/src/components/backend/Resource/Form/KindPicker.js
@@ -16,12 +16,14 @@ class KindPicker extends PureComponent {
   renderKindPickerButtons(kindList) {
     if (!kindList) return null;
     return (
-      <ul>
+      <ul role="radiogroup">
         {kindList.map(kind => {
           const safeKind = kind.toLowerCase();
+          const kindValue = this.props.getModelValue("attributes[kind]");
+          const isActive = safeKind === kindValue;
           const buttonClass = classNames({
             button: true,
-            active: safeKind === this.props.getModelValue("attributes[kind]")
+            active: isActive
           });
           return (
             <li key={safeKind}>
@@ -30,6 +32,8 @@ class KindPicker extends PureComponent {
                   this.props.set(safeKind);
                 }}
                 className={buttonClass}
+                role="radio"
+                aria-checked={isActive}
               >
                 <figure>
                   <figcaption>

--- a/client/src/components/backend/Resource/Form/__tests__/__snapshots__/KindPicker-test.js.snap
+++ b/client/src/components/backend/Resource/Form/__tests__/__snapshots__/KindPicker-test.js.snap
@@ -87,11 +87,15 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
         </select>
       </div>
     </div>
-    <ul>
+    <ul
+      role="radiogroup"
+    >
       <li>
         <div
+          aria-checked={true}
           className="button active"
           onClick={[Function]}
+          role="radio"
         >
           <figure>
             <figcaption>
@@ -126,8 +130,10 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
       </li>
       <li>
         <div
+          aria-checked={false}
           className="button"
           onClick={[Function]}
+          role="radio"
         >
           <figure>
             <figcaption>
@@ -157,8 +163,10 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
       </li>
       <li>
         <div
+          aria-checked={false}
           className="button"
           onClick={[Function]}
+          role="radio"
         >
           <figure>
             <figcaption>
@@ -197,8 +205,10 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
       </li>
       <li>
         <div
+          aria-checked={false}
           className="button"
           onClick={[Function]}
+          role="radio"
         >
           <figure>
             <figcaption>
@@ -225,8 +235,10 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
       </li>
       <li>
         <div
+          aria-checked={false}
           className="button"
           onClick={[Function]}
+          role="radio"
         >
           <figure>
             <figcaption>
@@ -262,8 +274,10 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
       </li>
       <li>
         <div
+          aria-checked={false}
           className="button"
           onClick={[Function]}
+          role="radio"
         >
           <figure>
             <figcaption>
@@ -293,8 +307,10 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
       </li>
       <li>
         <div
+          aria-checked={false}
           className="button"
           onClick={[Function]}
+          role="radio"
         >
           <figure>
             <figcaption>
@@ -336,8 +352,10 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
       </li>
       <li>
         <div
+          aria-checked={false}
           className="button"
           onClick={[Function]}
+          role="radio"
         >
           <figure>
             <figcaption>
@@ -364,8 +382,10 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
       </li>
       <li>
         <div
+          aria-checked={false}
           className="button"
           onClick={[Function]}
+          role="radio"
         >
           <figure>
             <figcaption>
@@ -395,8 +415,10 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
       </li>
       <li>
         <div
+          aria-checked={false}
           className="button"
           onClick={[Function]}
+          role="radio"
         >
           <figure>
             <figcaption>

--- a/client/src/components/backend/TwitterQuery/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/components/backend/TwitterQuery/__tests__/__snapshots__/Form-test.js.snap
@@ -75,7 +75,8 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
       className="form-input"
     >
       <label
-        className="above"
+        aria-hidden="true"
+        className="form-input-heading above"
       >
         Active
       </label>
@@ -83,9 +84,17 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
         className="toggle-indicator"
       >
         <div
+          aria-pressed={true}
           className="boolean-primary checked"
           onClick={[Function]}
-        />
+          role="button"
+        >
+          <span
+            className="screen-reader-text"
+          >
+            Active
+          </span>
+        </div>
       </div>
     </div>
     <div

--- a/client/src/components/frontend/Event/Tile.js
+++ b/client/src/components/frontend/Event/Tile.js
@@ -103,6 +103,7 @@ export default class Tile extends Component {
             className="utility"
             data-id={"destroy"}
             onClick={this.props.destroyCallback}
+            role="button"
           >
             <i className="manicon manicon-trashcan" aria-hidden="true" />
             <span className="screen-reader-text">Delete Event</span>

--- a/client/src/components/frontend/Layout/Footer.js
+++ b/client/src/components/frontend/Layout/Footer.js
@@ -67,15 +67,19 @@ class LayoutFooter extends Component {
   buildAuthLink() {
     if (this.props.authentication.authenticated) {
       return (
-        <a onClick={this.handleLogoutClick} href="#">
+        <span
+          className="fake-link"
+          role="button"
+          onClick={this.handleLogoutClick}
+        >
           {"Log Out"}
-        </a>
+        </span>
       );
     }
     return (
-      <a onClick={this.handleLoginClick} href="#">
+      <span className="fake-link" role="button" onClick={this.handleLoginClick}>
         {"Log In"}
-      </a>
+      </span>
     );
   }
 

--- a/client/src/components/frontend/Layout/Splash.js
+++ b/client/src/components/frontend/Layout/Splash.js
@@ -195,14 +195,14 @@ export default class Splash extends Component {
                   {this.attribute("linkText")}
                 </a>
                 {!this.props.authenticated ? (
-                  <a
-                    href="#"
+                  <span
                     onClick={this.handleSignUp}
                     target="blank"
                     className="button-bare-primary"
+                    role="button"
                   >
                     {"Sign Up"}
-                  </a>
+                  </span>
                 ) : null}
               </nav>
             ) : null}

--- a/client/src/components/frontend/Layout/__tests__/__snapshots__/Footer-tests.js.snap
+++ b/client/src/components/frontend/Layout/__tests__/__snapshots__/Footer-tests.js.snap
@@ -53,12 +53,13 @@ exports[`Frontend.Layout.Footer component renders correctly 1`] = `
                   className="footer-nav"
                 >
                   <li>
-                    <a
-                      href="#"
+                    <span
+                      className="fake-link"
                       onClick={[Function]}
+                      role="button"
                     >
                       Log In
-                    </a>
+                    </span>
                   </li>
                   <li>
                     <a

--- a/client/src/components/frontend/Project/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/components/frontend/Project/__tests__/__snapshots__/Resources-test.js.snap
@@ -161,10 +161,12 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
               <div
                 className="resource-preview-wrapper"
                 onClick={[Function]}
+                role="button"
               >
                 <div
                   className="resource-link"
                   onClick={[Function]}
+                  role="link"
                 >
                   <div
                     className="icon-thumbnail-primary "
@@ -222,6 +224,7 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
               onClick={[Function]}
               onMouseOut={[Function]}
               onMouseOver={[Function]}
+              role="link"
             >
               <div>
                 <header
@@ -258,7 +261,13 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
                 className="resource-tag-list"
                 onClick={[Function]}
                 onMouseOver={[Function]}
+                role="presentation"
               >
+                <span
+                  className="screen-reader-text"
+                >
+                  Tags list
+                </span>
                 <ul>
                   <li>
                     <a
@@ -301,10 +310,12 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
               <div
                 className="resource-preview-wrapper"
                 onClick={[Function]}
+                role="button"
               >
                 <div
                   className="resource-link"
                   onClick={[Function]}
+                  role="link"
                 >
                   <div
                     className="icon-thumbnail-primary "
@@ -362,6 +373,7 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
               onClick={[Function]}
               onMouseOut={[Function]}
               onMouseOver={[Function]}
+              role="link"
             >
               <div>
                 <header
@@ -398,7 +410,13 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
                 className="resource-tag-list"
                 onClick={[Function]}
                 onMouseOver={[Function]}
+                role="presentation"
               >
+                <span
+                  className="screen-reader-text"
+                >
+                  Tags list
+                </span>
                 <ul>
                   <li>
                     <a

--- a/client/src/components/frontend/Resource/Card.js
+++ b/client/src/components/frontend/Resource/Card.js
@@ -162,7 +162,11 @@ class ResourceCard extends Component {
     return (
       <li className="resource-card">
         <Resource.Preview resource={resource}>
-          <div className="resource-link" onClick={this.handlePreviewClick}>
+          <div
+            className="resource-link"
+            onClick={this.handlePreviewClick}
+            role="link"
+          >
             <Resourceish.Thumbnail resourceish={resource} />
             <div className="preview-text">{this.getPreviewText(attr)}</div>
           </div>
@@ -172,6 +176,7 @@ class ResourceCard extends Component {
           onMouseOver={this.handleInfoMouseOver}
           onMouseOut={this.handleInfoMouseOut}
           onClick={this.handleInfoClick}
+          role="link"
         >
           <div>
             <header className="resource-title">

--- a/client/src/components/frontend/Resource/Player/Audio.js
+++ b/client/src/components/frontend/Resource/Player/Audio.js
@@ -138,14 +138,14 @@ export default class ResourcePlayerAudio extends Component {
   renderUnstarted() {
     if (this.state.started) return null;
     return (
-      <div className="cover" onClick={this.startPlayback}>
-        <button>
-          <span className="screen-reader-text">Start Playback</span>
+      <div className="cover" onClick={this.startPlayback} role="button">
+        <span className="screen-reader-text">Start Playback</span>
+        <div className="play-button-indicator">
           <i
             className="manicon manicon-triangle-right-fill"
             aria-hidden="true"
           />
-        </button>
+        </div>
       </div>
     );
   }
@@ -174,11 +174,9 @@ export default class ResourcePlayerAudio extends Component {
         />
         <div className="control-bar">
           <button className="play-pause" onClick={this.togglePlayback}>
-            {this.state.playing ? (
-              <span className="screen-reader-text">Pause Playback</span>
-            ) : (
-              <span className="screen-reader-text">Start Playback</span>
-            )}
+            <span className="screen-reader-text">
+              {this.state.playing ? "Pause Playback" : "Start Playback"}
+            </span>
             <i className={playPauseClasses} aria-hidden="true" />
           </button>
           <div className="progress">
@@ -202,11 +200,9 @@ export default class ResourcePlayerAudio extends Component {
           </div>
           <div className="volume">
             <button className="mute" onClick={this.toggleMute}>
-              {this.state.muted ? (
-                <span className="screen-reader-text">Unmute</span>
-              ) : (
-                <span className="screen-reader-text">Mute</span>
-              )}
+              <span className="screen-reader-text">
+                {this.state.muted ? "Unmute" : "Mute"}
+              </span>
               <i className={muteClasses} aria-hidden="true" />
             </button>
             <div className="slider">

--- a/client/src/components/frontend/Resource/Preview/Preview.js
+++ b/client/src/components/frontend/Resource/Preview/Preview.js
@@ -102,6 +102,7 @@ export default class ResourcePreview extends Component {
         <div
           className="resource-preview-wrapper"
           onClick={this.handleOpenPreviewClick}
+          role="button"
         >
           {this.renderChildren()}
         </div>

--- a/client/src/components/frontend/Resource/Preview/__tests__/__snapshots__/Preview-test.js.snap
+++ b/client/src/components/frontend/Resource/Preview/__tests__/__snapshots__/Preview-test.js.snap
@@ -8,6 +8,7 @@ exports[`Frontend.Resource.Preview component renders correctly 1`] = `
   <div
     className="resource-preview-wrapper"
     onClick={[Function]}
+    role="button"
   >
     <div>
       Test Button

--- a/client/src/components/frontend/Resource/TagList.js
+++ b/client/src/components/frontend/Resource/TagList.js
@@ -61,7 +61,9 @@ export default class ResourceTagList extends Component {
         className="resource-tag-list"
         onMouseOver={this.stopPropagation}
         onClick={this.stopPropagation}
+        role="presentation"
       >
+        <span className="screen-reader-text">Tags list</span>
         <ul>{this.mapTagsToLinks(this.props.resource)}</ul>
       </nav>
     );

--- a/client/src/components/frontend/Resource/__tests__/__snapshots__/Card-test.js.snap
+++ b/client/src/components/frontend/Resource/__tests__/__snapshots__/Card-test.js.snap
@@ -11,10 +11,12 @@ exports[`Frontend.Resource.Card component renders correctly 1`] = `
     <div
       className="resource-preview-wrapper"
       onClick={[Function]}
+      role="button"
     >
       <div
         className="resource-link"
         onClick={[Function]}
+        role="link"
       >
         <div
           className="icon-thumbnail-primary "
@@ -72,6 +74,7 @@ exports[`Frontend.Resource.Card component renders correctly 1`] = `
     onClick={[Function]}
     onMouseOut={[Function]}
     onMouseOver={[Function]}
+    role="link"
   >
     <div>
       <header
@@ -108,7 +111,13 @@ exports[`Frontend.Resource.Card component renders correctly 1`] = `
       className="resource-tag-list"
       onClick={[Function]}
       onMouseOver={[Function]}
+      role="presentation"
     >
+      <span
+        className="screen-reader-text"
+      >
+        Tags list
+      </span>
       <ul>
         <li>
           <a

--- a/client/src/components/frontend/Resource/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/components/frontend/Resource/__tests__/__snapshots__/Detail-test.js.snap
@@ -48,6 +48,7 @@ exports[`Frontend.Resource.Detail component renders correctly 1`] = `
                 <div
                   className="resource-preview-wrapper"
                   onClick={[Function]}
+                  role="button"
                 >
                   <div
                     className="zoom-indicator"
@@ -178,7 +179,13 @@ exports[`Frontend.Resource.Detail component renders correctly 1`] = `
               className="resource-tag-list"
               onClick={[Function]}
               onMouseOver={[Function]}
+              role="presentation"
             >
+              <span
+                className="screen-reader-text"
+              >
+                Tags list
+              </span>
               <ul>
                 <li>
                   <a
@@ -279,7 +286,13 @@ exports[`Frontend.Resource.Detail component renders correctly 1`] = `
               className="resource-tag-list"
               onClick={[Function]}
               onMouseOver={[Function]}
+              role="presentation"
             >
+              <span
+                className="screen-reader-text"
+              >
+                Tags list
+              </span>
               <ul>
                 <li>
                   <a

--- a/client/src/components/frontend/Resource/__tests__/__snapshots__/Hero-test.js.snap
+++ b/client/src/components/frontend/Resource/__tests__/__snapshots__/Hero-test.js.snap
@@ -18,6 +18,7 @@ exports[`Frontend.Resource.Hero component renders correctly 1`] = `
           <div
             className="resource-preview-wrapper"
             onClick={[Function]}
+            role="button"
           >
             <div
               className="zoom-indicator"

--- a/client/src/components/frontend/Resource/__tests__/__snapshots__/Meta-test.js.snap
+++ b/client/src/components/frontend/Resource/__tests__/__snapshots__/Meta-test.js.snap
@@ -66,7 +66,13 @@ exports[`Frontend.Resource.Meta component renders correctly 1`] = `
     className="resource-tag-list"
     onClick={[Function]}
     onMouseOver={[Function]}
+    role="presentation"
   >
+    <span
+      className="screen-reader-text"
+    >
+      Tags list
+    </span>
     <ul>
       <li>
         <a

--- a/client/src/components/frontend/ResourceCollection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/components/frontend/ResourceCollection/__tests__/__snapshots__/Detail-test.js.snap
@@ -90,6 +90,7 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
                   <div
                     className="resource-preview-wrapper"
                     onClick={[Function]}
+                    role="button"
                   >
                     <div
                       className="zoom-indicator"
@@ -120,7 +121,6 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
       >
         <div
           className="slide-caption"
-          onClick={[Function]}
         >
           <header>
             <h2
@@ -411,10 +411,12 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
               <div
                 className="resource-preview-wrapper"
                 onClick={[Function]}
+                role="button"
               >
                 <div
                   className="resource-link"
                   onClick={[Function]}
+                  role="link"
                 >
                   <div
                     className="icon-thumbnail-primary "
@@ -472,6 +474,7 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
               onClick={[Function]}
               onMouseOut={[Function]}
               onMouseOver={[Function]}
+              role="link"
             >
               <div>
                 <header
@@ -508,7 +511,13 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
                 className="resource-tag-list"
                 onClick={[Function]}
                 onMouseOver={[Function]}
+                role="presentation"
               >
+                <span
+                  className="screen-reader-text"
+                >
+                  Tags list
+                </span>
                 <ul>
                   <li>
                     <a

--- a/client/src/components/frontend/ResourceList/Slide/Caption.js
+++ b/client/src/components/frontend/ResourceList/Slide/Caption.js
@@ -156,7 +156,7 @@ export default class ResourceListSlideCaption extends Component {
     };
 
     return (
-      <div className="slide-caption" onClick={this.handleReadMore}>
+      <div className="slide-caption">
         <header>
           <h2
             className="resource-title"

--- a/client/src/components/frontend/ResourceList/Slide/__tests__/__snapshots__/Caption-test.js.snap
+++ b/client/src/components/frontend/ResourceList/Slide/__tests__/__snapshots__/Caption-test.js.snap
@@ -3,7 +3,6 @@
 exports[`Frontend.ResourceList.Slide.Caption component renders correctly 1`] = `
 <div
   className="slide-caption"
-  onClick={[Function]}
 >
   <header>
     <h2

--- a/client/src/components/frontend/ResourceList/Slide/__tests__/__snapshots__/SlideImage-test.js.snap
+++ b/client/src/components/frontend/ResourceList/Slide/__tests__/__snapshots__/SlideImage-test.js.snap
@@ -9,6 +9,7 @@ exports[`Frontend.ResourceList.Slide.SlideImage component renders correctly 1`] 
     <div
       className="resource-preview-wrapper"
       onClick={[Function]}
+      role="button"
     >
       <div
         className="zoom-indicator"

--- a/client/src/components/frontend/ResourceList/__tests__/__snapshots__/Cards-test.js.snap
+++ b/client/src/components/frontend/ResourceList/__tests__/__snapshots__/Cards-test.js.snap
@@ -33,10 +33,12 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
           <div
             className="resource-preview-wrapper"
             onClick={[Function]}
+            role="button"
           >
             <div
               className="resource-link"
               onClick={[Function]}
+              role="link"
             >
               <div
                 className="icon-thumbnail-primary "
@@ -94,6 +96,7 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
           onClick={[Function]}
           onMouseOut={[Function]}
           onMouseOver={[Function]}
+          role="link"
         >
           <div>
             <header
@@ -130,7 +133,13 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
             className="resource-tag-list"
             onClick={[Function]}
             onMouseOver={[Function]}
+            role="presentation"
           >
+            <span
+              className="screen-reader-text"
+            >
+              Tags list
+            </span>
             <ul>
               <li>
                 <a
@@ -173,10 +182,12 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
           <div
             className="resource-preview-wrapper"
             onClick={[Function]}
+            role="button"
           >
             <div
               className="resource-link"
               onClick={[Function]}
+              role="link"
             >
               <div
                 className="icon-thumbnail-primary "
@@ -234,6 +245,7 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
           onClick={[Function]}
           onMouseOut={[Function]}
           onMouseOver={[Function]}
+          role="link"
         >
           <div>
             <header
@@ -270,7 +282,13 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
             className="resource-tag-list"
             onClick={[Function]}
             onMouseOver={[Function]}
+            role="presentation"
           >
+            <span
+              className="screen-reader-text"
+            >
+              Tags list
+            </span>
             <ul>
               <li>
                 <a

--- a/client/src/components/frontend/ResourceList/__tests__/__snapshots__/Slideshow-test.js.snap
+++ b/client/src/components/frontend/ResourceList/__tests__/__snapshots__/Slideshow-test.js.snap
@@ -26,6 +26,7 @@ exports[`Frontend.ResourceList.Slideshow Component renders correctly 1`] = `
                 <div
                   className="resource-preview-wrapper"
                   onClick={[Function]}
+                  role="button"
                 >
                   <div
                     className="zoom-indicator"
@@ -56,7 +57,6 @@ exports[`Frontend.ResourceList.Slideshow Component renders correctly 1`] = `
     >
       <div
         className="slide-caption"
-        onClick={[Function]}
       >
         <header>
           <h2

--- a/client/src/components/frontend/Utility/Toggle.js
+++ b/client/src/components/frontend/Utility/Toggle.js
@@ -43,7 +43,7 @@ export default class Toggle extends Component {
 
     return (
       <div className="button-switch-primary">
-        <div className="wrapper" onClick={this.handleClick}>
+        <div className="wrapper" onClick={this.handleClick} role="button">
           {options.map(option => {
             return this.renderOption(option);
           })}

--- a/client/src/components/frontend/Utility/__tests__/__snapshots__/Toggle-test.js.snap
+++ b/client/src/components/frontend/Utility/__tests__/__snapshots__/Toggle-test.js.snap
@@ -7,6 +7,7 @@ exports[`Frontend.Utility.Toggle component renders correctly 1`] = `
   <div
     className="wrapper"
     onClick={[Function]}
+    role="button"
   >
     <div
       className="button selected"

--- a/client/src/components/global/Drawer/Wrapper.js
+++ b/client/src/components/global/Drawer/Wrapper.js
@@ -144,7 +144,11 @@ export default class DrawerWrapper extends PureComponent {
           {props.title ? props.title : null}
         </div>
         {hasClose ? (
-          <div onClick={this.handleLeaveEvent} className="close-button-primary">
+          <div
+            onClick={this.handleLeaveEvent}
+            role="button"
+            className="close-button-primary"
+          >
             <span className="close-text">Close</span>
             <i className="manicon manicon-x" aria-hidden="true" />
           </div>
@@ -192,7 +196,11 @@ export default class DrawerWrapper extends PureComponent {
         <div>
           <Utility.LockBodyScroll>
             <div className={this.props.identifier}>
-              <div className="drawer-overlay" onClick={this.handleLeaveEvent} />
+              <div
+                className="drawer-overlay"
+                onClick={this.handleLeaveEvent}
+                role="button"
+              />
               {this.renderDrawer()}
             </div>
           </Utility.LockBodyScroll>

--- a/client/src/components/global/Drawer/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/components/global/Drawer/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -16,7 +16,7 @@ exports[`Backend.Drawer.Wrapper Component renders correctly 1`] = `
                         <div className=\\"drawer-title\\">
                           wrapper
                         </div>
-                        <div onClick={[Function]} className=\\"close-button-primary\\">
+                        <div onClick={[Function]} role=\\"button\\" className=\\"close-button-primary\\">
                           <span className=\\"close-text\\">
                             Close
                           </span>

--- a/client/src/components/global/SignInUp/UpdateForm.js
+++ b/client/src/components/global/SignInUp/UpdateForm.js
@@ -233,6 +233,7 @@ class UpdateFormContainer extends Component {
                     {this.hasAvatar() ? (
                       <i
                         onClick={this.handleRemoveAvatar}
+                        role="button"
                         style={{
                           position: "absolute",
                           top: 0,

--- a/client/src/components/reader/Annotation/Popup/Secondary/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/components/reader/Annotation/Popup/Secondary/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -5,6 +5,7 @@ exports[`Reader.Annotation.Popup.Secondary.Wrapper Component renders correctly w
   className="annotation-popup"
   onClick={[Function]}
   onMouseDown={[Function]}
+  role="presentation"
   style={
     Object {
       "bottom": "auto",

--- a/client/src/components/reader/Annotation/Popup/Wrapper.js
+++ b/client/src/components/reader/Annotation/Popup/Wrapper.js
@@ -236,6 +236,7 @@ export default class AnnotationPopup extends Component {
       <div
         onMouseDown={this.stopPropagation}
         onClick={this.stopPropagation}
+        role="presentation"
         className={popupClass}
         ref={a => {
           this.popupEl = a;

--- a/client/src/components/reader/Annotation/Popup/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/components/reader/Annotation/Popup/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -5,6 +5,7 @@ exports[`Reader.Annotation.Popup.Wrapper Component renders correctly when not lo
   className="annotation-popup"
   onClick={[Function]}
   onMouseDown={[Function]}
+  role="presentation"
   style={
     Object {
       "bottom": "auto",

--- a/client/src/components/reader/ControlMenu/AppearanceMenuButton.js
+++ b/client/src/components/reader/ControlMenu/AppearanceMenuButton.js
@@ -28,7 +28,7 @@ export default class AppearanceMenuButton extends Component {
       >
         <i className="manicon manicon-aa" aria-hidden="true" />
         <span className="screen-reader-text">
-          {"Click to open reader appearance menu"}
+          {"Open reader appearance menu"}
         </span>
       </button>
     );

--- a/client/src/components/reader/ControlMenu/NotesButton.js
+++ b/client/src/components/reader/ControlMenu/NotesButton.js
@@ -27,9 +27,7 @@ export default class NotesButton extends PureComponent {
         data-id="toggle-notes"
       >
         <i className="manicon manicon-notepad" aria-hidden="true" />
-        <span className="screen-reader-text">
-          Click to hide or show user annotations overlay
-        </span>
+        <span className="screen-reader-text">Open the notes menu</span>
       </button>
     );
   }

--- a/client/src/components/reader/ControlMenu/VisibilityMenuButton.js
+++ b/client/src/components/reader/ControlMenu/VisibilityMenuButton.js
@@ -28,9 +28,7 @@ export default class VisibilityMenuButton extends PureComponent {
         data-id="toggle-visibility"
       >
         <i className="manicon manicon-eye-outline" aria-hidden="true" />
-        <span className="screen-reader-text">
-          Click to hide or show annotation/resources in the reader
-        </span>
+        <span className="screen-reader-text">Open the visibility menu</span>
       </button>
     );
   }

--- a/client/src/components/reader/ControlMenu/__tests__/__snapshots__/AppearanceMenuButton-test.js.snap
+++ b/client/src/components/reader/ControlMenu/__tests__/__snapshots__/AppearanceMenuButton-test.js.snap
@@ -13,7 +13,7 @@ exports[`Reader.ControlMenu.AppearanceMenuButton Component renders correctly 1`]
   <span
     className="screen-reader-text"
   >
-    Click to open reader appearance menu
+    Open reader appearance menu
   </span>
 </button>
 `;

--- a/client/src/components/reader/ControlMenu/__tests__/__snapshots__/NotesButton-test.js.snap
+++ b/client/src/components/reader/ControlMenu/__tests__/__snapshots__/NotesButton-test.js.snap
@@ -13,7 +13,7 @@ exports[`Reader.ControlMenu.NotesButton Component renders correctly 1`] = `
   <span
     className="screen-reader-text"
   >
-    Click to hide or show user annotations overlay
+    Open the notes menu
   </span>
 </button>
 `;

--- a/client/src/components/reader/ControlMenu/__tests__/__snapshots__/VisibilityMenuButton-test.js.snap
+++ b/client/src/components/reader/ControlMenu/__tests__/__snapshots__/VisibilityMenuButton-test.js.snap
@@ -13,7 +13,7 @@ exports[`Reader.ControlMenu.VisibilityMenuButton Component renders correctly 1`]
   <span
     className="screen-reader-text"
   >
-    Click to hide or show annotation/resources in the reader
+    Open the visibility menu
   </span>
 </button>
 `;

--- a/client/src/components/reader/Notation/Collection/PickerListItem.js
+++ b/client/src/components/reader/Notation/Collection/PickerListItem.js
@@ -25,7 +25,7 @@ export default class CollectionPickerListItem extends PureComponent {
 
     return (
       <li>
-        <a href="#" onClick={this.handleClick}>
+        <span role="button" className="fake-link" onClick={this.handleClick}>
           <header>
             <figure className="cover">
               <Resourceish.Thumbnail
@@ -46,7 +46,7 @@ export default class CollectionPickerListItem extends PureComponent {
               </h3>
             </div>
           </header>
-        </a>
+        </span>
       </li>
     );
   }

--- a/client/src/components/reader/Notation/Collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/components/reader/Notation/Collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -77,7 +77,6 @@ exports[`Reader.Notation.Collection.Detail component renders correctly 1`] = `
       >
         <div
           className="slide-caption"
-          onClick={[Function]}
         >
           <header>
             <h2

--- a/client/src/components/reader/Notation/Collection/__tests__/__snapshots__/PickerListItem-test.js.snap
+++ b/client/src/components/reader/Notation/Collection/__tests__/__snapshots__/PickerListItem-test.js.snap
@@ -2,9 +2,10 @@
 
 exports[`Reader.Notation.Collection.PickerListItem component renders correctly 1`] = `
 <li>
-  <a
-    href="#"
+  <span
+    className="fake-link"
     onClick={[Function]}
+    role="button"
   >
     <header>
       <figure
@@ -66,6 +67,6 @@ exports[`Reader.Notation.Collection.PickerListItem component renders correctly 1
         </h3>
       </div>
     </header>
-  </a>
+  </span>
 </li>
 `;

--- a/client/src/components/reader/Notation/Marker.js
+++ b/client/src/components/reader/Notation/Marker.js
@@ -72,6 +72,7 @@ class NotationMarker extends Component {
               key={annotation.id}
               title={id}
               data-annotation-notation={id}
+              role="presentation"
               className={markerClassNames}
               onClick={event => {
                 this.handleClick(event, annotation);

--- a/client/src/components/reader/Notation/Resource/PickerListItem.js
+++ b/client/src/components/reader/Notation/Resource/PickerListItem.js
@@ -23,7 +23,7 @@ export default class ResourcePickerListItem extends PureComponent {
     const attr = resource.attributes;
     return (
       <li>
-        <a href="#" onClick={this.handleClick}>
+        <span role="button" className="fake-link" onClick={this.handleClick}>
           <header>
             <figure className="cover">
               <Resourceish.Thumbnail
@@ -47,7 +47,7 @@ export default class ResourcePickerListItem extends PureComponent {
               </h3>
             </div>
           </header>
-        </a>
+        </span>
       </li>
     );
   }

--- a/client/src/components/reader/Notation/Resource/__tests__/__snapshots__/PickerListItem-test.js.snap
+++ b/client/src/components/reader/Notation/Resource/__tests__/__snapshots__/PickerListItem-test.js.snap
@@ -2,9 +2,10 @@
 
 exports[`Reader.Notation.Resource.PickerListItem component renders correctly 1`] = `
 <li>
-  <a
-    href="#"
+  <span
+    className="fake-link"
     onClick={[Function]}
+    role="button"
   >
     <header>
       <figure
@@ -69,6 +70,6 @@ exports[`Reader.Notation.Resource.PickerListItem component renders correctly 1`]
         </h3>
       </div>
     </header>
-  </a>
+  </span>
 </li>
 `;

--- a/client/src/components/reader/Notation/__tests__/__snapshots__/Marker-test.js.snap
+++ b/client/src/components/reader/Notation/__tests__/__snapshots__/Marker-test.js.snap
@@ -8,6 +8,7 @@ exports[`Reader.Notation.Marker component renders correctly 1`] = `
     onClick={[Function]}
     onMouseLeave={[Function]}
     onMouseOver={[Function]}
+    role="presentation"
     title="1"
   >
     <i

--- a/client/src/components/reader/Notes/FilteredList.js
+++ b/client/src/components/reader/Notes/FilteredList.js
@@ -29,8 +29,10 @@ export default class FilteredList extends PureComponent {
   renderHeading() {
     return (
       <div className="drawer-bar">
-        <h2 className="drawer-title" onClick={this.props.handleSeeAllClick}>
-          Your Notes
+        <h2 className="drawer-title">
+          <div role="button" onClick={this.props.handleSeeAllClick}>
+            Your Notes
+          </div>
         </h2>
         {this.props.sortedAnnotations.length > 0 ? (
           <button

--- a/client/src/components/reader/Notes/Partial/Group.js
+++ b/client/src/components/reader/Notes/Partial/Group.js
@@ -110,9 +110,14 @@ export default class Group extends Component {
     });
     return (
       <li>
-        <div className={classes} onClick={this.handleClick}>
+        <div className={classes} onClick={this.handleClick} role="button">
           <i className={`manicon manicon-caret-down`} aria-hidden="true" />
           <label>{this.props.sectionName}</label>
+          {this.state.expanded ? (
+            <span className="screen-reader-text">Collapse Notes</span>
+          ) : (
+            <span className="screen-reader-text">Expand Notes</span>
+          )}
         </div>
         {this.renderGroupItems(this.props.annotations)}
       </li>

--- a/client/src/components/reader/Notes/Partial/GroupItem.js
+++ b/client/src/components/reader/Notes/Partial/GroupItem.js
@@ -41,12 +41,17 @@ export default class GroupItem extends Component {
       this.props.annotation.attributes.format
     );
     return (
+      /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
       <li className="item" onClick={this.handleVisitAnnotation}>
+        <span className="screen-reader-text">
+          {this.props.annotation.attributes.format}
+        </span>
         <i className={iconClasses} aria-hidden="true" />
         <span>
           {this.maybeTruncateText(this.props.annotation.attributes.subject)}
         </span>
       </li>
+      /* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
     );
   }
 }

--- a/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/Group-test.js.snap
+++ b/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/Group-test.js.snap
@@ -5,6 +5,7 @@ exports[`Reader.Notes.Partial.Group Component renders correctly 1`] = `
   <div
     className="item"
     onClick={[Function]}
+    role="button"
   >
     <i
       aria-hidden="true"
@@ -13,6 +14,11 @@ exports[`Reader.Notes.Partial.Group Component renders correctly 1`] = `
     <label>
       Test
     </label>
+    <span
+      className="screen-reader-text"
+    >
+      Expand Notes
+    </span>
   </div>
   <ul
     className=""
@@ -21,6 +27,9 @@ exports[`Reader.Notes.Partial.Group Component renders correctly 1`] = `
       className="item"
       onClick={[Function]}
     >
+      <span
+        className="screen-reader-text"
+      />
       <i
         aria-hidden="true"
         className="manicon manicon-null"
@@ -33,6 +42,9 @@ exports[`Reader.Notes.Partial.Group Component renders correctly 1`] = `
       className="item"
       onClick={[Function]}
     >
+      <span
+        className="screen-reader-text"
+      />
       <i
         aria-hidden="true"
         className="manicon manicon-null"

--- a/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/GroupItem-test.js.snap
+++ b/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/GroupItem-test.js.snap
@@ -5,6 +5,9 @@ exports[`Reader.Notes.Partial.GroupItem Component renders correctly 1`] = `
   className="item"
   onClick={[Function]}
 >
+  <span
+    className="screen-reader-text"
+  />
   <i
     aria-hidden="true"
     className="manicon manicon-null"

--- a/client/src/components/reader/Notes/__tests__/__snapshots__/FilteredList-test.js.snap
+++ b/client/src/components/reader/Notes/__tests__/__snapshots__/FilteredList-test.js.snap
@@ -7,9 +7,13 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
   >
     <h2
       className="drawer-title"
-      onClick={[MockFunction]}
     >
-      Your Notes
+      <div
+        onClick={[MockFunction]}
+        role="button"
+      >
+        Your Notes
+      </div>
     </h2>
     <button
       className="button-primary"
@@ -73,6 +77,7 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
         <div
           className="item"
           onClick={[Function]}
+          role="button"
         >
           <i
             aria-hidden="true"
@@ -81,6 +86,11 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
           <label>
             Test
           </label>
+          <span
+            className="screen-reader-text"
+          >
+            Expand Notes
+          </span>
         </div>
         <ul
           className=""
@@ -89,6 +99,9 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
             className="item"
             onClick={[Function]}
           >
+            <span
+              className="screen-reader-text"
+            />
             <i
               aria-hidden="true"
               className="manicon manicon-null"
@@ -101,6 +114,9 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
             className="item"
             onClick={[Function]}
           >
+            <span
+              className="screen-reader-text"
+            />
             <i
               aria-hidden="true"
               className="manicon manicon-null"

--- a/client/src/components/reader/TextTitles.js
+++ b/client/src/components/reader/TextTitles.js
@@ -43,10 +43,19 @@ export default class TextTitles extends Component {
     });
 
     return (
+      /* eslint-disable jsx-a11y/no-static-element-interactions */
       <header className={titleClass} onClick={this.handleTitleClick}>
-        <h3 className="text-title">{this.props.textTitle}</h3>
-        <h2 className="section-title">{this.props.sectionTitle}</h2>
+        <h3 className="screen-reader-text">
+          {`${this.props.textTitle} ${this.props.sectionTitle}`}
+        </h3>
+        <h3 className="text-title" aria-hidden="true">
+          {this.props.textTitle}
+        </h3>
+        <h2 className="section-title" aria-hidden="true">
+          {this.props.sectionTitle}
+        </h2>
       </header>
+      /* eslint-enable jsx-a11y/no-static-element-interactions */
     );
   }
 }

--- a/client/src/components/reader/__tests__/__snapshots__/FooterMenu-test.js.snap
+++ b/client/src/components/reader/__tests__/__snapshots__/FooterMenu-test.js.snap
@@ -24,7 +24,7 @@ exports[`Reader.FooterMenu Component renders correctly 1`] = `
             <span
               className="screen-reader-text"
             >
-              Click to hide or show user annotations overlay
+              Open the notes menu
             </span>
           </button>
         </li>
@@ -41,7 +41,7 @@ exports[`Reader.FooterMenu Component renders correctly 1`] = `
             <span
               className="screen-reader-text"
             >
-              Click to hide or show annotation/resources in the reader
+              Open the visibility menu
             </span>
           </button>
         </li>
@@ -58,7 +58,7 @@ exports[`Reader.FooterMenu Component renders correctly 1`] = `
             <span
               className="screen-reader-text"
             >
-              Click to open reader appearance menu
+              Open reader appearance menu
             </span>
           </button>
         </li>

--- a/client/src/components/reader/__tests__/__snapshots__/Header-test.js.snap
+++ b/client/src/components/reader/__tests__/__snapshots__/Header-test.js.snap
@@ -41,7 +41,7 @@ exports[`Reader.Header Component renders correctly 1`] = `
             <span
               className="screen-reader-text"
             >
-              Click to hide or show annotation/resources in the reader
+              Open the visibility menu
             </span>
           </button>
         </li>
@@ -58,7 +58,7 @@ exports[`Reader.Header Component renders correctly 1`] = `
             <span
               className="screen-reader-text"
             >
-              Click to open reader appearance menu
+              Open reader appearance menu
             </span>
           </button>
         </li>
@@ -456,7 +456,7 @@ exports[`Reader.Header Component renders correctly when no TOC or metadata 1`] =
             <span
               className="screen-reader-text"
             >
-              Click to hide or show annotation/resources in the reader
+              Open the visibility menu
             </span>
           </button>
         </li>
@@ -473,7 +473,7 @@ exports[`Reader.Header Component renders correctly when no TOC or metadata 1`] =
             <span
               className="screen-reader-text"
             >
-              Click to open reader appearance menu
+              Open reader appearance menu
             </span>
           </button>
         </li>

--- a/client/src/components/reader/__tests__/__snapshots__/TextTitles-test.js.snap
+++ b/client/src/components/reader/__tests__/__snapshots__/TextTitles-test.js.snap
@@ -6,11 +6,18 @@ exports[`Reader.TextTitles Component renders correctly 1`] = `
   onClick={[Function]}
 >
   <h3
+    className="screen-reader-text"
+  >
+    Rowan: Greatest Dog Chapter 1
+  </h3>
+  <h3
+    aria-hidden="true"
     className="text-title"
   >
     Rowan: Greatest Dog
   </h3>
   <h2
+    aria-hidden="true"
     className="section-title"
   >
     Chapter 1

--- a/client/src/containers/Manifold.js
+++ b/client/src/containers/Manifold.js
@@ -183,7 +183,11 @@ class ManifoldContainer extends PureComponent {
     );
 
     return (
-      <div onClick={this.handleGlobalClick} className="global-container">
+      <div
+        onClick={this.handleGlobalClick}
+        role="presentation"
+        className="global-container"
+      >
         <div id="global-notification-container" />
         <div id="global-overlay-container" />
         {this.renderTypekit()}

--- a/client/src/containers/backend/Collection/Resources.js
+++ b/client/src/containers/backend/Collection/Resources.js
@@ -186,7 +186,22 @@ export class CollectionResourcesContainer extends Component {
             <div
               onClick={event => this.handleSelect(event, resource)}
               className={classes}
-            />
+              role="button"
+            >
+              {this.isInCollection(resource) ? (
+                <span className="screen-reader-text">
+                  {`Remove ${
+                    resource.attributes.titleFormatted
+                  } Resource from Collection`}
+                </span>
+              ) : (
+                <span className="screen-reader-text">
+                  {`Add ${
+                    resource.attributes.titleFormatted
+                  } Resource to Collection`}
+                </span>
+              )}
+            </div>
           </div>
         </div>
       </li>

--- a/client/src/containers/backend/Collection/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/containers/backend/Collection/__tests__/__snapshots__/Resources-test.js.snap
@@ -158,7 +158,14 @@ exports[`Backend Collection Resources Container renders correctly 1`] = `
                     <div
                       className="boolean-primary checked"
                       onClick={[Function]}
-                    />
+                      role="button"
+                    >
+                      <span
+                        className="screen-reader-text"
+                      >
+                        Remove Image Resource from Collection
+                      </span>
+                    </div>
                   </div>
                 </div>
               </li>
@@ -239,7 +246,14 @@ exports[`Backend Collection Resources Container renders correctly 1`] = `
                     <div
                       className="boolean-primary"
                       onClick={[Function]}
-                    />
+                      role="button"
+                    >
+                      <span
+                        className="screen-reader-text"
+                      >
+                        Add Image Resource to Collection
+                      </span>
+                    </div>
                   </div>
                 </div>
               </li>

--- a/client/src/containers/backend/Form/PredictiveInput.js
+++ b/client/src/containers/backend/Form/PredictiveInput.js
@@ -252,6 +252,7 @@ class PredictiveInput extends PureComponent {
                 highlighted: option.id === this.state.highlighted
               });
               return (
+                /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
                 <li
                   key={option.id}
                   className={listingClass}
@@ -264,6 +265,7 @@ class PredictiveInput extends PureComponent {
                 >
                   {this.props.label(option)}
                 </li>
+                /* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
               );
             })}
           </ul>

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/Edit-test.js.snap
@@ -53,7 +53,8 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
               className="form-input"
             >
               <label
-                className="above"
+                aria-hidden="true"
+                className="form-input-heading above"
               >
                 Can modify project?
               </label>
@@ -61,16 +62,25 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
                 className="toggle-indicator"
               >
                 <div
+                  aria-pressed={false}
                   className="boolean-primary"
                   onClick={[Function]}
-                />
+                  role="button"
+                >
+                  <span
+                    className="screen-reader-text"
+                  >
+                    Can modify project?
+                  </span>
+                </div>
               </div>
             </div>
             <div
               className="form-input"
             >
               <label
-                className="above"
+                aria-hidden="true"
+                className="form-input-heading above"
               >
                 Can modify resource metadata?
               </label>
@@ -78,16 +88,25 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
                 className="toggle-indicator"
               >
                 <div
+                  aria-pressed={false}
                   className="boolean-primary"
                   onClick={[Function]}
-                />
+                  role="button"
+                >
+                  <span
+                    className="screen-reader-text"
+                  >
+                    Can modify resource metadata?
+                  </span>
+                </div>
               </div>
             </div>
             <div
               className="form-input"
             >
               <label
-                className="above"
+                aria-hidden="true"
+                className="form-input-heading above"
               >
                 Is a project author?
               </label>
@@ -95,9 +114,17 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
                 className="toggle-indicator"
               >
                 <div
+                  aria-pressed={false}
                   className="boolean-primary"
                   onClick={[Function]}
-                />
+                  role="button"
+                >
+                  <span
+                    className="screen-reader-text"
+                  >
+                    Is a project author?
+                  </span>
+                </div>
               </div>
             </div>
           </div>

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/Form-test.js.snap
@@ -63,7 +63,8 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
             className="form-input"
           >
             <label
-              className="above"
+              aria-hidden="true"
+              className="form-input-heading above"
             >
               Can modify project?
             </label>
@@ -71,16 +72,25 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
               className="toggle-indicator"
             >
               <div
+                aria-pressed={false}
                 className="boolean-primary"
                 onClick={[Function]}
-              />
+                role="button"
+              >
+                <span
+                  className="screen-reader-text"
+                >
+                  Can modify project?
+                </span>
+              </div>
             </div>
           </div>
           <div
             className="form-input"
           >
             <label
-              className="above"
+              aria-hidden="true"
+              className="form-input-heading above"
             >
               Can modify resource metadata?
             </label>
@@ -88,16 +98,25 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
               className="toggle-indicator"
             >
               <div
+                aria-pressed={false}
                 className="boolean-primary"
                 onClick={[Function]}
-              />
+                role="button"
+              >
+                <span
+                  className="screen-reader-text"
+                >
+                  Can modify resource metadata?
+                </span>
+              </div>
             </div>
           </div>
           <div
             className="form-input"
           >
             <label
-              className="above"
+              aria-hidden="true"
+              className="form-input-heading above"
             >
               Is a project author?
             </label>
@@ -105,9 +124,17 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
               className="toggle-indicator"
             >
               <div
+                aria-pressed={false}
                 className="boolean-primary"
                 onClick={[Function]}
-              />
+                role="button"
+              >
+                <span
+                  className="screen-reader-text"
+                >
+                  Is a project author?
+                </span>
+              </div>
             </div>
           </div>
         </div>

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/New-test.js.snap
@@ -73,7 +73,8 @@ exports[`Backend Permission New Container renders correctly 1`] = `
               className="form-input"
             >
               <label
-                className="above"
+                aria-hidden="true"
+                className="form-input-heading above"
               >
                 Can modify project?
               </label>
@@ -81,16 +82,25 @@ exports[`Backend Permission New Container renders correctly 1`] = `
                 className="toggle-indicator"
               >
                 <div
+                  aria-pressed={false}
                   className="boolean-primary"
                   onClick={[Function]}
-                />
+                  role="button"
+                >
+                  <span
+                    className="screen-reader-text"
+                  >
+                    Can modify project?
+                  </span>
+                </div>
               </div>
             </div>
             <div
               className="form-input"
             >
               <label
-                className="above"
+                aria-hidden="true"
+                className="form-input-heading above"
               >
                 Can modify resource metadata?
               </label>
@@ -98,16 +108,25 @@ exports[`Backend Permission New Container renders correctly 1`] = `
                 className="toggle-indicator"
               >
                 <div
+                  aria-pressed={false}
                   className="boolean-primary"
                   onClick={[Function]}
-                />
+                  role="button"
+                >
+                  <span
+                    className="screen-reader-text"
+                  >
+                    Can modify resource metadata?
+                  </span>
+                </div>
               </div>
             </div>
             <div
               className="form-input"
             >
               <label
-                className="above"
+                aria-hidden="true"
+                className="form-input-heading above"
               >
                 Is a project author?
               </label>
@@ -115,9 +134,17 @@ exports[`Backend Permission New Container renders correctly 1`] = `
                 className="toggle-indicator"
               >
                 <div
+                  aria-pressed={false}
                   className="boolean-primary"
                   onClick={[Function]}
-                />
+                  role="button"
+                >
+                  <span
+                    className="screen-reader-text"
+                  >
+                    Is a project author?
+                  </span>
+                </div>
               </div>
             </div>
           </div>

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/Events-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/Events-test.js.snap
@@ -112,6 +112,7 @@ exports[`Backend Project Events Container renders correctly 1`] = `
                 className="utility"
                 data-id="destroy"
                 onClick={[Function]}
+                role="button"
               >
                 <i
                   aria-hidden="true"
@@ -159,6 +160,7 @@ exports[`Backend Project Events Container renders correctly 1`] = `
                 className="utility"
                 data-id="destroy"
                 onClick={[Function]}
+                role="button"
               >
                 <i
                   aria-hidden="true"

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/General-test.js.snap
@@ -89,12 +89,21 @@ exports[`Backend Project General Container renders correctly 1`] = `
             className="toggle-indicator"
           >
             <div
+              aria-pressed={false}
               className="boolean-primary"
               onClick={[Function]}
-            />
+              role="button"
+            >
+              <span
+                className="screen-reader-text"
+              >
+                Draft Mode
+              </span>
+            </div>
           </div>
           <label
-            className="below secondary"
+            aria-hidden="true"
+            className="form-input-heading below secondary"
           >
             Draft Mode
           </label>
@@ -106,12 +115,21 @@ exports[`Backend Project General Container renders correctly 1`] = `
             className="toggle-indicator"
           >
             <div
+              aria-pressed={false}
               className="boolean-primary"
               onClick={[Function]}
-            />
+              role="button"
+            >
+              <span
+                className="screen-reader-text"
+              >
+                Featured
+              </span>
+            </div>
           </div>
           <label
-            className="below secondary"
+            aria-hidden="true"
+            className="form-input-heading below secondary"
           >
             Featured
           </label>

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/ProjectPage-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/ProjectPage-test.js.snap
@@ -288,7 +288,8 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
         className="form-input"
       >
         <label
-          className="above"
+          aria-hidden="true"
+          className="form-input-heading above"
         >
           Hide Project Activity
         </label>
@@ -296,9 +297,17 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           className="toggle-indicator"
         >
           <div
+            aria-pressed={false}
             className="boolean-primary"
             onClick={[Function]}
-          />
+            role="button"
+          >
+            <span
+              className="screen-reader-text"
+            >
+              Hide Project Activity
+            </span>
+          </div>
         </div>
       </div>
       <div

--- a/client/src/containers/backend/Resource/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Resource/__tests__/__snapshots__/New-test.js.snap
@@ -169,11 +169,15 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                     </select>
                   </div>
                 </div>
-                <ul>
+                <ul
+                  role="radiogroup"
+                >
                   <li>
                     <div
+                      aria-checked={true}
                       className="button active"
                       onClick={[Function]}
+                      role="radio"
                     >
                       <figure>
                         <figcaption>
@@ -208,8 +212,10 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                   </li>
                   <li>
                     <div
+                      aria-checked={false}
                       className="button"
                       onClick={[Function]}
+                      role="radio"
                     >
                       <figure>
                         <figcaption>
@@ -239,8 +245,10 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                   </li>
                   <li>
                     <div
+                      aria-checked={false}
                       className="button"
                       onClick={[Function]}
+                      role="radio"
                     >
                       <figure>
                         <figcaption>
@@ -279,8 +287,10 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                   </li>
                   <li>
                     <div
+                      aria-checked={false}
                       className="button"
                       onClick={[Function]}
+                      role="radio"
                     >
                       <figure>
                         <figcaption>
@@ -307,8 +317,10 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                   </li>
                   <li>
                     <div
+                      aria-checked={false}
                       className="button"
                       onClick={[Function]}
+                      role="radio"
                     >
                       <figure>
                         <figcaption>
@@ -344,8 +356,10 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                   </li>
                   <li>
                     <div
+                      aria-checked={false}
                       className="button"
                       onClick={[Function]}
+                      role="radio"
                     >
                       <figure>
                         <figcaption>
@@ -375,8 +389,10 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                   </li>
                   <li>
                     <div
+                      aria-checked={false}
                       className="button"
                       onClick={[Function]}
+                      role="radio"
                     >
                       <figure>
                         <figcaption>
@@ -418,8 +434,10 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                   </li>
                   <li>
                     <div
+                      aria-checked={false}
                       className="button"
                       onClick={[Function]}
+                      role="radio"
                     >
                       <figure>
                         <figcaption>
@@ -446,8 +464,10 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                   </li>
                   <li>
                     <div
+                      aria-checked={false}
                       className="button"
                       onClick={[Function]}
+                      role="radio"
                     >
                       <figure>
                         <figcaption>
@@ -477,8 +497,10 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                   </li>
                   <li>
                     <div
+                      aria-checked={false}
                       className="button"
                       onClick={[Function]}
+                      role="radio"
                     >
                       <figure>
                         <figcaption>

--- a/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/Edit-test.js.snap
@@ -117,7 +117,8 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
           className="form-input"
         >
           <label
-            className="above"
+            aria-hidden="true"
+            className="form-input-heading above"
           >
             Active
           </label>
@@ -125,9 +126,17 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
             className="toggle-indicator"
           >
             <div
+              aria-pressed={true}
               className="boolean-primary checked"
               onClick={[Function]}
-            />
+              role="button"
+            >
+              <span
+                className="screen-reader-text"
+              >
+                Active
+              </span>
+            </div>
           </div>
         </div>
         <div

--- a/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/New-test.js.snap
@@ -85,7 +85,8 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
         className="form-input"
       >
         <label
-          className="above"
+          aria-hidden="true"
+          className="form-input-heading above"
         >
           Active
         </label>
@@ -93,9 +94,17 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
           className="toggle-indicator"
         >
           <div
+            aria-pressed={true}
             className="boolean-primary checked"
             onClick={[Function]}
-          />
+            role="button"
+          >
+            <span
+              className="screen-reader-text"
+            >
+              Active
+            </span>
+          </div>
         </div>
       </div>
       <div

--- a/client/src/containers/backend/__tests__/__snapshots__/Backend-test.js.snap
+++ b/client/src/containers/backend/__tests__/__snapshots__/Backend-test.js.snap
@@ -156,9 +156,9 @@ exports[`Backend Backend Container renders correctly 1`] = `
                                   <li>
                                     <ul className=\\"footer-nav\\">
                                       <li>
-                                        <a onClick={[Function]} href=\\"#\\">
+                                        <span className=\\"fake-link\\" role=\\"button\\" onClick={[Function]}>
                                           Log Out
-                                        </a>
+                                        </span>
                                       </li>
                                       <li>
                                         <Link to=\\"/\\" replace={false}>

--- a/client/src/containers/frontend/__tests__/__snapshots__/CollectionDetail-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/CollectionDetail-test.js.snap
@@ -109,6 +109,7 @@ exports[`Frontend CollectionDetail Container renders correctly 1`] = `
                     <div
                       className="resource-preview-wrapper"
                       onClick={[Function]}
+                      role="button"
                     >
                       <div
                         className="zoom-indicator"
@@ -139,7 +140,6 @@ exports[`Frontend CollectionDetail Container renders correctly 1`] = `
         >
           <div
             className="slide-caption"
-            onClick={[Function]}
           >
             <header>
               <h2
@@ -441,10 +441,12 @@ exports[`Frontend CollectionDetail Container renders correctly 1`] = `
                 <div
                   className="resource-preview-wrapper"
                   onClick={[Function]}
+                  role="button"
                 >
                   <div
                     className="resource-link"
                     onClick={[Function]}
+                    role="link"
                   >
                     <div
                       className="icon-thumbnail-primary "
@@ -502,6 +504,7 @@ exports[`Frontend CollectionDetail Container renders correctly 1`] = `
                 onClick={[Function]}
                 onMouseOut={[Function]}
                 onMouseOver={[Function]}
+                role="link"
               >
                 <div>
                   <header
@@ -538,7 +541,13 @@ exports[`Frontend CollectionDetail Container renders correctly 1`] = `
                   className="resource-tag-list"
                   onClick={[Function]}
                   onMouseOver={[Function]}
+                  role="presentation"
                 >
+                  <span
+                    className="screen-reader-text"
+                  >
+                    Tags list
+                  </span>
                   <ul>
                     <li>
                       <a

--- a/client/src/containers/frontend/__tests__/__snapshots__/Frontend-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/Frontend-test.js.snap
@@ -211,12 +211,13 @@ exports[`Frontend Frontend Container renders correctly 1`] = `
                     className="footer-nav"
                   >
                     <li>
-                      <a
-                        href="#"
+                      <span
+                        className="fake-link"
                         onClick={[Function]}
+                        role="button"
                       >
                         Log Out
-                      </a>
+                      </span>
                     </li>
                     <li>
                       <a

--- a/client/src/containers/frontend/__tests__/__snapshots__/ProjectResources-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/ProjectResources-test.js.snap
@@ -184,10 +184,12 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
                 <div
                   className="resource-preview-wrapper"
                   onClick={[Function]}
+                  role="button"
                 >
                   <div
                     className="resource-link"
                     onClick={[Function]}
+                    role="link"
                   >
                     <div
                       className="icon-thumbnail-primary "
@@ -245,6 +247,7 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
                 onClick={[Function]}
                 onMouseOut={[Function]}
                 onMouseOver={[Function]}
+                role="link"
               >
                 <div>
                   <header
@@ -281,7 +284,13 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
                   className="resource-tag-list"
                   onClick={[Function]}
                   onMouseOver={[Function]}
+                  role="presentation"
                 >
+                  <span
+                    className="screen-reader-text"
+                  >
+                    Tags list
+                  </span>
                   <ul>
                     <li>
                       <a

--- a/client/src/containers/frontend/__tests__/__snapshots__/ResourceDetail-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/ResourceDetail-test.js.snap
@@ -67,6 +67,7 @@ exports[`Frontend ResourceDetail Container renders correctly 1`] = `
                   <div
                     className="resource-preview-wrapper"
                     onClick={[Function]}
+                    role="button"
                   >
                     <div
                       className="zoom-indicator"
@@ -197,7 +198,13 @@ exports[`Frontend ResourceDetail Container renders correctly 1`] = `
                 className="resource-tag-list"
                 onClick={[Function]}
                 onMouseOver={[Function]}
+                role="presentation"
               >
+                <span
+                  className="screen-reader-text"
+                >
+                  Tags list
+                </span>
                 <ul>
                   <li>
                     <a
@@ -298,7 +305,13 @@ exports[`Frontend ResourceDetail Container renders correctly 1`] = `
                 className="resource-tag-list"
                 onClick={[Function]}
                 onMouseOver={[Function]}
+                role="presentation"
               >
+                <span
+                  className="screen-reader-text"
+                >
+                  Tags list
+                </span>
                 <ul>
                   <li>
                     <a

--- a/client/src/containers/reader/Annotation/Annotatable.js
+++ b/client/src/containers/reader/Annotation/Annotatable.js
@@ -655,6 +655,7 @@ class Annotatable extends Component {
     // find a work-around, we're stuck with it. The following line disables the lint
     // warning around this tabindex.
     /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+    /* eslint-disable jsx-a11y/no-static-element-interactions */
     return (
       <div
         className="no-focus-outline"
@@ -706,6 +707,7 @@ class Annotatable extends Component {
         ) : null}
       </div>
     );
+    /* eslint-enable jsx-a11y/no-static-element-interactions */
     /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
   }
 }

--- a/client/src/containers/reader/Annotation/__tests__/__snapshots__/Annotatable-test.js.snap
+++ b/client/src/containers/reader/Annotation/__tests__/__snapshots__/Annotatable-test.js.snap
@@ -17,6 +17,7 @@ exports[`Reader Annotation Annotatable Container renders correctly 1`] = `
     className="annotation-popup"
     onClick={[Function]}
     onMouseDown={[Function]}
+    role="presentation"
     style={
       Object {
         "bottom": "auto",

--- a/client/src/containers/reader/Notation/Collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/containers/reader/Notation/Collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -103,7 +103,6 @@ exports[`Reader Notation Collection Detail Container renders correctly 1`] = `
               >
                 <div
                   className="slide-caption"
-                  onClick={[Function]}
                 >
                   <header>
                     <h2

--- a/client/src/containers/reader/Notation/__tests__/__snapshots__/Picker-test.js.snap
+++ b/client/src/containers/reader/Notation/__tests__/__snapshots__/Picker-test.js.snap
@@ -14,6 +14,7 @@ exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
       <div
         className="wrapper"
         onClick={[Function]}
+        role="button"
       >
         <div
           className="button selected"
@@ -92,9 +93,10 @@ exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
           <section>
             <ul>
               <li>
-                <a
-                  href="#"
+                <span
+                  className="fake-link"
                   onClick={[Function]}
+                  role="button"
                 >
                   <header>
                     <figure
@@ -159,12 +161,13 @@ exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
                       </h3>
                     </div>
                   </header>
-                </a>
+                </span>
               </li>
               <li>
-                <a
-                  href="#"
+                <span
+                  className="fake-link"
                   onClick={[Function]}
+                  role="button"
                 >
                   <header>
                     <figure
@@ -229,7 +232,7 @@ exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
                       </h3>
                     </div>
                   </header>
-                </a>
+                </span>
               </li>
             </ul>
           </section>

--- a/client/src/containers/reader/__tests__/__snapshots__/Reader-test.js.snap
+++ b/client/src/containers/reader/__tests__/__snapshots__/Reader-test.js.snap
@@ -33,11 +33,18 @@ exports[`Reader Reader Container renders correctly 1`] = `
           onClick={[Function]}
         >
           <h3
+            className="screen-reader-text"
+          >
+            Ain't No Thang Title Page
+          </h3>
+          <h3
+            aria-hidden="true"
             className="text-title"
           >
             Ain't No Thang
           </h3>
           <h2
+            aria-hidden="true"
             className="section-title"
           >
             Title Page
@@ -60,7 +67,7 @@ exports[`Reader Reader Container renders correctly 1`] = `
                 <span
                   className="screen-reader-text"
                 >
-                  Click to hide or show annotation/resources in the reader
+                  Open the visibility menu
                 </span>
               </button>
             </li>
@@ -77,7 +84,7 @@ exports[`Reader Reader Container renders correctly 1`] = `
                 <span
                   className="screen-reader-text"
                 >
-                  Click to open reader appearance menu
+                  Open reader appearance menu
                 </span>
               </button>
             </li>
@@ -503,7 +510,7 @@ exports[`Reader Reader Container renders correctly 1`] = `
               <span
                 className="screen-reader-text"
               >
-                Click to hide or show user annotations overlay
+                Open the notes menu
               </span>
             </button>
           </li>
@@ -520,7 +527,7 @@ exports[`Reader Reader Container renders correctly 1`] = `
               <span
                 className="screen-reader-text"
               >
-                Click to hide or show annotation/resources in the reader
+                Open the visibility menu
               </span>
             </button>
           </li>
@@ -537,7 +544,7 @@ exports[`Reader Reader Container renders correctly 1`] = `
               <span
                 className="screen-reader-text"
               >
-                Click to open reader appearance menu
+                Open reader appearance menu
               </span>
             </button>
           </li>

--- a/client/src/containers/reader/__tests__/__snapshots__/Section-test.js.snap
+++ b/client/src/containers/reader/__tests__/__snapshots__/Section-test.js.snap
@@ -37,6 +37,7 @@ exports[`Reader Section Container renders correctly 1`] = `
           className="annotation-popup"
           onClick={[Function]}
           onMouseDown={[Function]}
+          role="presentation"
           style={
             Object {
               "bottom": "auto",

--- a/client/src/theme/Components/backend/_vertical-list.scss
+++ b/client/src/theme/Components/backend/_vertical-list.scss
@@ -19,7 +19,7 @@
       padding-bottom: 8px;
     }
 
-    a {
+    a, .fake-link {
       padding: 10px 0 17px;
     }
   }
@@ -103,7 +103,7 @@
         border-color: $neutral100;
         box-shadow: -21px 0 0 $neutral100, 21px 0 0 $neutral100;
 
-        a {
+        a, .fake-link {
           color: $accentPrimary;
         }
 
@@ -114,7 +114,7 @@
     }
 
     // Use .list-item on li if the items don't link
-    a {
+    a, .fake-link {
       display: flex;
       flex-direction: column;
       justify-content: space-between;

--- a/client/src/theme/Components/browse/layout/_footer-browse.scss
+++ b/client/src/theme/Components/browse/layout/_footer-browse.scss
@@ -78,7 +78,7 @@
       @include listUnstyled;
     }
 
-    a {
+    a, .fake-link {
       @include templateHead;
       display: inline-block;
       font-size: 17px;

--- a/client/src/theme/Components/browse/resource/_audio-player.scss
+++ b/client/src/theme/Components/browse/resource/_audio-player.scss
@@ -8,26 +8,31 @@
     position: absolute;
     top: 0;
     left: 0;
+    z-index: 50;
     width: 100%;
     height: 100%;
-    z-index: 50;
     cursor: pointer;
     background: transparentize($neutralBlack, 0.5);
 
-    button {
+    .play-button-indicator {
       position: absolute;
       top: calc(50% - 35px);
       left: calc(50% - 35px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
       width: 70px;
       height: 70px;
+      padding: 1px 7px 2px;
+      color: $neutralWhite;
+      text-align: center;
+      background-color: $accentPrimary;
       border: 0;
       border-radius: 50%;
-      background-color: $accentPrimary;
-      color: $neutralWhite;
 
       .manicon {
-        font-size: 32px;
         margin-left: 4px;
+        font-size: 32px;
       }
     }
   }

--- a/client/src/theme/STACSS/_appearance.scss
+++ b/client/src/theme/STACSS/_appearance.scss
@@ -28,6 +28,7 @@
 // --------------------------------------------------------
 .fake-link {
   text-decoration: underline;
+  cursor: pointer;
 }
 
 .invisible {
@@ -79,6 +80,7 @@
 // --------------------------------------------------------
 @mixin buttonUnstyled {
   padding: 0;
+  cursor: pointer;
   background: transparent;
   border: 0;
   // iOS applies this by default,
@@ -89,6 +91,7 @@
 }
 
 @mixin buttonRounded {
+  cursor: pointer;
   border-radius: 7px;
 }
 


### PR DESCRIPTION
Resolves #1079

Interactive elements have the correct roles (either semantically or through a role attribute) even/especially if the element has no default role.

This comes with some caveats.  In several chunks you'll see `/* eslint-disable jsx-a11y/no-static-element-interactions */` or `/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */`.  This indicates an technically interactive element (in that it is an element that responds to a user interaction) that is either 1) behaving as a catch to stop an event from bubbling up, 2) that is a catch all for some higher order behavior (most notably hiding all elements that were revealed using javascript), or 3) that represents a non-applicable or non-tenable interaction when using a screen reader.  I propose addressing these elements' interactivity on a case by case basis in separate issues.  These special cases are outlined below:

1)
- `client/src/components/reader/Annotation/Popup/Wrapper.js`
- `client/src/components/frontend/Resource/TagList.js`

2)
- `client/src/containers/Manifold.js`

3)
- `client/src/components/reader/Notation/Marker.js`
- `client/src/components/reader/TextTiles.js`
- `client/src/containers/reader/Annotation/Annotatable.js`
- `client/src/components/reader/Notes/FilteredList.js`
- `client/src/components/reader/Notes/Partial/GroupItem.js`
- `client/src/containers/backend/Form/PredictiveInput.js`