### PR TITLE
[F] Generate TOC for single-page Google Doc

### DIFF
--- a/api/app/services/ingestor/preprocessor/html/header_ids.rb
+++ b/api/app/services/ingestor/preprocessor/html/header_ids.rb
@@ -1,0 +1,26 @@
+module Ingestor
+  module Preprocessor
+    module HTML
+      class HeaderIds
+        attr_accessor :document, :header_nodes
+
+        def init_state(markup)
+          @document = Nokogiri(markup)
+          @header_nodes = document.xpath("//h1 | //h2 | //h3 | //h4 | //h5 | //h6")
+        end
+
+        def run(markup)
+          init_state(markup)
+
+          header_nodes.each do |node|
+            next if node["id"]
+            node["id"] = Digest::MD5.hexdigest(node.name + node.text)
+          end
+
+          document.to_s
+        end
+
+      end
+    end
+  end
+end

--- a/api/app/services/ingestor/preprocessor/html/processor.rb
+++ b/api/app/services/ingestor/preprocessor/html/processor.rb
@@ -8,6 +8,7 @@ module Ingestor
           File.open(source_path, "r") do |file|
             contents = file.read
             # contents = Noop.new.run(contents)
+            contents = HeaderIds.new.run(contents)
             contents = InlineStyles.new.run(contents)
           end
           File.open(source_path, "w+") do |file|

--- a/api/app/services/ingestor/strategy/google_doc/builder.rb
+++ b/api/app/services/ingestor/strategy/google_doc/builder.rb
@@ -57,7 +57,7 @@ module Ingestor
         end
 
         def structure_inspector
-          @inspector
+          Inspector::Structure.new(@inspector)
         end
 
         def start_section_inspector

--- a/api/app/services/ingestor/strategy/google_doc/inspector/google_doc.rb
+++ b/api/app/services/ingestor/strategy/google_doc/inspector/google_doc.rb
@@ -11,13 +11,6 @@ module Ingestor
             @pointer = pointer
           end
 
-          def empty_collection(*_args)
-            []
-          end
-          alias toc empty_collection
-          alias page_list empty_collection
-          alias landmarks empty_collection
-
           def unique_id
             Digest::MD5.hexdigest(ingestion.source_url)
           end
@@ -28,12 +21,6 @@ module Ingestor
 
           def title
             @pointer.title
-          end
-
-          # For google doc, we don't know what the HTML file
-          # will be called, so we just get the first (only) one.
-          def index_path
-            ingestion.rel_path_for_file "*", %w(htm html)
           end
         end
       end

--- a/api/app/services/ingestor/strategy/google_doc/inspector/structure.rb
+++ b/api/app/services/ingestor/strategy/google_doc/inspector/structure.rb
@@ -1,0 +1,116 @@
+module Ingestor
+  module Strategy
+    module GoogleDoc
+      module Inspector
+        # Inspects Google Doc structures
+        class Structure < ::Ingestor::Inspector::StructureInspector
+
+          def initialize(google_doc_inspector)
+            @google_doc_inspector = google_doc_inspector
+            @ingestion = @google_doc_inspector.ingestion
+          end
+
+          def toc
+            build_toc_from_headers
+          end
+
+          def landmarks
+            []
+          end
+
+          def page_list
+            []
+          end
+
+          protected
+
+          # Store this as its own instance because we remove nodes
+          # from the copy as we go through it.
+          def body_parsed
+            @body_parsed ||= @google_doc_inspector.index_parsed
+          end
+
+          def build_toc_from_headers
+            entries = []
+            toc_selectors.each do |tag|
+              nodes = body_parsed.css(tag)
+              next if nodes.count.zero?
+              nodes.each do |node|
+                item = compose_and_traverse node, node == nodes.last
+                entries.push item if item.present?
+              end
+            end
+
+            entries
+          end
+
+          # Creates the toc entry for a node.  Recursively checks for
+          # nodes of the subsequent header level to create the children
+          # array.
+          def compose_and_traverse(node, last_of_kind = false)
+            return nil if node.text.blank?
+            item = make_structure_item(node)
+            return item unless toc_child_selector(node.name).present?
+
+            children = make_child_items node, last_of_kind
+            item[:children] = children if children.present?
+
+            item
+          end
+
+          def make_child_items(node, last_of_kind)
+            nodes = last_of_kind ? nodes_after(node) : nodes_between(node)
+            return [] unless nodes.present?
+            children = nodes.map { |child| compose_and_traverse child }.reject(&:nil?)
+            nodes.remove
+
+            children
+          end
+
+          def make_structure_item(node)
+            label = node.text.strip
+            source_path = @google_doc_inspector.index_path
+            anchor = node["id"]
+            {
+              label: label,
+              anchor: anchor,
+              source_path: source_path
+            }
+          end
+
+          private
+
+          def toc_selectors
+            %w(h1 h2 h3 h4 h5 h6)
+          end
+
+          def toc_child_selector(selector)
+            toc_selectors[toc_selectors.find_index(selector) + 1]
+          end
+
+          def node_selector_after(node, tag)
+            "//*[@id='#{node['id']}']/following::#{tag}"
+          end
+
+          def node_selector_before(node)
+            start = body_parsed.at_xpath node_selector_after(node, node.name)
+            return "//#{toc_child_selector(node.name)}" unless start.present?
+            "//*[@id='#{start['id']}']/preceding::#{toc_child_selector(node.name)}"
+          end
+
+          def nodes_after(node)
+            body_parsed.xpath node_selector_after(node, toc_child_selector(node.name))
+          end
+
+          def nodes_before(node)
+            body_parsed.xpath node_selector_before(node)
+          end
+
+          def nodes_between(node)
+            nodes_after(node) & nodes_before(node)
+          end
+        end
+      end
+    end
+  end
+end

--- a/api/spec/services/ingestor/preprocessor/html_spec.rb
+++ b/api/spec/services/ingestor/preprocessor/html_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Ingestor::Ingestion do
 
-  describe "When moving inline styles to a style block" do
+  describe "when preprocessing HTML ingestions" do
 
     before(:all) do
       @markup = <<~HEREDOC
@@ -19,11 +19,13 @@ RSpec.describe Ingestor::Ingestion do
           </style>
         </head>
         <body>
+          <h1>Header</h1>
           <p>
             <span class="some-class" style="font-weight: bold">A</span>
             <span style="font-weight: bold">B</span>
             <span style="text-decoration: underline">C</span>
           </p>
+          <h2>Header 2</h2>
         </body>
         </html>
       HEREDOC
@@ -50,11 +52,13 @@ RSpec.describe Ingestor::Ingestion do
         </style>
         </head>
         <body>
+          <h1 id="7bb1d4bc782b85bab1c21794a97a30df">Header</h1>
           <p>
             <span class="some-class extracted-inline-style-1">A</span>
             <span class="extracted-inline-style-1">B</span>
             <span class="extracted-inline-style-2">C</span>
           </p>
+          <h2 id="c58aad67287546f0ffcdb54c1b1f5b0c">Header 2</h2>
         </body>
         </html>
       HEREDOC
@@ -71,7 +75,7 @@ RSpec.describe Ingestor::Ingestion do
       @file.unlink
     end
 
-    it "extracts styles into the head" do
+    it "correctly processes the HTML" do
       ::Ingestor::Preprocessor::HTML.process!(@path)
       expect(File.open(@path).read).to eq @processed
     end

--- a/api/spec/services/ingestor/strategy/google_doc/strategy_spec.rb
+++ b/api/spec/services/ingestor/strategy/google_doc/strategy_spec.rb
@@ -25,8 +25,12 @@ RSpec.describe Ingestor::Strategy::GoogleDoc::Strategy, :integration do
         expect(@text.text_sections.length).to be 1
       end
 
-      it "has an empty TOC" do
-        expect(@text.toc).to eq []
+      it "has a TOC" do
+        expect(@text.toc).to_not be_empty
+      end
+
+      it "has the correct TOC length" do
+        expect(@text.toc.length).to eq 9
       end
 
       it "has an empty landmarks property" do


### PR DESCRIPTION
Closes #1077
This commit adds TOC generation for single-page google docs. For TOCs
to generate reliably, it's important that documents are semantically correct.

A TOC node entry can only have children that have headers _one_ level below
itself. For instance, an `<h1>` will only receive `<h2>` children.  Those `<h2>`
children will then only receive `<h3>` children, and so on.