### PR TITLE
[B] Fix updater reloading model when errors were present

### DIFF
--- a/api/app/lib/updaters.rb
+++ b/api/app/lib/updaters.rb
@@ -31,8 +31,7 @@ module Updaters
   def update(model, creator: nil)
     @model = model
     update_without_save(model, creator: creator)
-    save_model(model)
-    post_update(model) if model.persisted?
+    post_update(model) if save_model(model)
     model
   end
 
@@ -44,12 +43,12 @@ module Updaters
   protected
 
   def save_model(model)
-    @saved = false
+    saved = false
     run_callbacks "save" do
-      @saved = model.save
+      saved = model.save
     end
-    model.reload if model.id && @saved
-    @saved = false
+    model.reload if model.id && saved
+    saved
   end
 
   def attachment_fields

--- a/api/spec/lib/updater_spec.rb
+++ b/api/spec/lib/updater_spec.rb
@@ -1,0 +1,15 @@
+describe Updaters::Default do
+
+  let(:updatable) {
+    FactoryBot.create(:user)
+  }
+
+  let(:invalid_params) {
+    { type: "user", data: { attributes: { email: "" } } }
+  }
+
+  it "returns a model with errors if the request is invalid" do
+    expect(::Updaters::User.new(invalid_params).update(updatable).valid?).to be false
+  end
+
+end


### PR DESCRIPTION
Fixes #1090

This was a regression from a3a91d3329b5c3549e6884ee6db4e5a11e962ba9.
The check `model.persisted?` was always true because at that point a
record has either been created or was already present. This then meant
the `#post_update` method was always called, which included a `model.reload`.
This fix uses `save_model`'s return to determine whether the `post_update`
method should be called.