### PR TITLE
All Label elements are used with associated form controls

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -112,21 +112,31 @@
     "jsx-a11y/anchor-has-content": 2,
     "jsx-a11y/anchor-is-valid": 2,
 
+    // Rules for WCAG related to form labels
+    "jsx-a11y/label-has-for": [
+      2,
+      {
+        "components": [ "Label" ],
+        "required": {
+          "some": [ "nesting", "id" ]
+        },
+        "allowChildren": false
+      }
+    ],
+
     // Rules for WCAG we should eventually enable
     "jsx-a11y/aria-activedescendant-has-tabindex": 0,
-    "jsx-a11y/click-events-have-key-events": 0,
-    "jsx-a11y/heading-has-content": 0,
+    "jsx-a11y/no-noninteractive-tabindex": 0,
     "jsx-a11y/interactive-supports-focus": 0,
-    "jsx-a11y/label-has-for": 0,
-    "jsx-a11y/media-has-caption": 0,
+    "jsx-a11y/click-events-have-key-events": 0,
     "jsx-a11y/mouse-events-have-key-events": 0,
     "jsx-a11y/no-access-key": 0,
+    "jsx-a11y/no-onchange": 0,
+    "jsx-a11y/media-has-caption": 0,
+    "jsx-a11y/heading-has-content": 0,
     "jsx-a11y/no-autofocus": 0,
     "jsx-a11y/no-distracting-elements": 0,
-    "jsx-a11y/no-noninteractive-tabindex": 0,
-    "jsx-a11y/no-onchange": 0,
     "jsx-a11y/scope": 0,
-
   },
   "plugins": [
     "react", "import", "prettier", "jsx-a11y"

--- a/client/src/components/backend/Form/AttributeMap/Wrapper.js
+++ b/client/src/components/backend/Form/AttributeMap/Wrapper.js
@@ -102,7 +102,7 @@ class FormColumnMap extends PureComponent {
           <div className="form-input">
             <div className="form-column-map">
               <div className="column column-mappable">
-                <label>{"Spreadsheet Columns"}</label>
+                <h4 className="column-heading">{"Spreadsheet Columns"}</h4>
                 <ul className="mappable">
                   {sortedHeaders.map((header, index) => {
                     const position = this.getHeaderPosition(header, this.props);
@@ -121,7 +121,7 @@ class FormColumnMap extends PureComponent {
                 </ul>
               </div>
               <div className="column column-available">
-                <label>{"Available Attributes"}</label>
+                <h4 className="column-heading">{"Available Attributes"}</h4>
                 <Droppable droppableId="attributesAvailable" isDropDisabled>
                   {(provided, snapshotIgnored) => (
                     <div className="available" ref={provided.innerRef}>

--- a/client/src/components/backend/Form/Checkboxes.js
+++ b/client/src/components/backend/Form/Checkboxes.js
@@ -24,7 +24,9 @@ class FormCheckboxes extends Component {
     return (
       <div className="form-input">
         {this.props.label ? (
-          <label style={{ marginBottom: "1.5em" }}>{this.props.label}</label>
+          <h4 className="form-input-heading" style={{ marginBottom: "1.5em" }}>
+            {this.props.label}
+          </h4>
         ) : null}
         {this.props.options.map(option => {
           const checked = this.props.value === option.value;

--- a/client/src/components/backend/Form/CodeArea.js
+++ b/client/src/components/backend/Form/CodeArea.js
@@ -21,7 +21,7 @@ const CodeAreaInput = Loadable({
           errors={props.errors}
           label={props.label}
         >
-          <label>{props.label}</label>
+          <h4 className="form-input-heading">{props.label}</h4>
           {isString(props.instructions) ? (
             <span className="instructions">{props.instructions}</span>
           ) : null}

--- a/client/src/components/backend/Form/Date.js
+++ b/client/src/components/backend/Form/Date.js
@@ -170,7 +170,7 @@ class FormDate extends Component {
   render() {
     return (
       <div className="form-input">
-        <label>{this.props.label}</label>
+        <h4 className="form-input-heading">{this.props.label}</h4>
         <div className="form-date">
           <div className="form-select input-month">
             <i className="manicon manicon-caret-down" aria-hidden="true" />

--- a/client/src/components/backend/Form/GeneratedPasswordInput.js
+++ b/client/src/components/backend/Form/GeneratedPasswordInput.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import uniqueId from "lodash/uniqueId";
 import setter from "./setter";
 import classnames from "classnames";
 import { Form as GlobalForm } from "components/global";
@@ -30,6 +31,7 @@ class FormGeneratedPasswordInput extends Component {
   }
 
   componentDidMount() {
+    this.id = uniqueId("generated-password-");
     if (this.props.focusOnMount === true && this.inputElement)
       this.inputElement.focus();
     this.setValueFromCurrentState();
@@ -71,6 +73,7 @@ class FormGeneratedPasswordInput extends Component {
         ref={input => {
           this.inputElement = input;
         }}
+        id={this.id}
         type={type}
         placeholder={"Enter a password"}
         onChange={event => this.handlePasswordChange(event)}
@@ -93,18 +96,16 @@ class FormGeneratedPasswordInput extends Component {
         errors={this.props.errors}
         label="Password"
       >
-        <label>Password</label>
+        <label htmlFor={this.id}>Password</label>
         <span
           className="password-visibility-toggle"
           onClick={event => this.togglePassword(event)}
           role="button"
         >
           <i className={iconClass} aria-hidden="true" />
-          {this.state.showPassword ? (
-            <span className="screen-reader-text">hide password</span>
-          ) : (
-            <span className="screen-reader-text">show password</span>
-          )}
+          <span className="screen-reader-text">
+            {this.state.showPassword ? "hide password" : "show password"}
+          </span>
         </span>
         {this.renderInput()}
       </GlobalForm.Errorable>

--- a/client/src/components/backend/Form/HasMany.js
+++ b/client/src/components/backend/Form/HasMany.js
@@ -129,7 +129,7 @@ export default class FormHasMany extends PureComponent {
         </header>
       );
     } else {
-      out = <label>{this.props.label}</label>;
+      out = <h4 className="form-input-heading">{this.props.label}</h4>;
     }
     return out;
   }
@@ -183,8 +183,8 @@ export default class FormHasMany extends PureComponent {
                       className="manicon manicon-x"
                     >
                       <span className="screen-reader-text">
-                        Click to remove {this.label(entity, this.props)}
-                        from the {this.props.label} list.
+                        Click to remove {this.label(entity, this.props)} from
+                        the {this.props.label} list.
                       </span>
                     </button>
                   </div>

--- a/client/src/components/backend/Form/MaskedTextInput.js
+++ b/client/src/components/backend/Form/MaskedTextInput.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import uniqueId from "lodash/uniqueId";
 import MaskedInput from "react-text-mask";
 import createNumberMask from "text-mask-addons/dist/createNumberMask";
 import fill from "lodash/fill";
@@ -26,6 +27,10 @@ class FormMaskedTextInput extends Component {
   constructor() {
     super();
     this.placeholderChar = "\u005F"; // react-text-mask default "_"
+  }
+
+  componentDidMount() {
+    this.id = uniqueId("masked-text-");
   }
 
   currencyMask() {
@@ -86,11 +91,14 @@ class FormMaskedTextInput extends Component {
 
     return (
       <div className="form-input">
-        <label className={labelClass}>{this.props.label}</label>
+        <label htmlFor={this.id} className={labelClass}>
+          {this.props.label}
+        </label>
         <Instructions instructions={this.props.instructions} />
         <MaskedInput
           onChange={this.props.onChange}
           value={this.props.value}
+          id={this.id}
           type="text"
           mask={mask}
           placeholder={this.props.placeholder}

--- a/client/src/components/backend/Form/Radios.js
+++ b/client/src/components/backend/Form/Radios.js
@@ -24,7 +24,18 @@ class FormRadios extends Component {
     return (
       <div className="form-input">
         {this.props.label ? (
-          <label style={{ marginBottom: "1.5em" }}>{this.props.label}</label>
+          <div>
+            <span className="screen-reader-text">
+              Select a {this.props.label}
+            </span>
+            <h4
+              className="form-input-heading"
+              style={{ marginBottom: "1.5em" }}
+              aria-hidden="true"
+            >
+              {this.props.label}
+            </h4>
+          </div>
         ) : null}
         {this.props.options.map(option => {
           const checked = this.props.value === option.value;

--- a/client/src/components/backend/Form/Select.js
+++ b/client/src/components/backend/Form/Select.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import uniqueId from "lodash/uniqueId";
 import { Form as GlobalForm } from "components/global";
 import setter from "./setter";
 import isNull from "lodash/isNull";
@@ -23,6 +24,10 @@ class FormSelect extends Component {
     ).isRequired
   };
 
+  componentDidMount() {
+    this.id = uniqueId("select-");
+  }
+
   render() {
     const value = isNull(this.props.value) ? "" : this.props.value;
 
@@ -42,11 +47,11 @@ class FormSelect extends Component {
           errors={this.props.errors}
           label={this.props.label}
         >
-          <label>{this.props.label}</label>
+          <label htmlFor={this.id}>{this.props.label}</label>
           <Instructions instructions={this.props.instructions} />
           <div className="form-select">
             <i className="manicon manicon-caret-down" aria-hidden="true" />
-            <select onChange={this.props.onChange} value={value}>
+            <select id={this.id} onChange={this.props.onChange} value={value}>
               {options}
             </select>
           </div>

--- a/client/src/components/backend/Form/Switch.js
+++ b/client/src/components/backend/Form/Switch.js
@@ -62,11 +62,7 @@ class FormSwitch extends Component {
       this.props.labelClass
     );
     const wrapperClasses = classnames("form-input", this.props.className);
-    const label = (
-      <label aria-hidden="true" className={labelClasses}>
-        {this.props.label}
-      </label>
-    );
+    const label = <h4 className={labelClasses}>{this.props.label}</h4>;
 
     return (
       <div className={wrapperClasses}>

--- a/client/src/components/backend/Form/TextArea.js
+++ b/client/src/components/backend/Form/TextArea.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import uniqueId from "lodash/uniqueId";
 import setter from "./setter";
 import { Form as GlobalForm } from "components/global";
 import isString from "lodash/isString";
@@ -24,6 +25,10 @@ class FormTextArea extends Component {
     height: 100
   };
 
+  componentDidMount() {
+    this.id = uniqueId("textarea-");
+  }
+
   render() {
     const labelClass = classnames({
       "has-instructions": isString(this.props.instructions)
@@ -37,9 +42,12 @@ class FormTextArea extends Component {
           errors={this.props.errors}
           label={this.props.label}
         >
-          <label className={labelClass}>{this.props.label}</label>
+          <label htmlFor={this.id} className={labelClass}>
+            {this.props.label}
+          </label>
           <Instructions instructions={this.props.instructions} />
           <textarea
+            id={this.id}
             style={{ height: this.props.height }}
             placeholder={this.props.placeholder}
             onChange={this.props.onChange}

--- a/client/src/components/backend/Form/TextInput.js
+++ b/client/src/components/backend/Form/TextInput.js
@@ -1,4 +1,3 @@
-import uniqueId from "lodash/uniqueId";
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import setter from "./setter";

--- a/client/src/components/backend/Form/TextInput.js
+++ b/client/src/components/backend/Form/TextInput.js
@@ -1,3 +1,4 @@
+import uniqueId from "lodash/uniqueId";
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import setter from "./setter";
@@ -33,8 +34,9 @@ class FormTextInput extends Component {
   componentDidMount() {
     this.id = uniqueId("text-input-");
 
-    if (this.props.focusOnMount === true && this.inputElement)
+    if (this.props.focusOnMount === true && this.inputElement) {
       this.inputElement.focus();
+    }
   }
 
   renderValue(value) {

--- a/client/src/components/backend/Form/Upload.js
+++ b/client/src/components/backend/Form/Upload.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import uniqueId from "lodash/uniqueId";
 import Dropzone from "react-dropzone";
 import { Form as GlobalForm } from "components/global";
 import classnames from "classnames";
@@ -102,6 +103,10 @@ export class FormUpload extends Component {
       removed: false,
       attachment: null
     };
+  }
+
+  componentDidMount() {
+    this.id = uniqueId("upload-");
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -287,10 +292,13 @@ export class FormUpload extends Component {
           label={this.props.label}
         >
           {this.props.label ? (
-            <label className={labelClass}>{this.props.label}</label>
+            <label htmlFor={this.id} className={labelClass}>
+              {this.props.label}
+            </label>
           ) : null}
           <Instructions instructions={this.props.instructions} />
           <Dropzone
+            id={this.id}
             style={this.props.inlineStyle}
             className={`form-dropzone style-${this.props.layout}`}
             multiple={false}

--- a/client/src/components/backend/Form/__tests__/__snapshots__/Date-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/Date-test.js.snap
@@ -4,9 +4,11 @@ exports[`Backend.Form.Date component renders correctly 1`] = `
 <div
   className="form-input"
 >
-  <label>
+  <h4
+    className="form-input-heading"
+  >
     Some date
-  </label>
+  </h4>
   <div
     className="form-date"
   >

--- a/client/src/components/backend/Form/__tests__/__snapshots__/GeneratedPasswordInput-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/GeneratedPasswordInput-test.js.snap
@@ -5,7 +5,9 @@ exports[`Backend.Form.GeneratedPasswordInput component renders correctly 1`] = `
   className="form-input password-input"
   style={Object {}}
 >
-  <label>
+  <label
+    htmlFor={undefined}
+  >
     Password
   </label>
   <span
@@ -24,6 +26,7 @@ exports[`Backend.Form.GeneratedPasswordInput component renders correctly 1`] = `
     </span>
   </span>
   <input
+    id={undefined}
     onChange={[Function]}
     placeholder="Enter a password"
     type="password"

--- a/client/src/components/backend/Form/__tests__/__snapshots__/HasMany-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/HasMany-test.js.snap
@@ -5,9 +5,11 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
   className="form-input"
   style={Object {}}
 >
-  <label>
+  <h4
+    className="form-input-heading"
+  >
     makers
-  </label>
+  </h4>
   <nav
     className="has-many-list"
   >
@@ -48,7 +50,7 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
             >
               Click to remove 
               John
-              from the 
+               from the 
               makers
                list.
             </span>
@@ -91,7 +93,7 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
             >
               Click to remove 
               Jane
-              from the 
+               from the 
               makers
                list.
             </span>

--- a/client/src/components/backend/Form/__tests__/__snapshots__/Radios-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/Radios-test.js.snap
@@ -4,15 +4,25 @@ exports[`Backend.Form.Radios component renders correctly 1`] = `
 <div
   className="form-input"
 >
-  <label
-    style={
-      Object {
-        "marginBottom": "1.5em",
+  <div>
+    <span
+      className="screen-reader-text"
+    >
+      Select a 
+      Label this
+    </span>
+    <h4
+      aria-hidden="true"
+      className="form-input-heading"
+      style={
+        Object {
+          "marginBottom": "1.5em",
+        }
       }
-    }
-  >
-    Label this
-  </label>
+    >
+      Label this
+    </h4>
+  </div>
   <label
     className="form-toggle radio"
     htmlFor="1"

--- a/client/src/components/backend/Form/__tests__/__snapshots__/Select-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/Select-test.js.snap
@@ -8,7 +8,9 @@ exports[`Backend.Form.Select component renders correctly 1`] = `
     className="form-input"
     style={Object {}}
   >
-    <label>
+    <label
+      htmlFor={undefined}
+    >
       Label this
     </label>
     <div
@@ -19,6 +21,7 @@ exports[`Backend.Form.Select component renders correctly 1`] = `
         className="manicon manicon-caret-down"
       />
       <select
+        id={undefined}
         onChange={[Function]}
         value={undefined}
       >

--- a/client/src/components/backend/Form/__tests__/__snapshots__/Switch-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/Switch-test.js.snap
@@ -4,12 +4,11 @@ exports[`Backend.Form.Switch component renders correctly 1`] = `
 <div
   className="form-input"
 >
-  <label
-    aria-hidden="true"
+  <h4
     className="form-input-heading above"
   >
     Label this
-  </label>
+  </h4>
   <div
     className="toggle-indicator"
   >

--- a/client/src/components/backend/Form/__tests__/__snapshots__/SwitchArray-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/SwitchArray-test.js.snap
@@ -18,12 +18,11 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
     <div
       className="form-input"
     >
-      <label
-        aria-hidden="true"
+      <h4
         className="form-input-heading above"
       >
         Option one
-      </label>
+      </h4>
       <div
         className="toggle-indicator"
       >
@@ -44,12 +43,11 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
     <div
       className="form-input"
     >
-      <label
-        aria-hidden="true"
+      <h4
         className="form-input-heading above"
       >
         Option two
-      </label>
+      </h4>
       <div
         className="toggle-indicator"
       >

--- a/client/src/components/backend/Form/__tests__/__snapshots__/TextArea-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/TextArea-test.js.snap
@@ -10,10 +10,12 @@ exports[`Backend.Form.TextArea component renders correctly 1`] = `
   >
     <label
       className=""
+      htmlFor={undefined}
     >
       Label this
     </label>
     <textarea
+      id={undefined}
       onChange={[Function]}
       placeholder={undefined}
       style={

--- a/client/src/components/backend/Form/__tests__/__snapshots__/Upload-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/Upload-test.js.snap
@@ -10,12 +10,14 @@ exports[`Backend.Form.Upload component when the upload input does not have a val
   >
     <label
       className=""
+      htmlFor={undefined}
     >
       Cover
     </label>
     <react-dropzone
       accept="image/*"
       className="form-dropzone style-portrait"
+      id={undefined}
       multiple={false}
       onDrop={[Function]}
       style={undefined}
@@ -66,12 +68,14 @@ exports[`Backend.Form.Upload component when the upload input doesn't have a remo
   >
     <label
       className=""
+      htmlFor={undefined}
     >
       Cover
     </label>
     <react-dropzone
       accept="image/*"
       className="form-dropzone style-portrait"
+      id={undefined}
       multiple={false}
       onDrop={[Function]}
       style={undefined}
@@ -135,12 +139,14 @@ exports[`Backend.Form.Upload component when the upload input doesn't have set an
   >
     <label
       className=""
+      htmlFor={undefined}
     >
       Cover
     </label>
     <react-dropzone
       accept="image/*"
       className="form-dropzone style-portrait"
+      id={undefined}
       multiple={false}
       onDrop={[Function]}
       style={undefined}
@@ -204,12 +210,14 @@ exports[`Backend.Form.Upload component when the upload input has a value renders
   >
     <label
       className=""
+      htmlFor={undefined}
     >
       Cover
     </label>
     <react-dropzone
       accept="image/*"
       className="form-dropzone style-portrait"
+      id={undefined}
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Ingestion/Form/__tests__/__snapshots__/Type-test.js.snap
+++ b/client/src/components/backend/Ingestion/Form/__tests__/__snapshots__/Type-test.js.snap
@@ -7,15 +7,25 @@ exports[`Backend.Ingestion.Form.Type component renders cancel button when passed
   <div
     className="form-input"
   >
-    <label
-      style={
-        Object {
-          "marginBottom": "1.5em",
+    <div>
+      <span
+        className="screen-reader-text"
+      >
+        Select a 
+        Text Format
+      </span>
+      <h4
+        aria-hidden="true"
+        className="form-input-heading"
+        style={
+          Object {
+            "marginBottom": "1.5em",
+          }
         }
-      }
-    >
-      Text Format
-    </label>
+      >
+        Text Format
+      </h4>
+    </div>
     <label
       className="form-toggle radio"
       htmlFor="epub"
@@ -141,15 +151,25 @@ exports[`Backend.Ingestion.Form.Type component renders correctly 1`] = `
   <div
     className="form-input"
   >
-    <label
-      style={
-        Object {
-          "marginBottom": "1.5em",
+    <div>
+      <span
+        className="screen-reader-text"
+      >
+        Select a 
+        Text Format
+      </span>
+      <h4
+        aria-hidden="true"
+        className="form-input-heading"
+        style={
+          Object {
+            "marginBottom": "1.5em",
+          }
         }
-      }
-    >
-      Text Format
-    </label>
+      >
+        Text Format
+      </h4>
+    </div>
     <label
       className="form-toggle radio"
       htmlFor="epub"

--- a/client/src/components/backend/Ingestion/Form/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/components/backend/Ingestion/Form/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -13,15 +13,25 @@ exports[`Backend.Ingestion.Form.Wrapper component renders correctly 1`] = `
       <div
         className="form-input"
       >
-        <label
-          style={
-            Object {
-              "marginBottom": "1.5em",
+        <div>
+          <span
+            className="screen-reader-text"
+          >
+            Select a 
+            Text Format
+          </span>
+          <h4
+            aria-hidden="true"
+            className="form-input-heading"
+            style={
+              Object {
+                "marginBottom": "1.5em",
+              }
             }
-          }
-        >
-          Text Format
-        </label>
+          >
+            Text Format
+          </h4>
+        </div>
         <label
           className="form-toggle radio"
           htmlFor="epub"

--- a/client/src/components/backend/List/Searchable.js
+++ b/client/src/components/backend/List/Searchable.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
+import uniqueId from "lodash/uniqueId";
 import { Utility } from "components/global";
 import { HigherOrder } from "containers/global";
 import withCurrentUser from "containers/global/HigherOrder/withCurrentUser";
@@ -71,6 +72,8 @@ export class ListSearchable extends PureComponent {
 
   componentDidMount() {
     this.searchId = uniqueId("list-search-");
+    this.filterId = uniqueId("filter-");
+    this.sortId = uniqueId("sort-");
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -137,7 +140,7 @@ export class ListSearchable extends PureComponent {
 
     return (
       <div className="select-group">
-        <label>Sort By:</label>
+        <label htmlFor={this.sortId}>Sort By:</label>
         {this.renderSortSelect(adjustedOptions)}
       </div>
     );
@@ -147,7 +150,7 @@ export class ListSearchable extends PureComponent {
     if (!this.state.showOptions || !this.props.filterOptions) return null;
     return (
       <div className="select-group">
-        <label>Filter Results:</label>
+        <label htmlFor={this.filterId}>Filter Results:</label>
         {Object.keys(this.props.filterOptions).map(filter =>
           this.renderFilterSelect(filter)
         )}
@@ -159,6 +162,7 @@ export class ListSearchable extends PureComponent {
     return (
       <div className="select" key="filter[order]">
         <select
+          id={this.sortId}
           onChange={event => this.setFilter(event, "order")}
           value={this.state.filter.order || ""}
           data-id={"filter"}
@@ -175,6 +179,7 @@ export class ListSearchable extends PureComponent {
     return (
       <div className="select" key={filter}>
         <select
+          id={this.filterId}
           onChange={event => this.setFilter(event, filter)}
           value={this.state.filter[filter] || ""}
           data-id={"filter"}

--- a/client/src/components/backend/List/Searchable.js
+++ b/client/src/components/backend/List/Searchable.js
@@ -1,6 +1,5 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
-import uniqueId from "lodash/uniqueId";
 import { Utility } from "components/global";
 import { HigherOrder } from "containers/global";
 import withCurrentUser from "containers/global/HigherOrder/withCurrentUser";

--- a/client/src/components/backend/Project/Form/AvatarBuilder.js
+++ b/client/src/components/backend/Project/Form/AvatarBuilder.js
@@ -119,7 +119,7 @@ class AvatarBuilder extends Component {
         {this.state.confirmation ? (
           <Dialog.Confirm {...this.state.confirmation} />
         ) : null}
-        <label className="section-header">Project Thumbnail</label>
+        <h4 className="form-input-heading">Project Thumbnail</h4>
         <div className="grid">
           <div className="section current">
             <span className="label" aria-hidden="true">

--- a/client/src/components/backend/Project/Form/__tests__/__snapshots__/Subjects-test.js.snap
+++ b/client/src/components/backend/Project/Form/__tests__/__snapshots__/Subjects-test.js.snap
@@ -5,9 +5,11 @@ exports[`Backend Project Form Subjects Component renders correctly 1`] = `
   className="form-input"
   style={Object {}}
 >
-  <label>
+  <h4
+    className="form-input-heading"
+  >
     Subjects
-  </label>
+  </h4>
   <nav
     className="has-many-list"
   >
@@ -34,7 +36,7 @@ exports[`Backend Project Form Subjects Component renders correctly 1`] = `
             >
               Click to remove 
               Hip Hop
-              from the 
+               from the 
               Subjects
                list.
             </span>

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Audio-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Audio-test.js.snap
@@ -13,12 +13,14 @@ exports[`Backend.Resource.Form.Audio component renders correctly 1`] = `
     >
       <label
         className=""
+        htmlFor={undefined}
       >
         Audio File
       </label>
       <react-dropzone
         accept="audio/*"
         className="form-dropzone style-square"
+        id={undefined}
         multiple={false}
         onDrop={[Function]}
         style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Document-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Document-test.js.snap
@@ -10,12 +10,14 @@ exports[`Backend.Resource.Form.Document component renders correctly 1`] = `
   >
     <label
       className=""
+      htmlFor={undefined}
     >
       Document File
     </label>
     <react-dropzone
       accept="application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/msword,text/*,application/vnd.oasis.opendocument.text"
       className="form-dropzone style-square"
+      id={undefined}
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/File-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/File-test.js.snap
@@ -10,11 +10,13 @@ exports[`Backend.Resource.Form.File component renders correctly 1`] = `
   >
     <label
       className=""
+      htmlFor={undefined}
     >
       File
     </label>
     <react-dropzone
       className="form-dropzone style-square"
+      id={undefined}
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Image-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Image-test.js.snap
@@ -10,12 +10,14 @@ exports[`Backend.Resource.Form.Image component renders correctly 1`] = `
   >
     <label
       className=""
+      htmlFor={undefined}
     >
       Image File
     </label>
     <react-dropzone
       accept="image/*"
       className="form-dropzone style-square"
+      id={undefined}
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Pdf-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Pdf-test.js.snap
@@ -10,12 +10,14 @@ exports[`Backend.Resource.Form.Pdf component renders correctly 1`] = `
   >
     <label
       className=""
+      htmlFor={undefined}
     >
       PDF File
     </label>
     <react-dropzone
       accept="application/pdf"
       className="form-dropzone style-square"
+      id={undefined}
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Presentation-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Presentation-test.js.snap
@@ -10,12 +10,14 @@ exports[`Backend.Resource.Form.Presentation component renders correctly 1`] = `
   >
     <label
       className=""
+      htmlFor={undefined}
     >
       Presentation File
     </label>
     <react-dropzone
       accept="application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-powerpoint,application/vnd.oasis.opendocument.presentation"
       className="form-dropzone style-square"
+      id={undefined}
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Spreadsheet-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Spreadsheet-test.js.snap
@@ -10,12 +10,14 @@ exports[`Backend.Resource.Form.Spreadsheet component renders correctly 1`] = `
   >
     <label
       className=""
+      htmlFor={undefined}
     >
       Spreadsheet File
     </label>
     <react-dropzone
       accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,application/vnd.oasis.opendocument.spreadsheet,"
       className="form-dropzone style-square"
+      id={undefined}
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Variants-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Variants-test.js.snap
@@ -13,11 +13,13 @@ exports[`Backend.Resource.Form.Variants component renders correctly 1`] = `
     >
       <label
         className=""
+        htmlFor={undefined}
       >
         Variant
       </label>
       <react-dropzone
         className="form-dropzone style-square"
+        id={undefined}
         multiple={false}
         onDrop={[Function]}
         style={undefined}
@@ -60,11 +62,13 @@ exports[`Backend.Resource.Form.Variants component renders correctly 1`] = `
     >
       <label
         className=""
+        htmlFor={undefined}
       >
         Variant
       </label>
       <react-dropzone
         className="form-dropzone style-square"
+        id={undefined}
         multiple={false}
         onDrop={[Function]}
         style={undefined}
@@ -114,12 +118,14 @@ exports[`Backend.Resource.Form.Variants component when kind is image renders cor
     >
       <label
         className=""
+        htmlFor={undefined}
       >
         High Resolution Image
       </label>
       <react-dropzone
         accept="image/*"
         className="form-dropzone style-square"
+        id={undefined}
         multiple={false}
         onDrop={[Function]}
         style={undefined}
@@ -167,12 +173,14 @@ exports[`Backend.Resource.Form.Variants component when kind is image renders cor
     >
       <label
         className=""
+        htmlFor={undefined}
       >
         Thumbnail Image
       </label>
       <react-dropzone
         accept="image/*"
         className="form-dropzone style-square"
+        id={undefined}
         multiple={false}
         onDrop={[Function]}
         style={undefined}
@@ -227,12 +235,14 @@ exports[`Backend.Resource.Form.Variants component when kind is pdf renders corre
     >
       <label
         className=""
+        htmlFor={undefined}
       >
         Thumbnail Image
       </label>
       <react-dropzone
         accept="image/*"
         className="form-dropzone style-square"
+        id={undefined}
         multiple={false}
         onDrop={[Function]}
         style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Video-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Video-test.js.snap
@@ -7,12 +7,11 @@ exports[`Backend.Resource.Form.Video component renders correctly 1`] = `
   <div
     className="form-input"
   >
-    <label
-      aria-hidden="true"
+    <h4
       className="form-input-heading above"
     >
       Is this an externally linked video?
-    </label>
+    </h4>
     <div
       className="toggle-indicator"
     >
@@ -39,12 +38,14 @@ exports[`Backend.Resource.Form.Video component renders correctly 1`] = `
     >
       <label
         className=""
+        htmlFor={undefined}
       >
         Video File
       </label>
       <react-dropzone
         accept="video/*"
         className="form-dropzone style-square"
+        id={undefined}
         multiple={false}
         onDrop={[Function]}
         style={undefined}
@@ -93,12 +94,11 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
   <div
     className="form-input"
   >
-    <label
-      aria-hidden="true"
+    <h4
       className="form-input-heading above"
     >
       Is this an externally linked video?
-    </label>
+    </h4>
     <div
       className="toggle-indicator"
     >
@@ -144,7 +144,9 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
         className="form-input"
         style={Object {}}
       >
-        <label>
+        <label
+          htmlFor={undefined}
+        >
           External Video Type
         </label>
         <div
@@ -155,6 +157,7 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
             className="manicon manicon-caret-down"
           />
           <select
+            id={undefined}
             onChange={[Function]}
             value={undefined}
           >

--- a/client/src/components/backend/Resource/Form/KindPicker.js
+++ b/client/src/components/backend/Resource/Form/KindPicker.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
+import uniqueId from "lodash/uniqueId";
 import classNames from "classnames";
 import { Resource } from "components/frontend";
 import setter from "components/backend/Form/setter";
@@ -12,6 +13,10 @@ class KindPicker extends PureComponent {
     includeButtons: PropTypes.bool,
     set: PropTypes.func
   };
+
+  componentDidMount() {
+    this.id = uniqueId("kind-");
+  }
 
   renderKindPickerButtons(kindList) {
     if (!kindList) return null;
@@ -81,11 +86,12 @@ class KindPicker extends PureComponent {
     return (
       <div className="resource-kind-picker form-secondary">
         <div className="form-input">
-          <label>Kind</label>
+          <label htmlFor={this.id}>Kind</label>
           <div className={selectClass}>
             <div className="form-select">
               <i className="manicon manicon-caret-down" aria-hidden="true" />
               <select
+                id={this.id}
                 onChange={event => {
                   this.props.set(event.target.value);
                 }}

--- a/client/src/components/backend/Resource/Form/__tests__/__snapshots__/KindAttributes-test.js.snap
+++ b/client/src/components/backend/Resource/Form/__tests__/__snapshots__/KindAttributes-test.js.snap
@@ -10,12 +10,14 @@ exports[`Backend.Resource.Form.KindAttributes component when kind is audio rende
   >
     <label
       className=""
+      htmlFor={undefined}
     >
       Image File
     </label>
     <react-dropzone
       accept="image/*"
       className="form-dropzone style-square"
+      id={undefined}
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/__tests__/__snapshots__/KindPicker-test.js.snap
+++ b/client/src/components/backend/Resource/Form/__tests__/__snapshots__/KindPicker-test.js.snap
@@ -7,7 +7,9 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
   <div
     className="form-input"
   >
-    <label>
+    <label
+      htmlFor={undefined}
+    >
       Kind
     </label>
     <div
@@ -21,6 +23,7 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
           className="manicon manicon-caret-down"
         />
         <select
+          id={undefined}
           onChange={[Function]}
           value="image"
         >

--- a/client/src/components/backend/TwitterQuery/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/components/backend/TwitterQuery/__tests__/__snapshots__/Form-test.js.snap
@@ -45,7 +45,9 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <label>
+        <label
+          htmlFor={undefined}
+        >
           Fetch tweets by:
         </label>
         <div
@@ -56,6 +58,7 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
             className="manicon manicon-caret-down"
           />
           <select
+            id={undefined}
             onChange={[Function]}
             value={undefined}
           >
@@ -76,12 +79,11 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
     <div
       className="form-input"
     >
-      <label
-        aria-hidden="true"
+      <h4
         className="form-input-heading above"
       >
         Active
-      </label>
+      </h4>
       <div
         className="toggle-indicator"
       >

--- a/client/src/components/frontend/Static/Form.js
+++ b/client/src/components/frontend/Static/Form.js
@@ -20,8 +20,12 @@ export default class StaticForm extends Component {
             <div className="row-3-p">
               <div className="col-33">
                 <div className="form-input form-error">
-                  <label>Text Entry Field</label>
-                  <input type="text" placeholder="Text Entry Field" />
+                  <label htmlFor="text-1">Text Entry Field</label>
+                  <input
+                    id="text-1"
+                    type="text"
+                    placeholder="Text Entry Field"
+                  />
                   <i className="manicon manicon-stop" aria-hidden="true" />
                   <span className="form-error-message">something happened</span>
                 </div>
@@ -29,20 +33,24 @@ export default class StaticForm extends Component {
 
               <div className="col-33">
                 <div className="form-input">
-                  <label>Text Entry Field</label>
-                  <input type="text" placeholder="Text Entry Field" />
+                  <label htmlFor="text-2">Text Entry Field</label>
+                  <input
+                    id="text-2"
+                    type="text"
+                    placeholder="Text Entry Field"
+                  />
                 </div>
               </div>
 
               <div className="col-33">
                 <div className="form-input">
-                  <label>&nbsp;</label>
+                  <label htmlFor="select-1">&nbsp;</label>
                   <div className="form-select">
                     <i
                       className="manicon manicon-caret-down"
                       aria-hidden="true"
                     />
-                    <select>
+                    <select id="select-1">
                       <option>Select Dropdown</option>
                       <option>Select an option</option>
                       <option>If you please</option>
@@ -55,8 +63,11 @@ export default class StaticForm extends Component {
             <div className="row-3-p">
               <div className="col-66">
                 <div className="form-input">
-                  <label>Editable text field</label>
-                  <textarea placeholder="Start typing annotation here..." />
+                  <label htmlFor="textarea-1">Editable text field</label>
+                  <textarea
+                    id="textarea-1"
+                    placeholder="Start typing annotation here..."
+                  />
                 </div>
               </div>
 
@@ -95,7 +106,7 @@ export default class StaticForm extends Component {
                 </div>
 
                 <div className="form-input">
-                  <label>Checkboxes Vertical</label>
+                  <h4 className="form-input-heading">Checkboxes Vertical</h4>
                   {/* Radio buttons and checkboxes get wrapped in a toggle class */}
                   <label className="form-toggle checkbox">
                     <input type="checkbox" />
@@ -127,7 +138,7 @@ export default class StaticForm extends Component {
                 </div>
 
                 <div className="form-input">
-                  <label>Radios Vertical</label>
+                  <h4 className="form-input-heading">Radios Vertical</h4>
                   <label className="form-toggle radio">
                     <input type="radio" name="test" />
                     <span className="toggle-indicator" aria-hidden="true">
@@ -154,7 +165,7 @@ export default class StaticForm extends Component {
             <div className="row-3-p">
               <div className="col-66">
                 <div className="form-input">
-                  <label>Checkboxes Horizontal</label>
+                  <h4 className="form-input-heading">Checkboxes Horizontal</h4>
 
                   <label className="form-toggle checkbox horizontal">
                     <input type="checkbox" />
@@ -182,7 +193,7 @@ export default class StaticForm extends Component {
                 </div>
 
                 <div className="form-input">
-                  <label>Checkboxes Horizontal</label>
+                  <h4 className="form-input-heading">Checkboxes Horizontal</h4>
 
                   <label className="form-toggle radio horizontal">
                     <input type="radio" />

--- a/client/src/components/frontend/Static/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/components/frontend/Static/__tests__/__snapshots__/Form-test.js.snap
@@ -20,10 +20,13 @@ exports[`Frontend.Static.Form component renders correctly 1`] = `
           <div
             className="form-input form-error"
           >
-            <label>
+            <label
+              htmlFor="text-1"
+            >
               Text Entry Field
             </label>
             <input
+              id="text-1"
               placeholder="Text Entry Field"
               type="text"
             />
@@ -44,10 +47,13 @@ exports[`Frontend.Static.Form component renders correctly 1`] = `
           <div
             className="form-input"
           >
-            <label>
+            <label
+              htmlFor="text-2"
+            >
               Text Entry Field
             </label>
             <input
+              id="text-2"
               placeholder="Text Entry Field"
               type="text"
             />
@@ -59,7 +65,9 @@ exports[`Frontend.Static.Form component renders correctly 1`] = `
           <div
             className="form-input"
           >
-            <label>
+            <label
+              htmlFor="select-1"
+            >
                
             </label>
             <div
@@ -69,7 +77,9 @@ exports[`Frontend.Static.Form component renders correctly 1`] = `
                 aria-hidden="true"
                 className="manicon manicon-caret-down"
               />
-              <select>
+              <select
+                id="select-1"
+              >
                 <option>
                   Select Dropdown
                 </option>
@@ -93,10 +103,13 @@ exports[`Frontend.Static.Form component renders correctly 1`] = `
           <div
             className="form-input"
           >
-            <label>
+            <label
+              htmlFor="textarea-1"
+            >
               Editable text field
             </label>
             <textarea
+              id="textarea-1"
               placeholder="Start typing annotation here..."
             />
           </div>
@@ -164,9 +177,11 @@ exports[`Frontend.Static.Form component renders correctly 1`] = `
           <div
             className="form-input"
           >
-            <label>
+            <h4
+              className="form-input-heading"
+            >
               Checkboxes Vertical
-            </label>
+            </h4>
             <label
               className="form-toggle checkbox"
             >
@@ -231,9 +246,11 @@ exports[`Frontend.Static.Form component renders correctly 1`] = `
           <div
             className="form-input"
           >
-            <label>
+            <h4
+              className="form-input-heading"
+            >
               Radios Vertical
-            </label>
+            </h4>
             <label
               className="form-toggle radio"
             >
@@ -297,9 +314,11 @@ exports[`Frontend.Static.Form component renders correctly 1`] = `
           <div
             className="form-input"
           >
-            <label>
+            <h4
+              className="form-input-heading"
+            >
               Checkboxes Horizontal
-            </label>
+            </h4>
             <label
               className="form-toggle checkbox horizontal"
             >
@@ -364,9 +383,11 @@ exports[`Frontend.Static.Form component renders correctly 1`] = `
           <div
             className="form-input"
           >
-            <label>
+            <h4
+              className="form-input-heading"
+            >
               Checkboxes Horizontal
-            </label>
+            </h4>
             <label
               className="form-toggle radio horizontal"
             >

--- a/client/src/components/frontend/Utility/ConfirmableButton.js
+++ b/client/src/components/frontend/Utility/ConfirmableButton.js
@@ -27,7 +27,7 @@ export default class ConfirmableButton extends Component {
   renderConfirmation() {
     return (
       <div className="confirmation">
-        <label>{this.props.label}</label>
+        <div className="confirmation-label">{this.props.label}</div>
         <button className="confirm" onClick={this.handleConfirm}>
           Confirm
         </button>

--- a/client/src/components/global/Search/Query/Form.js
+++ b/client/src/components/global/Search/Query/Form.js
@@ -162,11 +162,11 @@ export default class SearchQuery extends PureComponent {
         {this.props.scopes.length > 0 ? (
           <div className="filters">
             {this.props.searchType !== "reader" ? (
-              <label className="group-label">{"Search within:"}</label>
+              <h4 className="group-label">{"Search within:"}</h4>
             ) : null}
             <div className="checkbox-group">
               {this.props.searchType === "reader" ? (
-                <label className="group-label">{"Search within:"}</label>
+                <h4 className="group-label">{"Search within:"}</h4>
               ) : null}
               {this.props.scopes.map(scope => {
                 const filterCheckboxId = uniqueId(scope.value + "-");
@@ -196,7 +196,7 @@ export default class SearchQuery extends PureComponent {
 
         {this.props.facets.length > 0 ? (
           <div className="filters">
-            <label className="group-label">{"Show Results For:"}</label>
+            <h4 className="group-label">{"Show Results For:"}</h4>
             <div className="checkbox-group">
               <label htmlFor="all-filters" key={"all"} className="checkbox">
                 <input

--- a/client/src/components/global/SignInUp/Create.js
+++ b/client/src/components/global/SignInUp/Create.js
@@ -111,7 +111,7 @@ class CreateContainer extends Component {
               name="attributes[email]"
               errors={errors}
             >
-              <label>Email</label>
+              <label htmlFor="create-email">Email</label>
               <input
                 value={this.state.user.email}
                 type="text"
@@ -128,7 +128,7 @@ class CreateContainer extends Component {
               name={["attributes[firstName]", "attributes[lastName]"]}
               errors={errors}
             >
-              <label>Name</label>
+              <label htmlFor="create-name">Name</label>
               <input
                 value={this.state.user.name}
                 type="text"

--- a/client/src/components/global/SignInUp/Login.js
+++ b/client/src/components/global/SignInUp/Login.js
@@ -76,7 +76,7 @@ export default class Login extends Component {
         <form method="post" onSubmit={this.handleLogin}>
           <div className="row-1-p">
             <div className="form-input form-error">
-              <label>Email</label>
+              <label htmlFor="login-email">Email</label>
               <input
                 type="text"
                 name="email"

--- a/client/src/components/global/SignInUp/PasswordForgot.js
+++ b/client/src/components/global/SignInUp/PasswordForgot.js
@@ -104,7 +104,7 @@ class PasswordForgotContainer extends Component {
         <form method="" onSubmit={event => this.handleSubmit(event)}>
           <div className="row-1-p">
             <div className="form-input form-error">
-              <label>Email</label>
+              <label htmlFor="password-forgot-email">Email</label>
               <Form.HigherOrder.Validation
                 submitted={this.state.submitted}
                 value={this.state.email}

--- a/client/src/components/global/SignInUp/UpdateForm.js
+++ b/client/src/components/global/SignInUp/UpdateForm.js
@@ -263,7 +263,7 @@ class UpdateFormContainer extends Component {
             name="attributes[firstName]"
             errors={errors}
           >
-            <label>First Name</label>
+            <label htmlFor="update-firstName">First Name</label>
             <input
               value={this.state.firstName}
               type="text"
@@ -278,7 +278,7 @@ class UpdateFormContainer extends Component {
             name="attributes[lastName]"
             errors={errors}
           >
-            <label>Last Name</label>
+            <label htmlFor="update-lastName">Last Name</label>
             <input
               value={this.state.lastName}
               type="text"
@@ -293,7 +293,7 @@ class UpdateFormContainer extends Component {
             name="attributes[email]"
             errors={errors}
           >
-            <label>Email</label>
+            <label htmlFor="update-email">Email</label>
             <input
               value={this.state.email}
               type="text"

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/Create-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/Create-test.js.snap
@@ -18,7 +18,9 @@ exports[`Global.SignInUp.Create component renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <label>
+        <label
+          htmlFor="create-email"
+        >
           Email
         </label>
         <input
@@ -38,7 +40,9 @@ exports[`Global.SignInUp.Create component renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <label>
+        <label
+          htmlFor="create-name"
+        >
           Name
         </label>
         <input

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/CreateUpdate-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/CreateUpdate-test.js.snap
@@ -60,7 +60,9 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="update-firstName"
+      >
         First Name
       </label>
       <input
@@ -76,7 +78,9 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="update-lastName"
+      >
         Last Name
       </label>
       <input
@@ -92,7 +96,9 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="update-email"
+      >
         Email
       </label>
       <input

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/Login-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/Login-test.js.snap
@@ -12,7 +12,9 @@ exports[`Global.SignInUp.Login component renders correctly 1`] = `
       <div
         className="form-input form-error"
       >
-        <label>
+        <label
+          htmlFor="login-email"
+        >
           Email
         </label>
         <input

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/Overlay-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/Overlay-test.js.snap
@@ -55,7 +55,9 @@ exports[`Global.SignInUp.Overlay component renders correctly 1`] = `
               <div
                 className="form-input form-error"
               >
-                <label>
+                <label
+                  htmlFor="login-email"
+                >
                   Email
                 </label>
                 <input

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/PasswordForgot-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/PasswordForgot-test.js.snap
@@ -12,7 +12,9 @@ exports[`Global.SignInUp.PasswordForgot component renders correctly 1`] = `
       <div
         className="form-input form-error"
       >
-        <label>
+        <label
+          htmlFor="password-forgot-email"
+        >
           Email
         </label>
         <div>

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/Update-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/Update-test.js.snap
@@ -56,7 +56,9 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="update-firstName"
+      >
         First Name
       </label>
       <input
@@ -72,7 +74,9 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="update-lastName"
+      >
         Last Name
       </label>
       <input
@@ -88,7 +92,9 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="update-email"
+      >
         Email
       </label>
       <input

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/UpdateForm-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/UpdateForm-test.js.snap
@@ -56,7 +56,9 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="update-firstName"
+      >
         First Name
       </label>
       <input
@@ -72,7 +74,9 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="update-lastName"
+      >
         Last Name
       </label>
       <input
@@ -88,7 +92,9 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="update-email"
+      >
         Email
       </label>
       <input
@@ -213,7 +219,9 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="update-firstName"
+      >
         First Name
       </label>
       <input
@@ -229,7 +237,9 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="update-lastName"
+      >
         Last Name
       </label>
       <input
@@ -245,7 +255,9 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="update-email"
+      >
         Email
       </label>
       <input

--- a/client/src/components/reader/Annotation/Share/Citation.js
+++ b/client/src/components/reader/Annotation/Share/Citation.js
@@ -76,7 +76,9 @@ export default class AnnotationShareEditor extends PureComponent {
       <div className="annotation-editor citation">
         <div>
           <nav className="utility styles">
+            {/* eslint-disable jsx-a11y/label-has-for */}
             <label>Citation Style:</label>
+            {/* eslint-enable jsx-a11y/label-has-for */}
             <ul>{this.renderStyleButtons()}</ul>
           </nav>
           <div

--- a/client/src/components/reader/Notes/Partial/Filters.js
+++ b/client/src/components/reader/Notes/Partial/Filters.js
@@ -49,7 +49,7 @@ export default class Filters extends Component {
   render() {
     return (
       <nav className="filters">
-        <label className="label">Show your:</label>
+        <h4 className="label">Show your:</h4>
         <div className="checkbox-group">
           {this.renderCheckBox("Highlights", "highlight")}
           {this.renderCheckBox("Annotations", "annotation")}

--- a/client/src/components/reader/Notes/Partial/Group.js
+++ b/client/src/components/reader/Notes/Partial/Group.js
@@ -112,12 +112,7 @@ export default class Group extends Component {
       <li>
         <div className={classes} onClick={this.handleClick} role="button">
           <i className={`manicon manicon-caret-down`} aria-hidden="true" />
-          <label>{this.props.sectionName}</label>
-          {this.state.expanded ? (
-            <span className="screen-reader-text">Collapse Notes</span>
-          ) : (
-            <span className="screen-reader-text">Expand Notes</span>
-          )}
+          <h4 className="item-label">{this.props.sectionName}</h4>
         </div>
         {this.renderGroupItems(this.props.annotations)}
       </li>

--- a/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/Filters-test.js.snap
@@ -4,11 +4,11 @@ exports[`Reader.Notes.Partial.Group Component renders correctly 1`] = `
 <nav
   className="filters"
 >
-  <label
+  <h4
     className="label"
   >
     Show your:
-  </label>
+  </h4>
   <div
     className="checkbox-group"
   >

--- a/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/Group-test.js.snap
+++ b/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/Group-test.js.snap
@@ -11,14 +11,11 @@ exports[`Reader.Notes.Partial.Group Component renders correctly 1`] = `
       aria-hidden="true"
       className="manicon manicon-caret-down"
     />
-    <label>
-      Test
-    </label>
-    <span
-      className="screen-reader-text"
+    <h4
+      className="item-label"
     >
-      Expand Notes
-    </span>
+      Test
+    </h4>
   </div>
   <ul
     className=""

--- a/client/src/components/reader/Notes/__tests__/__snapshots__/FilteredList-test.js.snap
+++ b/client/src/components/reader/Notes/__tests__/__snapshots__/FilteredList-test.js.snap
@@ -25,11 +25,11 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
   <nav
     className="filters"
   >
-    <label
+    <h4
       className="label"
     >
       Show your:
-    </label>
+    </h4>
     <div
       className="checkbox-group"
     >
@@ -87,14 +87,11 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
             aria-hidden="true"
             className="manicon manicon-caret-down"
           />
-          <label>
-            Test
-          </label>
-          <span
-            className="screen-reader-text"
+          <h4
+            className="item-label"
           >
-            Expand Notes
-          </span>
+            Test
+          </h4>
         </div>
         <ul
           className=""

--- a/client/src/containers/backend/Collection/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Collection/__tests__/__snapshots__/General-test.js.snap
@@ -35,10 +35,12 @@ exports[`Backend Collection General Container renders correctly 1`] = `
         >
           <label
             className=""
+            htmlFor={undefined}
           >
             Description
           </label>
           <textarea
+            id={undefined}
             onChange={[Function]}
             placeholder="Enter a description"
             style={
@@ -59,12 +61,14 @@ exports[`Backend Collection General Container renders correctly 1`] = `
         >
           <label
             className=""
+            htmlFor={undefined}
           >
             Cover Image
           </label>
           <react-dropzone
             accept="image/*"
             className="form-dropzone style-landscape"
+            id={undefined}
             multiple={false}
             onDrop={[Function]}
             style={undefined}

--- a/client/src/containers/backend/Collection/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Collection/__tests__/__snapshots__/New-test.js.snap
@@ -110,10 +110,12 @@ exports[`Backend Collection New Container renders correctly 1`] = `
               >
                 <label
                   className=""
+                  htmlFor={undefined}
                 >
                   Description
                 </label>
                 <textarea
+                  id={undefined}
                   onChange={[Function]}
                   placeholder="Enter a description"
                   style={
@@ -134,12 +136,14 @@ exports[`Backend Collection New Container renders correctly 1`] = `
               >
                 <label
                   className=""
+                  htmlFor={undefined}
                 >
                   Cover Image
                 </label>
                 <react-dropzone
                   accept="image/*"
                   className="form-dropzone style-landscape"
+                  id={undefined}
                   multiple={false}
                   onDrop={[Function]}
                   style={undefined}

--- a/client/src/containers/backend/Content/Features/Detail.js
+++ b/client/src/containers/backend/Content/Features/Detail.js
@@ -228,7 +228,9 @@ class FeatureDetailContainer extends PureComponent {
                     {previewFeature ? (
                       <div className="form-secondary">
                         <div className="form-input">
-                          <label>Feature Preview</label>
+                          <h4 className="form-input-heading">
+                            Feature Preview
+                          </h4>
                           <span className="instructions">
                             This is an approximate preview of your feature.
                             Foreground, background, and markdown will not be

--- a/client/src/containers/backend/Form/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/containers/backend/Form/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -9,9 +9,11 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <h4
+        className="form-input-heading"
+      >
         Authors
-      </label>
+      </h4>
       <nav
         className="has-many-list"
       >
@@ -62,7 +64,7 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
                 >
                   Click to remove 
                   Rowan Ida
-                  from the 
+                   from the 
                   Authors
                    list.
                 </span>
@@ -111,9 +113,11 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <h4
+        className="form-input-heading"
+      >
         Contributors
-      </label>
+      </h4>
       <nav
         className="has-many-list"
       >
@@ -164,7 +168,7 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
                 >
                   Click to remove 
                   Rowan Ida
-                  from the 
+                   from the 
                   Contributors
                    list.
                 </span>

--- a/client/src/containers/backend/People/Makers/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/People/Makers/__tests__/__snapshots__/Edit-test.js.snap
@@ -115,12 +115,14 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
           >
             <label
               className=""
+              htmlFor={undefined}
             >
               Avatar Image
             </label>
             <react-dropzone
               accept="image/*"
               className="form-dropzone style-square"
+              id={undefined}
               multiple={false}
               onDrop={[Function]}
               style={undefined}

--- a/client/src/containers/backend/People/Makers/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/People/Makers/__tests__/__snapshots__/New-test.js.snap
@@ -101,12 +101,14 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
           >
             <label
               className=""
+              htmlFor={undefined}
             >
               Avatar Image
             </label>
             <react-dropzone
               accept="image/*"
               className="form-dropzone style-square"
+              id={undefined}
               multiple={false}
               onDrop={[Function]}
               style={undefined}

--- a/client/src/containers/backend/People/Users/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/People/Users/__tests__/__snapshots__/Edit-test.js.snap
@@ -106,7 +106,9 @@ exports[`Backend People Users Edit Container renders correctly 1`] = `
             className="form-input"
             style={Object {}}
           >
-            <label>
+            <label
+              htmlFor={undefined}
+            >
               Role
             </label>
             <div
@@ -117,6 +119,7 @@ exports[`Backend People Users Edit Container renders correctly 1`] = `
                 className="manicon manicon-caret-down"
               />
               <select
+                id={undefined}
                 onChange={[Function]}
                 value="admin"
               >

--- a/client/src/containers/backend/People/Users/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/People/Users/__tests__/__snapshots__/New-test.js.snap
@@ -42,7 +42,9 @@ exports[`Backend Users New Container renders correctly 1`] = `
           className="form-input"
           style={Object {}}
         >
-          <label>
+          <label
+            htmlFor="select-2"
+          >
             Role
           </label>
           <div
@@ -53,6 +55,7 @@ exports[`Backend Users New Container renders correctly 1`] = `
               className="manicon manicon-caret-down"
             />
             <select
+              id="select-2"
               onChange={[Function]}
               value="reader"
             >
@@ -91,12 +94,12 @@ exports[`Backend Users New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="text-input-2"
+          htmlFor="text-input-3"
         >
           First Name
         </label>
         <input
-          id="text-input-2"
+          id="text-input-3"
           onChange={[Function]}
           placeholder="First Name"
           type="text"
@@ -109,12 +112,12 @@ exports[`Backend Users New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="text-input-3"
+          htmlFor="text-input-4"
         >
           Last Name
         </label>
         <input
-          id="text-input-3"
+          id="text-input-4"
           onChange={[Function]}
           placeholder="Last Name"
           type="text"
@@ -125,7 +128,9 @@ exports[`Backend Users New Container renders correctly 1`] = `
         className="form-input password-input"
         style={Object {}}
       >
-        <label>
+        <label
+          htmlFor="generated-password-5"
+        >
           Password
         </label>
         <span
@@ -144,6 +149,7 @@ exports[`Backend Users New Container renders correctly 1`] = `
           </span>
         </span>
         <input
+          id="generated-password-5"
           onChange={[Function]}
           placeholder="Enter a password"
           type="password"

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/Edit-test.js.snap
@@ -52,12 +52,11 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
             <div
               className="form-input"
             >
-              <label
-                aria-hidden="true"
+              <h4
                 className="form-input-heading above"
               >
                 Can modify project?
-              </label>
+              </h4>
               <div
                 className="toggle-indicator"
               >
@@ -78,12 +77,11 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
             <div
               className="form-input"
             >
-              <label
-                aria-hidden="true"
+              <h4
                 className="form-input-heading above"
               >
                 Can modify resource metadata?
-              </label>
+              </h4>
               <div
                 className="toggle-indicator"
               >
@@ -104,12 +102,11 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
             <div
               className="form-input"
             >
-              <label
-                aria-hidden="true"
+              <h4
                 className="form-input-heading above"
               >
                 Is a project author?
-              </label>
+              </h4>
               <div
                 className="toggle-indicator"
               >

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/Form-test.js.snap
@@ -63,12 +63,11 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
           <div
             className="form-input"
           >
-            <label
-              aria-hidden="true"
+            <h4
               className="form-input-heading above"
             >
               Can modify project?
-            </label>
+            </h4>
             <div
               className="toggle-indicator"
             >
@@ -89,12 +88,11 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
           <div
             className="form-input"
           >
-            <label
-              aria-hidden="true"
+            <h4
               className="form-input-heading above"
             >
               Can modify resource metadata?
-            </label>
+            </h4>
             <div
               className="toggle-indicator"
             >
@@ -115,12 +113,11 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
           <div
             className="form-input"
           >
-            <label
-              aria-hidden="true"
+            <h4
               className="form-input-heading above"
             >
               Is a project author?
-            </label>
+            </h4>
             <div
               className="toggle-indicator"
             >

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/New-test.js.snap
@@ -73,12 +73,11 @@ exports[`Backend Permission New Container renders correctly 1`] = `
             <div
               className="form-input"
             >
-              <label
-                aria-hidden="true"
+              <h4
                 className="form-input-heading above"
               >
                 Can modify project?
-              </label>
+              </h4>
               <div
                 className="toggle-indicator"
               >
@@ -99,12 +98,11 @@ exports[`Backend Permission New Container renders correctly 1`] = `
             <div
               className="form-input"
             >
-              <label
-                aria-hidden="true"
+              <h4
                 className="form-input-heading above"
               >
                 Can modify resource metadata?
-              </label>
+              </h4>
               <div
                 className="toggle-indicator"
               >
@@ -125,12 +123,11 @@ exports[`Backend Permission New Container renders correctly 1`] = `
             <div
               className="form-input"
             >
-              <label
-                aria-hidden="true"
+              <h4
                 className="form-input-heading above"
               >
                 Is a project author?
-              </label>
+              </h4>
               <div
                 className="toggle-indicator"
               >

--- a/client/src/containers/backend/Project/Text/Ingestion/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/Project/Text/Ingestion/__tests__/__snapshots__/Edit-test.js.snap
@@ -14,15 +14,25 @@ exports[`Project Text Ingestion Edit Container renders correctly 1`] = `
         <div
           className="form-input"
         >
-          <label
-            style={
-              Object {
-                "marginBottom": "1.5em",
+          <div>
+            <span
+              className="screen-reader-text"
+            >
+              Select a 
+              Text Format
+            </span>
+            <h4
+              aria-hidden="true"
+              className="form-input-heading"
+              style={
+                Object {
+                  "marginBottom": "1.5em",
+                }
               }
-            }
-          >
-            Text Format
-          </label>
+            >
+              Text Format
+            </h4>
+          </div>
           <label
             className="form-toggle radio"
             htmlFor="epub"

--- a/client/src/containers/backend/Project/Text/Ingestion/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Project/Text/Ingestion/__tests__/__snapshots__/New-test.js.snap
@@ -14,15 +14,25 @@ exports[`Project Text Ingestion New Container renders correctly 1`] = `
         <div
           className="form-input"
         >
-          <label
-            style={
-              Object {
-                "marginBottom": "1.5em",
+          <div>
+            <span
+              className="screen-reader-text"
+            >
+              Select a 
+              Text Format
+            </span>
+            <h4
+              aria-hidden="true"
+              className="form-input-heading"
+              style={
+                Object {
+                  "marginBottom": "1.5em",
+                }
               }
-            }
-          >
-            Text Format
-          </label>
+            >
+              Text Format
+            </h4>
+          </div>
           <label
             className="form-toggle radio"
             htmlFor="epub"

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -10,9 +10,11 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <label>
+        <h4
+          className="form-input-heading"
+        >
           Authors
-        </label>
+        </h4>
         <nav
           className="has-many-list"
         >
@@ -63,7 +65,7 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
                   >
                     Click to remove 
                     Rowan Ida
-                    from the 
+                     from the 
                     Authors
                      list.
                   </span>
@@ -112,9 +114,11 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <label>
+        <h4
+          className="form-input-heading"
+        >
           Contributors
-        </label>
+        </h4>
         <nav
           className="has-many-list"
         >
@@ -165,7 +169,7 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
                   >
                     Click to remove 
                     Rowan Ida
-                    from the 
+                     from the 
                     Contributors
                      list.
                   </span>

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/General-test.js.snap
@@ -107,12 +107,11 @@ exports[`Backend Project General Container renders correctly 1`] = `
               </span>
             </div>
           </div>
-          <label
-            aria-hidden="true"
+          <h4
             className="form-input-heading below secondary"
           >
             Draft Mode
-          </label>
+          </h4>
         </div>
         <div
           className="form-input"
@@ -133,12 +132,11 @@ exports[`Backend Project General Container renders correctly 1`] = `
               </span>
             </div>
           </div>
-          <label
-            aria-hidden="true"
+          <h4
             className="form-input-heading below secondary"
           >
             Featured
-          </label>
+          </h4>
         </div>
       </div>
       <div
@@ -156,6 +154,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
         >
           <label
             className=""
+            htmlFor={undefined}
           >
             Hashtag
           </label>
@@ -247,9 +246,11 @@ exports[`Backend Project General Container renders correctly 1`] = `
         <div
           className="form-input"
         >
-          <label>
+          <h4
+            className="form-input-heading"
+          >
             Publication Date
-          </label>
+          </h4>
           <div
             className="form-date"
           >
@@ -445,9 +446,11 @@ exports[`Backend Project General Container renders correctly 1`] = `
           className="form-input"
           style={Object {}}
         >
-          <label>
+          <h4
+            className="form-input-heading"
+          >
             Subjects
-          </label>
+          </h4>
           <nav
             className="has-many-list"
           >
@@ -474,7 +477,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
                     >
                       Click to remove 
                       Hip Hop
-                      from the 
+                       from the 
                       Subjects
                        list.
                     </span>
@@ -522,11 +525,11 @@ exports[`Backend Project General Container renders correctly 1`] = `
         <div
           className="form-input avatar-builder"
         >
-          <label
-            className="section-header"
+          <h4
+            className="form-input-heading"
           >
             Project Thumbnail
-          </label>
+          </h4>
           <div
             className="grid"
           >
@@ -728,6 +731,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
                   <react-dropzone
                     accept="image/*"
                     className="form-dropzone style-embed"
+                    id={undefined}
                     multiple={false}
                     onDrop={[Function]}
                     style={undefined}

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/New-test.js.snap
@@ -129,10 +129,12 @@ exports[`Backend Project New Container renders correctly 1`] = `
                 >
                   <label
                     className=""
+                    htmlFor={undefined}
                   >
                     Description
                   </label>
                   <textarea
+                    id={undefined}
                     onChange={[Function]}
                     placeholder={undefined}
                     style={

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/ProjectPage-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/ProjectPage-test.js.snap
@@ -17,6 +17,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
         >
           <label
             className="has-instructions"
+            htmlFor={undefined}
           >
             Description
           </label>
@@ -26,6 +27,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
             Enter a brief description of your project. This field accepts basic Markdown.
           </span>
           <textarea
+            id={undefined}
             onChange={[Function]}
             placeholder={undefined}
             style={
@@ -46,6 +48,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
         >
           <label
             className=""
+            htmlFor={undefined}
           >
             Hero Image
           </label>
@@ -61,6 +64,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           <react-dropzone
             accept="image/*"
             className="form-dropzone style-landscape"
+            id={undefined}
             multiple={false}
             onDrop={[Function]}
             style={undefined}
@@ -108,6 +112,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
         >
           <label
             className="has-instructions"
+            htmlFor={undefined}
           >
             Cover
           </label>
@@ -119,6 +124,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           <react-dropzone
             accept="image/*"
             className="form-dropzone style-portrait"
+            id={undefined}
             multiple={false}
             onDrop={[Function]}
             style={undefined}
@@ -208,6 +214,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
+          htmlFor={undefined}
         >
           Purchase Price
         </label>
@@ -217,6 +224,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           The cost of the published edition
         </span>
         <react-text-mask
+          id={undefined}
           mask={[Function]}
           onChange={[Function]}
           placeholder={undefined}
@@ -297,12 +305,11 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
       <div
         className="form-input"
       >
-        <label
-          aria-hidden="true"
+        <h4
           className="form-input-heading above"
         >
           Hide Project Activity
-        </label>
+        </h4>
         <div
           className="toggle-indicator"
         >

--- a/client/src/containers/backend/Resource/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Resource/__tests__/__snapshots__/General-test.js.snap
@@ -14,7 +14,9 @@ exports[`Backend Resource General Container renders correctly 1`] = `
         <div
           className="form-input"
         >
-          <label>
+          <label
+            htmlFor={undefined}
+          >
             Kind
           </label>
           <div
@@ -28,6 +30,7 @@ exports[`Backend Resource General Container renders correctly 1`] = `
                 className="manicon manicon-caret-down"
               />
               <select
+                id={undefined}
                 onChange={[Function]}
                 value="image"
               >
@@ -182,10 +185,12 @@ exports[`Backend Resource General Container renders correctly 1`] = `
         >
           <label
             className=""
+            htmlFor={undefined}
           >
             Description
           </label>
           <textarea
+            id={undefined}
             onChange={[Function]}
             placeholder="Enter a description"
             style={
@@ -206,10 +211,12 @@ exports[`Backend Resource General Container renders correctly 1`] = `
         >
           <label
             className=""
+            htmlFor={undefined}
           >
             Caption
           </label>
           <textarea
+            id={undefined}
             onChange={[Function]}
             placeholder="Enter a short description"
             style={
@@ -230,12 +237,14 @@ exports[`Backend Resource General Container renders correctly 1`] = `
         >
           <label
             className=""
+            htmlFor={undefined}
           >
             Image File
           </label>
           <react-dropzone
             accept="image/*"
             className="form-dropzone style-square"
+            id={undefined}
             multiple={false}
             onDrop={[Function]}
             style={undefined}

--- a/client/src/containers/backend/Resource/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Resource/__tests__/__snapshots__/New-test.js.snap
@@ -89,7 +89,9 @@ exports[`Backend Resource New Container renders correctly 1`] = `
               <div
                 className="form-input"
               >
-                <label>
+                <label
+                  htmlFor={undefined}
+                >
                   Kind
                 </label>
                 <div
@@ -103,6 +105,7 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                       className="manicon manicon-caret-down"
                     />
                     <select
+                      id={undefined}
                       onChange={[Function]}
                       value="image"
                     >
@@ -570,10 +573,12 @@ exports[`Backend Resource New Container renders correctly 1`] = `
               >
                 <label
                   className=""
+                  htmlFor={undefined}
                 >
                   Description
                 </label>
                 <textarea
+                  id={undefined}
                   onChange={[Function]}
                   placeholder="Enter a description"
                   style={
@@ -594,12 +599,14 @@ exports[`Backend Resource New Container renders correctly 1`] = `
               >
                 <label
                   className=""
+                  htmlFor={undefined}
                 >
                   Image File
                 </label>
                 <react-dropzone
                   accept="image/*"
                   className="form-dropzone style-square"
+                  id={undefined}
                   multiple={false}
                   onDrop={[Function]}
                   style={undefined}

--- a/client/src/containers/backend/Resource/__tests__/__snapshots__/Variants-test.js.snap
+++ b/client/src/containers/backend/Resource/__tests__/__snapshots__/Variants-test.js.snap
@@ -20,12 +20,14 @@ exports[`Backend Resource Variants Container renders correctly 1`] = `
           >
             <label
               className=""
+              htmlFor={undefined}
             >
               High Resolution Image
             </label>
             <react-dropzone
               accept="image/*"
               className="form-dropzone style-square"
+              id={undefined}
               multiple={false}
               onDrop={[Function]}
               style={undefined}
@@ -73,12 +75,14 @@ exports[`Backend Resource Variants Container renders correctly 1`] = `
           >
             <label
               className=""
+              htmlFor={undefined}
             >
               Thumbnail Image
             </label>
             <react-dropzone
               accept="image/*"
               className="form-dropzone style-square"
+              id={undefined}
               multiple={false}
               onDrop={[Function]}
               style={undefined}

--- a/client/src/containers/backend/Settings/__tests__/__snapshots__/Email-test.js.snap
+++ b/client/src/containers/backend/Settings/__tests__/__snapshots__/Email-test.js.snap
@@ -29,7 +29,7 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
       >
         <label
           className="has-instructions"
-          htmlFor="text-input-9"
+          htmlFor="text-input-11"
         >
           Email from address
         </label>
@@ -37,52 +37,6 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
           className="instructions"
         >
           All emails sent by manifold will be from this address.
-        </span>
-        <input
-          id="text-input-9"
-          onChange={[Function]}
-          placeholder="do-not-reply@manifoldapp.org"
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        className="form-input"
-        style={Object {}}
-      >
-        <label
-          className="has-instructions"
-          htmlFor="text-input-10"
-        >
-          Email from name
-        </label>
-        <span
-          className="instructions"
-        >
-          All emails sent by manifold will appear to be sent by this name.
-        </span>
-        <input
-          id="text-input-10"
-          onChange={[Function]}
-          placeholder="Manifold Scholarship"
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        className="form-input"
-        style={Object {}}
-      >
-        <label
-          className="has-instructions"
-          htmlFor="text-input-11"
-        >
-          Email reply-to address
-        </label>
-        <span
-          className="instructions"
-        >
-          Replies to emails sent by Manifold will go to this address.
         </span>
         <input
           id="text-input-11"
@@ -100,6 +54,52 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
           className="has-instructions"
           htmlFor="text-input-12"
         >
+          Email from name
+        </label>
+        <span
+          className="instructions"
+        >
+          All emails sent by manifold will appear to be sent by this name.
+        </span>
+        <input
+          id="text-input-12"
+          onChange={[Function]}
+          placeholder="Manifold Scholarship"
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        className="form-input"
+        style={Object {}}
+      >
+        <label
+          className="has-instructions"
+          htmlFor="text-input-13"
+        >
+          Email reply-to address
+        </label>
+        <span
+          className="instructions"
+        >
+          Replies to emails sent by Manifold will go to this address.
+        </span>
+        <input
+          id="text-input-13"
+          onChange={[Function]}
+          placeholder="do-not-reply@manifoldapp.org"
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        className="form-input"
+        style={Object {}}
+      >
+        <label
+          className="has-instructions"
+          htmlFor="text-input-14"
+        >
           Email reply-to name
         </label>
         <span
@@ -108,7 +108,7 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
           Replies to emails sent by Manifold will appear to be sent by this name.
         </span>
         <input
-          id="text-input-12"
+          id="text-input-14"
           onChange={[Function]}
           placeholder={undefined}
           type="text"
@@ -124,6 +124,7 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
         >
           <label
             className="has-instructions"
+            htmlFor="textarea-15"
           >
             Email closing
           </label>
@@ -133,6 +134,7 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
             How do you want to close emails sent by Manifold?
           </span>
           <textarea
+            id="textarea-15"
             onChange={[Function]}
             placeholder="Sincerely,
 The Manifold Team"
@@ -152,7 +154,9 @@ The Manifold Team"
           className="form-input"
           style={Object {}}
         >
-          <label>
+          <label
+            htmlFor="select-16"
+          >
             Email Delivery Method
           </label>
           <div
@@ -163,6 +167,7 @@ The Manifold Team"
               className="manicon manicon-caret-down"
             />
             <select
+              id="select-16"
               onChange={[Function]}
               value={undefined}
             >
@@ -194,7 +199,7 @@ The Manifold Team"
         >
           <label
             className="has-instructions"
-            htmlFor="text-input-13"
+            htmlFor="text-input-17"
           >
             Sendmail Location
           </label>
@@ -204,7 +209,7 @@ The Manifold Team"
             The location of the sendmail executable. Defaults to /usr/sbin/sendmail.
           </span>
           <input
-            id="text-input-13"
+            id="text-input-17"
             onChange={[Function]}
             placeholder={undefined}
             type="text"
@@ -217,7 +222,7 @@ The Manifold Team"
         >
           <label
             className="has-instructions"
-            htmlFor="text-input-14"
+            htmlFor="text-input-18"
           >
             Sendmail Arguments
           </label>
@@ -227,7 +232,7 @@ The Manifold Team"
             The command line arguments. Defaults to -i with -f sender@address added automatically before the message is sent.
           </span>
           <input
-            id="text-input-14"
+            id="text-input-18"
             onChange={[Function]}
             placeholder={undefined}
             type="text"
@@ -373,6 +378,7 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
         >
           <label
             className="has-instructions"
+            htmlFor="textarea-5"
           >
             Email closing
           </label>
@@ -382,6 +388,7 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
             How do you want to close emails sent by Manifold?
           </span>
           <textarea
+            id="textarea-5"
             onChange={[Function]}
             placeholder="Sincerely,
 The Manifold Team"
@@ -401,7 +408,9 @@ The Manifold Team"
           className="form-input"
           style={Object {}}
         >
-          <label>
+          <label
+            htmlFor="select-6"
+          >
             Email Delivery Method
           </label>
           <div
@@ -412,6 +421,7 @@ The Manifold Team"
               className="manicon manicon-caret-down"
             />
             <select
+              id="select-6"
               onChange={[Function]}
               value={undefined}
             >
@@ -443,7 +453,7 @@ The Manifold Team"
         >
           <label
             className="has-instructions"
-            htmlFor="text-input-5"
+            htmlFor="text-input-7"
           >
             SMTP Address
           </label>
@@ -451,52 +461,6 @@ The Manifold Team"
             className="instructions"
           >
             Allows you to use a remote mail server.
-          </span>
-          <input
-            id="text-input-5"
-            onChange={[Function]}
-            placeholder={undefined}
-            type="text"
-            value=""
-          />
-        </div>
-        <div
-          className="form-input"
-          style={Object {}}
-        >
-          <label
-            className="has-instructions"
-            htmlFor="text-input-6"
-          >
-            SMTP Port
-          </label>
-          <span
-            className="instructions"
-          >
-            On the off chance that your mail server doesn't run on port 25, you can change it.
-          </span>
-          <input
-            id="text-input-6"
-            onChange={[Function]}
-            placeholder={undefined}
-            type="text"
-            value=""
-          />
-        </div>
-        <div
-          className="form-input"
-          style={Object {}}
-        >
-          <label
-            className="has-instructions"
-            htmlFor="text-input-7"
-          >
-            SMTP Username
-          </label>
-          <span
-            className="instructions"
-          >
-            If your mail server requires authentication, set the username in this setting.
           </span>
           <input
             id="text-input-7"
@@ -514,6 +478,52 @@ The Manifold Team"
             className="has-instructions"
             htmlFor="text-input-8"
           >
+            SMTP Port
+          </label>
+          <span
+            className="instructions"
+          >
+            On the off chance that your mail server doesn't run on port 25, you can change it.
+          </span>
+          <input
+            id="text-input-8"
+            onChange={[Function]}
+            placeholder={undefined}
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          className="form-input"
+          style={Object {}}
+        >
+          <label
+            className="has-instructions"
+            htmlFor="text-input-9"
+          >
+            SMTP Username
+          </label>
+          <span
+            className="instructions"
+          >
+            If your mail server requires authentication, set the username in this setting.
+          </span>
+          <input
+            id="text-input-9"
+            onChange={[Function]}
+            placeholder={undefined}
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          className="form-input"
+          style={Object {}}
+        >
+          <label
+            className="has-instructions"
+            htmlFor="text-input-10"
+          >
             SMTP Password
           </label>
           <span
@@ -522,7 +532,7 @@ The Manifold Team"
             If your mail server requires authentication, set the password in this setting.
           </span>
           <input
-            id="text-input-8"
+            id="text-input-10"
             onChange={[Function]}
             placeholder={undefined}
             type="password"

--- a/client/src/containers/backend/Settings/__tests__/__snapshots__/Integrations-test.js.snap
+++ b/client/src/containers/backend/Settings/__tests__/__snapshots__/Integrations-test.js.snap
@@ -158,12 +158,14 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
         >
           <label
             className=""
+            htmlFor={undefined}
           >
             Google Service Config File
           </label>
           <react-dropzone
             accept="application/json"
             className="form-dropzone style-square"
+            id={undefined}
             multiple={false}
             onDrop={[Function]}
             style={undefined}
@@ -211,10 +213,12 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
         >
           <label
             className=""
+            htmlFor={undefined}
           >
             Google Private Key
           </label>
           <textarea
+            id={undefined}
             onChange={[Function]}
             placeholder={undefined}
             style={
@@ -361,10 +365,12 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
+          htmlFor={undefined}
         >
           Google Analytics Profile ID
         </label>
         <react-text-mask
+          id={undefined}
           mask={
             Array [
               "g",

--- a/client/src/containers/backend/Settings/__tests__/__snapshots__/Theme-test.js.snap
+++ b/client/src/containers/backend/Settings/__tests__/__snapshots__/Theme-test.js.snap
@@ -17,6 +17,7 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
         >
           <label
             className="has-instructions"
+            htmlFor={undefined}
           >
             Press Logo
           </label>
@@ -28,6 +29,7 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
           <react-dropzone
             accept="image/*"
             className="form-dropzone style-square"
+            id={undefined}
             multiple={false}
             onDrop={[Function]}
             style={undefined}

--- a/client/src/containers/backend/Text/Ingestion/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/Text/Ingestion/__tests__/__snapshots__/Edit-test.js.snap
@@ -14,15 +14,25 @@ exports[`Backend Text Ingestion Edit Container renders correctly 1`] = `
         <div
           className="form-input"
         >
-          <label
-            style={
-              Object {
-                "marginBottom": "1.5em",
+          <div>
+            <span
+              className="screen-reader-text"
+            >
+              Select a 
+              Text Format
+            </span>
+            <h4
+              aria-hidden="true"
+              className="form-input-heading"
+              style={
+                Object {
+                  "marginBottom": "1.5em",
+                }
               }
-            }
-          >
-            Text Format
-          </label>
+            >
+              Text Format
+            </h4>
+          </div>
           <label
             className="form-toggle radio"
             htmlFor="epub"

--- a/client/src/containers/backend/Text/Ingestion/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Text/Ingestion/__tests__/__snapshots__/New-test.js.snap
@@ -14,15 +14,25 @@ exports[`Backend Text Ingestion New Container renders correctly 1`] = `
         <div
           className="form-input"
         >
-          <label
-            style={
-              Object {
-                "marginBottom": "1.5em",
+          <div>
+            <span
+              className="screen-reader-text"
+            >
+              Select a 
+              Text Format
+            </span>
+            <h4
+              aria-hidden="true"
+              className="form-input-heading"
+              style={
+                Object {
+                  "marginBottom": "1.5em",
+                }
               }
-            }
-          >
-            Text Format
-          </label>
+            >
+              Text Format
+            </h4>
+          </div>
           <label
             className="form-toggle radio"
             htmlFor="epub"

--- a/client/src/containers/backend/Text/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/containers/backend/Text/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -10,9 +10,11 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <label>
+        <h4
+          className="form-input-heading"
+        >
           Authors
-        </label>
+        </h4>
         <nav
           className="has-many-list"
         >
@@ -63,7 +65,7 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
                   >
                     Click to remove 
                     Rowan Ida
-                    from the 
+                     from the 
                     Authors
                      list.
                   </span>
@@ -112,9 +114,11 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <label>
+        <h4
+          className="form-input-heading"
+        >
           Contributors
-        </label>
+        </h4>
         <nav
           className="has-many-list"
         >
@@ -165,7 +169,7 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
                   >
                     Click to remove 
                     Rowan Ida
-                    from the 
+                     from the 
                     Contributors
                      list.
                   </span>

--- a/client/src/containers/backend/Text/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Text/__tests__/__snapshots__/General-test.js.snap
@@ -29,9 +29,11 @@ exports[`Backend Text General Container renders correctly 1`] = `
       <div
         className="form-input"
       >
-        <label>
+        <h4
+          className="form-input-heading"
+        >
           Publication Date
-        </label>
+        </h4>
         <div
           className="form-date"
         >
@@ -245,10 +247,12 @@ exports[`Backend Text General Container renders correctly 1`] = `
         >
           <label
             className=""
+            htmlFor={undefined}
           >
             Description
           </label>
           <textarea
+            id={undefined}
             onChange={[Function]}
             placeholder="Enter a Brief Description"
             style={

--- a/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/Edit-test.js.snap
@@ -87,7 +87,9 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
             className="form-input"
             style={Object {}}
           >
-            <label>
+            <label
+              htmlFor={undefined}
+            >
               Fetch tweets by:
             </label>
             <div
@@ -98,6 +100,7 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
                 className="manicon manicon-caret-down"
               />
               <select
+                id={undefined}
                 onChange={[Function]}
                 value={undefined}
               >
@@ -118,12 +121,11 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
         <div
           className="form-input"
         >
-          <label
-            aria-hidden="true"
+          <h4
             className="form-input-heading above"
           >
             Active
-          </label>
+          </h4>
           <div
             className="toggle-indicator"
           >

--- a/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/New-test.js.snap
@@ -55,7 +55,9 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
           className="form-input"
           style={Object {}}
         >
-          <label>
+          <label
+            htmlFor={undefined}
+          >
             Fetch tweets by:
           </label>
           <div
@@ -66,6 +68,7 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
               className="manicon manicon-caret-down"
             />
             <select
+              id={undefined}
               onChange={[Function]}
               value={undefined}
             >
@@ -86,12 +89,11 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
       <div
         className="form-input"
       >
-        <label
-          aria-hidden="true"
+        <h4
           className="form-input-heading above"
         >
           Active
-        </label>
+        </h4>
         <div
           className="toggle-indicator"
         >

--- a/client/src/containers/frontend/Contact.js
+++ b/client/src/containers/frontend/Contact.js
@@ -75,7 +75,7 @@ export class ContactContainer extends Component {
                 name="attributes[email]"
                 errors={errors}
               >
-                <label>Email</label>
+                <label htmlFor="create-email">Email</label>
                 <input
                   value={this.state.contact.email}
                   type="text"
@@ -92,7 +92,7 @@ export class ContactContainer extends Component {
                 name={"attributes[fullName]"}
                 errors={errors}
               >
-                <label>Name</label>
+                <label htmlFor="create-name">Name</label>
                 <input
                   value={this.state.contact.fullName}
                   type="text"
@@ -109,7 +109,7 @@ export class ContactContainer extends Component {
                 name="attributes[message]"
                 errors={errors}
               >
-                <label>Message</label>
+                <label htmlFor="create-message">Message</label>
                 <textarea
                   value={this.state.contact.message}
                   type="message"

--- a/client/src/theme/Components/global/_confirmable-buttons.scss
+++ b/client/src/theme/Components/global/_confirmable-buttons.scss
@@ -3,8 +3,9 @@
   flex-direction: column;
   align-items: flex-start;
 
-  label {
+  .confirmation-label {
     @include utilityPrimary;
+    font-size: 14px;
     color: $neutral80;
   }
 

--- a/client/src/theme/Components/global/forms/_form-inputs-primary.scss
+++ b/client/src/theme/Components/global/forms/_form-inputs-primary.scss
@@ -403,8 +403,8 @@
   }
 
   .column-mappable {
-    width: 100%;
     flex-grow: 1;
+    width: 100%;
 
     @include respond($break80) {
       width: calc(100% - 28vw);

--- a/client/src/theme/Components/global/forms/_form-inputs-secondary.scss
+++ b/client/src/theme/Components/global/forms/_form-inputs-secondary.scss
@@ -28,6 +28,7 @@
       // Important required to override chrome default
       // scss-lint:disable ImportantRule
       -webkit-text-fill-color: $accentPrimaryPale !important;
+      // scss-lint:enable ImportantRule
     }
   }
 
@@ -65,7 +66,7 @@
   .instructions {
     @include templateCopy;
     display: block;
-    margin-bottom: .5em;
+    margin-bottom: 0.5em;
     font-size: 15px;
     font-style: italic;
     color: $neutral50;
@@ -85,19 +86,20 @@
   }
 
   .form-input {
-    label:not(.checkbox):not(.radio) {
+    .form-input-heading, .column-heading, label:not(.checkbox):not(.radio) {
       @include formLabelPrimary;
       display: block;
-      margin-bottom: .5em;
+      margin-top: 0;
+      margin-bottom: 0.5em;
       color: $neutral75;
 
       &.below {
-        margin-top: .6em;
+        margin-top: 0.6em;
         margin-bottom: 0;
       }
 
       &.has-instructions {
-        margin-bottom: .5em;
+        margin-bottom: 0.5em;
       }
 
       &.secondary {

--- a/client/src/theme/Components/reader/_notes.scss
+++ b/client/src/theme/Components/reader/_notes.scss
@@ -65,13 +65,13 @@
       .item {
         display: flex;
         align-items: center;
-        padding: 18px 20px;
-        max-height: 52px;
         justify-content: flex-start;
+        max-height: 52px;
+        padding: 18px 20px;
         color: $neutral90;
         border-bottom: 2px solid $neutral40;
         transition: color $duration $timing,
-        background-color $duration $timing;
+          background-color $duration $timing;
 
         @include respond($break65) {
           padding: 18px 32px;
@@ -86,19 +86,20 @@
 
         i {
           font-size: 8px;
-          transform: rotate(-.25turn);
           transition: transform $duration $timing;
+          transform: rotate(-0.25turn);
         }
 
-        label, span {
+        label, span, .item-label {
           @include utilityPrimary;
           margin-top: -2px;
+          margin-bottom: 0;
           margin-left: 20px;
-          color: inherit;
-          cursor: inherit;
-          text-transform: none;
           font-size: 16px;
+          color: inherit;
+          text-transform: none;
           letter-spacing: 0;
+          cursor: inherit;
 
           @include respond($break50) {
             font-size: 18px;
@@ -106,8 +107,8 @@
         }
 
         &:hover {
-          cursor: pointer;
           color: $neutral75;
+          cursor: pointer;
           background-color: $accentPrimaryLight;
         }
       }
@@ -116,12 +117,12 @@
         overflow: hidden;
 
         .item {
-          padding: 18px 20px 18px 20px;
           justify-content: flex-start;
+          padding: 18px 20px;
           color: $neutral90;
           border-bottom: none;
           transition: color $duration $timing,
-          background-color $duration $timing;
+            background-color $duration $timing;
 
           @include respond($break65) {
             padding: 18px 32px 18px 60px;
@@ -129,8 +130,8 @@
 
           i {
             font-size: 20px;
-            transform: rotate(0);
             color: $neutral50;
+            transform: rotate(0);
 
             @include respond($break50) {
               font-size: 21px;
@@ -180,9 +181,13 @@
       }
 
       .label {
-        color: $neutral70;
+        @include utilityPrimary;
+        display: inline-block;
         padding-right: 18px;
         margin-top: -2px;
+        margin-bottom: 0;
+        font-size: 14px;
+        color: $neutral70;
       }
 
       .checkbox-group {

--- a/client/src/theme/Components/reader/search/_query.scss
+++ b/client/src/theme/Components/reader/search/_query.scss
@@ -3,7 +3,7 @@
   input[type='text'] {
     @include templateHead;
     width: 100%;
-    padding: 0.444em 0.889em 0.444em;
+    padding: 0.444em 0.889em;
     font-size: 16px;
     color: $neutralOffBlack;
     background-color: $neutral05;
@@ -94,17 +94,27 @@
     }
 
     .group-label {
+      @include utilityPrimary;
       position: relative;
       display: block;
-      margin-right: 36px;
       padding-top: 2px;
+      margin-top:  0;
+      margin-right: 36px;
       margin-bottom: 10px;
+      font-size: 13px;
+      font-weight: $semibold;
+      color: $neutral70;
+      text-transform: uppercase;
+
+      @include respond($break40) {
+        font-size: 14px;
+      }
     }
 
     .checkbox {
-      width: 100%;
       position: relative;
       display: block;
+      width: 100%;
       margin-right: 36px;
       margin-bottom: 10px;
       cursor: pointer;


### PR DESCRIPTION
Resolves #1088
Related to #1101

Some Screen Readers have a "Form Mode" where each form element's description is drawn directly from its context.  If that form control does not have a properly associated label then that description might be drawn from non-associated text.  This PR ensures all labels for form controls currently implemented have the correct attributes to associate them with their form controls.  IT DOES NOT ensure that all form controls have labels.  Incidentally, for the sake of consistency, and in an effort to honor html elements' intrinsic uses, all labels not used to describe form controls were reformatted as h4s and restyled to be match their initial aesthetic as in almost all cases they were being used as a section heading.

In one case I could not find the react component in the frontend end so elected to leave its markup and styles as is until its whereabouts are better known: `client/src/components/reader/Annotation/Share/Citation.js`