### PR TITLE
[B] Fix reader side drawer resource list hoverstates

### DIFF
--- a/client/src/theme/Components/backend/_vertical-list.scss
+++ b/client/src/theme/Components/backend/_vertical-list.scss
@@ -116,10 +116,10 @@
     // Use .list-item on li if the items don't link
     a {
       display: flex;
+      flex-direction: column;
       justify-content: space-between;
       width: 100%;
       padding: 20px 0 17px;
-      flex-direction: column;
       color: $neutral30;
       text-decoration: none;
       transition: color $duration ease-out;
@@ -134,23 +134,15 @@
           border-color: $accentPrimary;
         }
 
-        figure svg .highlight {
+        figure svg, figure svg .highlight {
           fill: $accentPrimary;
         }
 
-        .project-title {
+        .project-title, .subtitle, .project-makers {
           color: $neutral20;
         }
 
-        .subtitle {
-          color: $neutral20;
-        }
-
-        .project-makers {
-          color: $neutral20;
-        }
-
-        .label {
+        .name, .label {
           color: $accentPrimary;
 
           &.secondary {
@@ -203,10 +195,10 @@
       }
 
       .manicon-twitter {
-        font-size: 22px;
         padding-right: 12px;
+        font-size: 22px;
 
-        &:before {
+        &::before {
           vertical-align: bottom;
         }
       }
@@ -236,16 +228,16 @@
     .label {
       @include utilityPrimary;
       display: table-cell;
+      padding-top: 15px;
       font-size: 14px;
       color: $neutral75;
-      padding-top: 15px;
-      vertical-align: top;
       white-space: nowrap;
+      vertical-align: top;
       transition: color $duration $timing;
 
       @include respond($break70) {
-        padding-left: 19px;
         padding-top: 0;
+        padding-left: 19px;
       }
 
       span + span {

--- a/client/src/theme/Components/backend/collection/_resources-list.scss
+++ b/client/src/theme/Components/backend/collection/_resources-list.scss
@@ -1,5 +1,4 @@
 .collection-resources-list {
-
   .section-heading-secondary {
     display: inline-block;
     padding-right: 10px;


### PR DESCRIPTION
Resolves #1086 

Adds styles to change the color of the icon and name of the resource in the list on hover (and retains the existing hoverstate of the subtitle)

![resource hoverstates](https://user-images.githubusercontent.com/8166060/40691190-97341f68-635f-11e8-9445-8697d2491db5.gif)
