### PR TITLE
Turns a functionless button in the predictive text input component into an icon

### DIFF
--- a/client/src/components/backend/Form/__tests__/__snapshots__/HasMany-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/HasMany-test.js.snap
@@ -105,7 +105,7 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
       <div
         className="input"
       >
-        <button
+        <i
           aria-hidden="true"
           className="manicon manicon-plus"
         />

--- a/client/src/components/backend/Project/Form/__tests__/__snapshots__/Subjects-test.js.snap
+++ b/client/src/components/backend/Project/Form/__tests__/__snapshots__/Subjects-test.js.snap
@@ -48,7 +48,7 @@ exports[`Backend Project Form Subjects Component renders correctly 1`] = `
       <div
         className="input"
       >
-        <button
+        <i
           aria-hidden="true"
           className="manicon manicon-plus"
         />

--- a/client/src/containers/backend/Form/PredictiveInput.js
+++ b/client/src/containers/backend/Form/PredictiveInput.js
@@ -227,7 +227,7 @@ class PredictiveInput extends PureComponent {
     return (
       <div className={classes}>
         <div className="input">
-          <button className="manicon manicon-plus" aria-hidden="true" />
+          <i className="manicon manicon-plus" aria-hidden="true" />
           <input
             className="text-input"
             type="text"

--- a/client/src/containers/backend/Form/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/containers/backend/Form/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -76,7 +76,7 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
           <div
             className="input"
           >
-            <button
+            <i
               aria-hidden="true"
               className="manicon manicon-plus"
             />
@@ -177,7 +177,7 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
           <div
             className="input"
           >
-            <button
+            <i
               aria-hidden="true"
               className="manicon manicon-plus"
             />

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/Form-test.js.snap
@@ -21,7 +21,7 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
             <div
               className="input"
             >
-              <button
+              <i
                 aria-hidden="true"
                 className="manicon manicon-plus"
               />

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/New-test.js.snap
@@ -31,7 +31,7 @@ exports[`Backend Permission New Container renders correctly 1`] = `
               <div
                 className="input"
               >
-                <button
+                <i
                   aria-hidden="true"
                   className="manicon manicon-plus"
                 />

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -77,7 +77,7 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
             <div
               className="input"
             >
-              <button
+              <i
                 aria-hidden="true"
                 className="manicon manicon-plus"
               />
@@ -178,7 +178,7 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
             <div
               className="input"
             >
-              <button
+              <i
                 aria-hidden="true"
                 className="manicon manicon-plus"
               />

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/General-test.js.snap
@@ -456,7 +456,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
               <div
                 className="input"
               >
-                <button
+                <i
                   aria-hidden="true"
                   className="manicon manicon-plus"
                 />

--- a/client/src/containers/backend/Text/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/containers/backend/Text/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -77,7 +77,7 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
             <div
               className="input"
             >
-              <button
+              <i
                 aria-hidden="true"
                 className="manicon manicon-plus"
               />
@@ -178,7 +178,7 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
             <div
               className="input"
             >
-              <button
+              <i
                 aria-hidden="true"
                 className="manicon manicon-plus"
               />

--- a/client/src/theme/Components/backend/forms/_input-predictive.scss
+++ b/client/src/theme/Components/backend/forms/_input-predictive.scss
@@ -10,9 +10,11 @@
 
   .manicon {
     @include buttonUnstyled;
+    display: inline-block;
     min-width: 50px;
     font-size: 13px;
     color: $accentPrimary;
+    text-align: center;
   }
 
   // Required for override


### PR DESCRIPTION
Resolves #1048

Plus sign next to the placeholder text in the Predictive Text Input was a button with no purpose so now it is an icon instead (visually identical).