### PR TITLE
All checkbox and radio inputs have labels or other descriptive text

### DIFF
--- a/client/src/components/global/Search/Query/Form.js
+++ b/client/src/components/global/Search/Query/Form.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
+import uniqueId from "lodash/uniqueId";
 
 export default class SearchQuery extends PureComponent {
   static displayName = "Search.Query";
@@ -160,10 +161,17 @@ export default class SearchQuery extends PureComponent {
                 <label className="group-label">{"Search within:"}</label>
               ) : null}
               {this.props.scopes.map(scope => {
+                const filterCheckboxId = uniqueId(scope.value + "-");
+
                 return (
-                  <label key={scope.value} className="checkbox">
+                  <label
+                    htmlFor={filterCheckboxId}
+                    key={scope.value}
+                    className="checkbox"
+                  >
                     <input
                       type="checkbox"
+                      id={filterCheckboxId}
                       checked={this.state.scope === scope.value}
                       onChange={this.makeScopeHandler(scope.value)}
                     />
@@ -182,9 +190,10 @@ export default class SearchQuery extends PureComponent {
           <div className="filters">
             <label className="group-label">{"Show Results For:"}</label>
             <div className="checkbox-group">
-              <label key={"all"} className="checkbox">
+              <label htmlFor="all-filters" key={"all"} className="checkbox">
                 <input
                   type="checkbox"
+                  id="all-filters"
                   checked={this.existsInState("facets", "All")}
                   onChange={this.makeFacetHandler("facets", "All")}
                 />
@@ -195,10 +204,17 @@ export default class SearchQuery extends PureComponent {
                 {"Everything"}
               </label>
               {this.props.facets.map(facet => {
+                const facetCheckboxId = uniqueId(facet.value + "-");
+
                 return (
-                  <label key={facet.value} className="checkbox">
+                  <label
+                    htmlFor={facetCheckboxId}
+                    key={facet.value}
+                    className="checkbox"
+                  >
                     <input
                       type="checkbox"
+                      id={facetCheckboxId}
                       checked={this.existsInState("facets", facet.value)}
                       onChange={this.makeFacetHandler("facets", facet.value)}
                     />

--- a/client/src/components/reader/Annotation/Editor.js
+++ b/client/src/components/reader/Annotation/Editor.js
@@ -118,9 +118,10 @@ export default class AnnotationSelectionEditor extends PureComponent {
           </GlobalForm.Errorable>
           <div className="utility">
             <div className="form-input">
-              <label className={checkClass}>
+              <label htmlFor="private-annotation" className={checkClass}>
                 <input
                   type="checkbox"
+                  id="private-annotation"
                   name="isPrivate"
                   value="1"
                   checked={this.state.isPrivate}

--- a/client/src/components/reader/Annotation/Selection/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/components/reader/Annotation/Selection/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -52,9 +52,11 @@ exports[`Reader.Annotation.Selection.Wrapper component renders correctly 1`] = `
         >
           <label
             className="form-toggle checkbox"
+            htmlFor="private-annotation"
           >
             <input
               checked={false}
+              id="private-annotation"
               name="isPrivate"
               onChange={[Function]}
               type="checkbox"

--- a/client/src/components/reader/Annotation/__tests__/__snapshots__/Editor-test.js.snap
+++ b/client/src/components/reader/Annotation/__tests__/__snapshots__/Editor-test.js.snap
@@ -30,9 +30,11 @@ exports[`Reader.Annotation.Editor component renders correctly 1`] = `
       >
         <label
           className="form-toggle checkbox"
+          htmlFor="private-annotation"
         >
           <input
             checked={false}
+            id="private-annotation"
             name="isPrivate"
             onChange={[Function]}
             type="checkbox"

--- a/client/src/components/reader/ControlMenu/VisibilityMenuBody.js
+++ b/client/src/components/reader/ControlMenu/VisibilityMenuBody.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import capitalize from "lodash/capitalize";
+import uniqueId from "lodash/uniqueId";
 
 export default class VisibilityMenuBody extends PureComponent {
   static displayName = "ControlMenu.VisibilityMenuBody";
@@ -54,12 +55,14 @@ export default class VisibilityMenuBody extends PureComponent {
 
   renderCheckbox(key, filterState, format) {
     let label = capitalize(key);
+    const checkboxId = uniqueId(label + "-checkbox-");
     if (key === "all") label = "Show All";
 
     return (
-      <label className="checkbox" key={`${format}-${key}`}>
+      <label htmlFor={checkboxId} className="checkbox" key={`${format}-${key}`}>
         <input
           type="checkbox"
+          id={checkboxId}
           checked={filterState[key]}
           onChange={() => this.handleFilterClick(format, key)}
         />

--- a/client/src/components/reader/ControlMenu/__tests__/__snapshots__/VisibilityMenuBody-test.js.snap
+++ b/client/src/components/reader/ControlMenu/__tests__/__snapshots__/VisibilityMenuBody-test.js.snap
@@ -18,9 +18,11 @@ exports[`Reader.ControlMenu.VisibilityMenuBody Component renders correctly 1`] =
       >
         <label
           className="checkbox"
+          htmlFor="Yours-checkbox-1"
         >
           <input
             checked={true}
+            id="Yours-checkbox-1"
             onChange={[Function]}
             type="checkbox"
           />
@@ -36,9 +38,11 @@ exports[`Reader.ControlMenu.VisibilityMenuBody Component renders correctly 1`] =
         </label>
         <label
           className="checkbox"
+          htmlFor="Others-checkbox-2"
         >
           <input
             checked={true}
+            id="Others-checkbox-2"
             onChange={[Function]}
             type="checkbox"
           />
@@ -67,9 +71,11 @@ exports[`Reader.ControlMenu.VisibilityMenuBody Component renders correctly 1`] =
       >
         <label
           className="checkbox"
+          htmlFor="Yours-checkbox-3"
         >
           <input
             checked={true}
+            id="Yours-checkbox-3"
             onChange={[Function]}
             type="checkbox"
           />
@@ -85,9 +91,11 @@ exports[`Reader.ControlMenu.VisibilityMenuBody Component renders correctly 1`] =
         </label>
         <label
           className="checkbox"
+          htmlFor="Others-checkbox-4"
         >
           <input
             checked={true}
+            id="Others-checkbox-4"
             onChange={[Function]}
             type="checkbox"
           />
@@ -116,9 +124,11 @@ exports[`Reader.ControlMenu.VisibilityMenuBody Component renders correctly 1`] =
       >
         <label
           className="checkbox"
+          htmlFor="All-checkbox-5"
         >
           <input
             checked={true}
+            id="All-checkbox-5"
             onChange={[Function]}
             type="checkbox"
           />

--- a/client/src/components/reader/Notes/Partial/Filters.js
+++ b/client/src/components/reader/Notes/Partial/Filters.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import uniqueId from "lodash/uniqueId";
 
 export default class Filters extends Component {
   static displayName = "Notes.List.Filters";
@@ -27,11 +28,13 @@ export default class Filters extends Component {
   renderCheckBox(label, format) {
     const formats = this.props.filter.formats;
     const checked = this.filteredBy(formats, format);
+    const checkboxId = uniqueId(label + "-checkbox-");
 
     return (
-      <label className="checkbox">
+      <label htmlFor={checkboxId} className="checkbox">
         <input
           type="checkbox"
+          id={checkboxId}
           checked={checked}
           onChange={e => this.toggleFormat(e, format)}
         />

--- a/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/Filters-test.js.snap
@@ -14,9 +14,11 @@ exports[`Reader.Notes.Partial.Group Component renders correctly 1`] = `
   >
     <label
       className="checkbox"
+      htmlFor="Highlights-checkbox-1"
     >
       <input
         checked={true}
+        id="Highlights-checkbox-1"
         onChange={[Function]}
         type="checkbox"
       />
@@ -32,9 +34,11 @@ exports[`Reader.Notes.Partial.Group Component renders correctly 1`] = `
     </label>
     <label
       className="checkbox"
+      htmlFor="Annotations-checkbox-2"
     >
       <input
         checked={true}
+        id="Annotations-checkbox-2"
         onChange={[Function]}
         type="checkbox"
       />

--- a/client/src/components/reader/Notes/__tests__/__snapshots__/FilteredList-test.js.snap
+++ b/client/src/components/reader/Notes/__tests__/__snapshots__/FilteredList-test.js.snap
@@ -31,9 +31,11 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
     >
       <label
         className="checkbox"
+        htmlFor="Highlights-checkbox-1"
       >
         <input
           checked={true}
+          id="Highlights-checkbox-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -49,9 +51,11 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
       </label>
       <label
         className="checkbox"
+        htmlFor="Annotations-checkbox-2"
       >
         <input
           checked={true}
+          id="Annotations-checkbox-2"
           onChange={[Function]}
           type="checkbox"
         />


### PR DESCRIPTION
Resolves #1103 

Includes updated tests.

Wherever possible I associated the label with the input using the `for` and `id` attributes (even if the label wrapped the input).  This ensures the greatest support across screen readers.