### PR TITLE
[F] Use Aria and role attributes to immediately bring errors to the attention of AT

### DIFF
--- a/client/src/components/backend/Category/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/components/backend/Category/__tests__/__snapshots__/Form-test.js.snap
@@ -13,12 +13,13 @@ exports[`Backend.Category.Form Component renders correctly 1`] = `
     >
       <label
         className=""
-        htmlFor={undefined}
+        htmlFor="text-input-15"
       >
         Title
       </label>
       <input
-        id={undefined}
+        aria-describedby="text-input-error-16"
+        id="text-input-15"
         onChange={[Function]}
         placeholder="What would you like to call this category?"
         type="text"

--- a/client/src/components/backend/Dialog/ResetPassword.js
+++ b/client/src/components/backend/Dialog/ResetPassword.js
@@ -110,6 +110,8 @@ class ResetPasswordWrapper extends PureComponent {
 
   renderResetForm() {
     const errors = get(this.props.response, "errors") || [];
+    const id = "reset-password";
+    const errorId = id + "-error";
 
     return (
       <form
@@ -121,15 +123,17 @@ class ResetPasswordWrapper extends PureComponent {
             className="form-input"
             name="attributes[password]"
             errors={errors}
+            idForError={errorId}
           >
-            <label htmlFor="reset-password">New Password</label>
+            <label htmlFor={id}>New Password</label>
             <input
               value={this.state.password}
               onChange={event => this.handleInputChange(event)}
               name="password"
               type="password"
-              id="reset-password"
+              id={id}
               placeholder="New Password"
+              aria-describedby={errorId}
             />
           </Form.Errorable>
         </div>

--- a/client/src/components/backend/Form/GeneratedPasswordInput.js
+++ b/client/src/components/backend/Form/GeneratedPasswordInput.js
@@ -15,11 +15,15 @@ class FormGeneratedPasswordInput extends Component {
     value: PropTypes.any,
     focusOnMount: PropTypes.bool,
     errors: PropTypes.array,
-    set: PropTypes.func
+    set: PropTypes.func,
+    id: PropTypes.string,
+    idForError: PropTypes.string
   };
 
   static defaultProps = {
-    focusOnMount: false
+    focusOnMount: false,
+    id: uniqueId("generated-password-"),
+    idForError: uniqueId("generated-password-error-")
   };
 
   constructor(props) {
@@ -31,7 +35,6 @@ class FormGeneratedPasswordInput extends Component {
   }
 
   componentDidMount() {
-    this.id = uniqueId("generated-password-");
     if (this.props.focusOnMount === true && this.inputElement)
       this.inputElement.focus();
     this.setValueFromCurrentState();
@@ -68,12 +71,14 @@ class FormGeneratedPasswordInput extends Component {
     // });
     //
     const type = this.state.showPassword ? "text" : "password";
+
     return (
       <input
         ref={input => {
           this.inputElement = input;
         }}
-        id={this.id}
+        id={this.props.id}
+        aria-describedby={this.props.idForError}
         type={type}
         placeholder={"Enter a password"}
         onChange={event => this.handlePasswordChange(event)}
@@ -95,8 +100,9 @@ class FormGeneratedPasswordInput extends Component {
         name={this.props.name}
         errors={this.props.errors}
         label="Password"
+        idForError={this.props.idForError}
       >
-        <label htmlFor={this.id}>Password</label>
+        <label htmlFor={this.props.id}>Password</label>
         <span
           className="password-visibility-toggle"
           onClick={event => this.togglePassword(event)}

--- a/client/src/components/backend/Form/HasMany.js
+++ b/client/src/components/backend/Form/HasMany.js
@@ -5,6 +5,7 @@ import { Form as FormContainer } from "containers/backend";
 import { Form as GlobalForm } from "components/global";
 import indexOf from "lodash/indexOf";
 import get from "lodash/get";
+import uniqueId from "lodash/uniqueId";
 
 export default class FormHasMany extends PureComponent {
   static displayName = "Form.HasMany";
@@ -21,7 +22,12 @@ export default class FormHasMany extends PureComponent {
     entityLabelAttribute: PropTypes.string.isRequired,
     entityAvatarAttribute: PropTypes.string,
     placeholder: PropTypes.string,
-    errors: PropTypes.array
+    errors: PropTypes.array,
+    idForError: PropTypes.string
+  };
+
+  static defaultProps = {
+    idForError: uniqueId("predictive-text-belongs-to-error-")
   };
 
   onMove = (event, entity, direction) => {
@@ -143,6 +149,7 @@ export default class FormHasMany extends PureComponent {
         name="*"
         errors={this.props.errors}
         label={this.props.label}
+        idForError={this.props.idForError}
       >
         {this.renderHeader()}
         <nav className="has-many-list">
@@ -202,6 +209,7 @@ export default class FormHasMany extends PureComponent {
             onNew={this.props.onNew ? this.onNew : null}
             onSelect={this.onSelect}
             fetch={this.props.optionsFetch}
+            idForError={this.props.idForError}
           />
         </nav>
       </GlobalForm.Errorable>

--- a/client/src/components/backend/Form/HigherOrder/Validation.js
+++ b/client/src/components/backend/Form/HigherOrder/Validation.js
@@ -15,7 +15,8 @@ export default class FormHigherOrderValidation extends Component {
     children: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
       .isRequired,
     onChange: PropTypes.func,
-    setValue: PropTypes.func
+    setValue: PropTypes.func,
+    idForError: PropTypes.string
   };
 
   static defaultProps = {};
@@ -105,10 +106,10 @@ export default class FormHigherOrderValidation extends Component {
       children,
       errorHandler,
       submitted,
+      idForError,
       ...transfer
     } = this.props;
     /* eslint-enable no-unused-vars */
-
     if (!this.props.validation) {
       return React.cloneElement(children, transfer);
     }
@@ -123,7 +124,10 @@ export default class FormHigherOrderValidation extends Component {
       <div>
         {React.cloneElement(this.props.children, transfer)}
         <div className="form-error">
-          <GlobalForm.InputError errors={Object.values(this.state.errors)} />
+          <GlobalForm.InputError
+            idForError={idForError}
+            errors={Object.values(this.state.errors)}
+          />
         </div>
       </div>
     );

--- a/client/src/components/backend/Form/MaskedTextInput.js
+++ b/client/src/components/backend/Form/MaskedTextInput.js
@@ -21,16 +21,17 @@ class FormMaskedTextInput extends Component {
     label: PropTypes.string,
     onChange: PropTypes.func,
     value: PropTypes.string,
-    instructions: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+    instructions: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    id: PropTypes.string
+  };
+
+  static defaultProps = {
+    id: uniqueId("masked-text-")
   };
 
   constructor() {
     super();
     this.placeholderChar = "\u005F"; // react-text-mask default "_"
-  }
-
-  componentDidMount() {
-    this.id = uniqueId("masked-text-");
   }
 
   currencyMask() {
@@ -91,14 +92,14 @@ class FormMaskedTextInput extends Component {
 
     return (
       <div className="form-input">
-        <label htmlFor={this.id} className={labelClass}>
+        <label htmlFor={this.props.id} className={labelClass}>
           {this.props.label}
         </label>
         <Instructions instructions={this.props.instructions} />
         <MaskedInput
           onChange={this.props.onChange}
           value={this.props.value}
-          id={this.id}
+          id={this.props.id}
           type="text"
           mask={mask}
           placeholder={this.props.placeholder}

--- a/client/src/components/backend/Form/PredictiveBelongsTo.js
+++ b/client/src/components/backend/Form/PredictiveBelongsTo.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import setter from "./setter";
+import uniqueId from "lodash/uniqueId";
 import { Form as FormContainer } from "containers/backend";
 import { Form as GlobalForm } from "components/global";
 
@@ -17,7 +18,8 @@ class FormPredictiveBelongsTo extends PureComponent {
     getModelValue: PropTypes.func,
     readOnly: PropTypes.bool,
     relationName: PropTypes.string,
-    errors: PropTypes.array
+    errors: PropTypes.array,
+    idForError: PropTypes.string
   };
 
   handleSelect = entity => {
@@ -37,6 +39,7 @@ class FormPredictiveBelongsTo extends PureComponent {
             className="form-input"
             name={`attributes[${this.props.relationName}]`}
             errors={this.props.errors}
+            idForError={this.props.idForError}
           >
             <FormContainer.PredictiveInput
               className="input-predictive"
@@ -45,6 +48,7 @@ class FormPredictiveBelongsTo extends PureComponent {
               placeholder="Select User"
               label={this.props.label}
               onSelect={entity => this.handleSelect(entity)}
+              idForError={this.props.idForError}
             />
           </GlobalForm.Errorable>
         ) : null}

--- a/client/src/components/backend/Form/Select.js
+++ b/client/src/components/backend/Form/Select.js
@@ -21,12 +21,15 @@ class FormSelect extends Component {
         value: PropTypes.any.isRequired,
         label: PropTypes.string.isRequired
       })
-    ).isRequired
+    ).isRequired,
+    id: PropTypes.string,
+    idForError: PropTypes.string
   };
 
-  componentDidMount() {
-    this.id = uniqueId("select-");
-  }
+  static defaultProps = {
+    id: uniqueId("select-"),
+    idForError: uniqueId("select-error-")
+  };
 
   render() {
     const value = isNull(this.props.value) ? "" : this.props.value;
@@ -46,12 +49,18 @@ class FormSelect extends Component {
           name={this.props.name}
           errors={this.props.errors}
           label={this.props.label}
+          idForError={this.props.idForError}
         >
           <label htmlFor={this.id}>{this.props.label}</label>
           <Instructions instructions={this.props.instructions} />
           <div className="form-select">
             <i className="manicon manicon-caret-down" aria-hidden="true" />
-            <select id={this.id} onChange={this.props.onChange} value={value}>
+            <select
+              id={this.id}
+              aria-describedby={this.props.idForError}
+              onChange={this.props.onChange}
+              value={value}
+            >
               {options}
             </select>
           </div>

--- a/client/src/components/backend/Form/TextArea.js
+++ b/client/src/components/backend/Form/TextArea.js
@@ -18,16 +18,16 @@ class FormTextArea extends Component {
     value: PropTypes.string,
     errors: PropTypes.array,
     name: PropTypes.string,
+    id: PropTypes.string,
+    idForError: PropTypes.string,
     instructions: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
   };
 
   static defaultProps = {
-    height: 100
+    height: 100,
+    id: uniqueId("textarea-"),
+    idForError: uniqueId("textarea-error-")
   };
-
-  componentDidMount() {
-    this.id = uniqueId("textarea-");
-  }
 
   render() {
     const labelClass = classnames({
@@ -41,13 +41,15 @@ class FormTextArea extends Component {
           name={this.props.name}
           errors={this.props.errors}
           label={this.props.label}
+          idForError={this.props.idForError}
         >
-          <label htmlFor={this.id} className={labelClass}>
+          <label htmlFor={this.props.id} className={labelClass}>
             {this.props.label}
           </label>
           <Instructions instructions={this.props.instructions} />
           <textarea
-            id={this.id}
+            id={this.props.id}
+            aria-describedby={this.props.idForError}
             style={{ height: this.props.height }}
             placeholder={this.props.placeholder}
             onChange={this.props.onChange}

--- a/client/src/components/backend/Form/TextInput.js
+++ b/client/src/components/backend/Form/TextInput.js
@@ -21,18 +21,20 @@ class FormTextInput extends Component {
     focusOnMount: PropTypes.bool,
     errors: PropTypes.array,
     password: PropTypes.bool,
-    join: PropTypes.func
+    join: PropTypes.func,
+    id: PropTypes.string,
+    idForError: PropTypes.string
   };
 
   static defaultProps = {
     focusOnMount: false,
     password: false,
-    join: array => array.join(", ")
+    join: array => array.join(", "),
+    id: uniqueId("text-input-"),
+    idForError: uniqueId("text-input-error-")
   };
 
   componentDidMount() {
-    this.id = uniqueId("text-input-");
-
     if (this.props.focusOnMount === true && this.inputElement) {
       this.inputElement.focus();
     }
@@ -56,8 +58,9 @@ class FormTextInput extends Component {
         name={this.props.name}
         errors={this.props.errors}
         label={this.props.label}
+        idForError={this.props.idForError}
       >
-        <label htmlFor={this.id} className={labelClass}>
+        <label htmlFor={this.props.id} className={labelClass}>
           {this.props.label}
         </label>
         <Instructions instructions={this.props.instructions} />
@@ -65,11 +68,12 @@ class FormTextInput extends Component {
           ref={input => {
             this.inputElement = input;
           }}
-          id={this.id}
+          id={this.props.id}
           type={inputType}
           placeholder={this.props.placeholder}
           onChange={this.props.onChange}
           value={this.renderValue(this.props.value)}
+          aria-describedby={this.props.idForError}
         />
       </GlobalForm.Errorable>
     );

--- a/client/src/components/backend/Form/Upload.js
+++ b/client/src/components/backend/Form/Upload.js
@@ -32,12 +32,16 @@ export class FormUpload extends Component {
     accepts: PropTypes.string,
     value: PropTypes.any, // the current value of the field in the connected model
     initialValue: PropTypes.string, // the initial value of the input when it's rendered
-    errors: PropTypes.array
+    errors: PropTypes.array,
+    inputId: PropTypes.string,
+    idForError: PropTypes.string
   };
 
   static defaultProps = {
     layout: "square",
-    accepts: "any"
+    accepts: "any",
+    inputId: uniqueId("upload-"),
+    idForError: uniqueId("upload-error-")
   };
 
   static types = {
@@ -103,10 +107,6 @@ export class FormUpload extends Component {
       removed: false,
       attachment: null
     };
-  }
-
-  componentDidMount() {
-    this.id = uniqueId("upload-");
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -281,10 +281,13 @@ export class FormUpload extends Component {
     const labelClass = classnames({
       "has-instructions": isString(this.props.instructions)
     });
+    const inputProps = {
+      id: this.props.inputId,
+      "aria-describedby": this.props.idForError
+    };
     const dropzoneProps = {};
     const { accepts } = this.accepts(this.props);
     if (accepts) dropzoneProps.accept = accepts;
-
     return (
       <div className="form-input">
         <GlobalForm.Errorable
@@ -292,15 +295,16 @@ export class FormUpload extends Component {
           name={this.props.name}
           errors={this.props.errors}
           label={this.props.label}
+          idForError={this.props.idForError}
         >
           {this.props.label ? (
-            <label htmlFor={this.id} className={labelClass}>
+            <label htmlFor={this.props.inputId} className={labelClass}>
               {this.props.label}
             </label>
           ) : null}
           <Instructions instructions={this.props.instructions} />
           <Dropzone
-            id={this.id}
+            inputProps={inputProps}
             style={this.props.inlineStyle}
             className={`form-dropzone style-${this.props.layout}`}
             multiple={false}

--- a/client/src/components/backend/Form/__tests__/__snapshots__/GeneratedPasswordInput-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/GeneratedPasswordInput-test.js.snap
@@ -6,7 +6,7 @@ exports[`Backend.Form.GeneratedPasswordInput component renders correctly 1`] = `
   style={Object {}}
 >
   <label
-    htmlFor={undefined}
+    htmlFor="generated-password-21"
   >
     Password
   </label>
@@ -27,7 +27,8 @@ exports[`Backend.Form.GeneratedPasswordInput component renders correctly 1`] = `
     </span>
   </span>
   <input
-    id={undefined}
+    aria-describedby="generated-password-error-22"
+    id="generated-password-21"
     onChange={[Function]}
     placeholder="Enter a password"
     type="password"

--- a/client/src/components/backend/Form/__tests__/__snapshots__/HasMany-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/HasMany-test.js.snap
@@ -112,6 +112,7 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
           className="manicon manicon-plus"
         />
         <input
+          aria-describedby={null}
           aria-label={undefined}
           className="text-input"
           onBlur={[Function]}

--- a/client/src/components/backend/Form/__tests__/__snapshots__/MaskedTestInput-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/MaskedTestInput-test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Backend.Form.MaskedTextInput component renders correctly 1`] = `"<div class=\\"form-input\\"><label class=\\"\\">Label this</label>ReactTextMask</div>"`;
+exports[`Backend.Form.MaskedTextInput component renders correctly 1`] = `"<div class=\\"form-input\\"><label for=\\"masked-text-1\\" class=\\"\\">Label this</label>ReactTextMask</div>"`;

--- a/client/src/components/backend/Form/__tests__/__snapshots__/Select-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/Select-test.js.snap
@@ -21,6 +21,7 @@ exports[`Backend.Form.Select component renders correctly 1`] = `
         className="manicon manicon-caret-down"
       />
       <select
+        aria-describedby="select-error-22"
         id={undefined}
         onChange={[Function]}
         value={undefined}

--- a/client/src/components/backend/Form/__tests__/__snapshots__/TextArea-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/TextArea-test.js.snap
@@ -10,12 +10,13 @@ exports[`Backend.Form.TextArea component renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="textarea-21"
     >
       Label this
     </label>
     <textarea
-      id={undefined}
+      aria-describedby="textarea-error-22"
+      id="textarea-21"
       onChange={[Function]}
       placeholder={undefined}
       style={

--- a/client/src/components/backend/Form/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/TextInput-test.js.snap
@@ -7,12 +7,13 @@ exports[`Backend.Form.TextInput component renders correctly 1`] = `
 >
   <label
     className=""
-    htmlFor={undefined}
+    htmlFor="text-input-15"
   >
     A form label
   </label>
   <input
-    id={undefined}
+    aria-describedby="text-input-error-16"
+    id="text-input-15"
     onChange={[Function]}
     placeholder={undefined}
     type="text"

--- a/client/src/components/backend/Form/__tests__/__snapshots__/Upload-test.js.snap
+++ b/client/src/components/backend/Form/__tests__/__snapshots__/Upload-test.js.snap
@@ -10,14 +10,19 @@ exports[`Backend.Form.Upload component when the upload input does not have a val
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="upload-21"
     >
       Cover
     </label>
     <react-dropzone
       accept="image/*"
       className="form-dropzone style-portrait"
-      id={undefined}
+      inputProps={
+        Object {
+          "aria-describedby": "upload-error-22",
+          "id": "upload-21",
+        }
+      }
       multiple={false}
       onDrop={[Function]}
       style={undefined}
@@ -69,14 +74,19 @@ exports[`Backend.Form.Upload component when the upload input doesn't have a remo
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="upload-21"
     >
       Cover
     </label>
     <react-dropzone
       accept="image/*"
       className="form-dropzone style-portrait"
-      id={undefined}
+      inputProps={
+        Object {
+          "aria-describedby": "upload-error-22",
+          "id": "upload-21",
+        }
+      }
       multiple={false}
       onDrop={[Function]}
       style={undefined}
@@ -142,14 +152,19 @@ exports[`Backend.Form.Upload component when the upload input doesn't have set an
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="upload-21"
     >
       Cover
     </label>
     <react-dropzone
       accept="image/*"
       className="form-dropzone style-portrait"
-      id={undefined}
+      inputProps={
+        Object {
+          "aria-describedby": "upload-error-22",
+          "id": "upload-21",
+        }
+      }
       multiple={false}
       onDrop={[Function]}
       style={undefined}
@@ -215,14 +230,19 @@ exports[`Backend.Form.Upload component when the upload input has a value renders
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="upload-21"
     >
       Cover
     </label>
     <react-dropzone
       accept="image/*"
       className="form-dropzone style-portrait"
-      id={undefined}
+      inputProps={
+        Object {
+          "aria-describedby": "upload-error-22",
+          "id": "upload-21",
+        }
+      }
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/List/Searchable.js
+++ b/client/src/components/backend/List/Searchable.js
@@ -51,7 +51,10 @@ export class ListSearchable extends PureComponent {
     filterChangeHandler: PropTypes.func,
     currentUser: PropTypes.object,
     initialFilter: PropTypes.object, // Initial filter is to set filter state from an existing state
-    defaultFilter: PropTypes.object // Default filter is what filter is set to when resetSearch() is called
+    defaultFilter: PropTypes.object, // Default filter is what filter is set to when resetSearch() is called
+    searchId: PropTypes.string,
+    filterId: PropTypes.string,
+    sortId: PropTypes.string
   };
 
   static defaultProps = {
@@ -60,19 +63,16 @@ export class ListSearchable extends PureComponent {
     secondaryButton: null,
     paginationPadding: 3,
     requireAbility: null,
-    initialFilter: null
+    initialFilter: null,
+    searchId: uniqueId("list-search-"),
+    filterId: uniqueId("list-filter-"),
+    sortId: uniqueId("list-sort-")
   };
 
   constructor(props) {
     super(props);
     this.state = this.initialState(props);
     this.authorization = new Authorization();
-  }
-
-  componentDidMount() {
-    this.searchId = uniqueId("list-search-");
-    this.filterId = uniqueId("filter-");
-    this.sortId = uniqueId("sort-");
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -139,7 +139,7 @@ export class ListSearchable extends PureComponent {
 
     return (
       <div className="select-group">
-        <label htmlFor={this.sortId}>Sort By:</label>
+        <label htmlFor={this.props.sortId}>Sort By:</label>
         {this.renderSortSelect(adjustedOptions)}
       </div>
     );
@@ -149,7 +149,7 @@ export class ListSearchable extends PureComponent {
     if (!this.state.showOptions || !this.props.filterOptions) return null;
     return (
       <div className="select-group">
-        <label htmlFor={this.filterId}>Filter Results:</label>
+        <label htmlFor={this.props.filterId}>Filter Results:</label>
         {Object.keys(this.props.filterOptions).map(filter =>
           this.renderFilterSelect(filter)
         )}
@@ -161,7 +161,7 @@ export class ListSearchable extends PureComponent {
     return (
       <div className="select" key="filter[order]">
         <select
-          id={this.sortId}
+          id={this.props.sortId}
           onChange={event => this.setFilter(event, "order")}
           value={this.state.filter.order || ""}
           data-id={"filter"}
@@ -178,7 +178,7 @@ export class ListSearchable extends PureComponent {
     return (
       <div className="select" key={filter}>
         <select
-          id={this.filterId}
+          id={this.props.filterId}
           onChange={event => this.setFilter(event, filter)}
           value={this.state.filter[filter] || ""}
           data-id={"filter"}
@@ -316,11 +316,11 @@ export class ListSearchable extends PureComponent {
               <i className="manicon manicon-magnify" aria-hidden="true" />
               <span className="screen-reader-text">Click to search</span>
             </button>
-            <label htmlFor={this.searchId} className="screen-reader-text">
+            <label htmlFor={this.props.searchId} className="screen-reader-text">
               Enter Search Criteria
             </label>
             <input
-              id={this.searchId}
+              id={this.props.searchId}
               value={this.state.filter.keyword || ""}
               type="text"
               placeholder="Search..."

--- a/client/src/components/backend/List/__tests__/__snapshots__/Searchable-test.js.snap
+++ b/client/src/components/backend/List/__tests__/__snapshots__/Searchable-test.js.snap
@@ -22,12 +22,12 @@ exports[`Backend.List.Searchable component renders correctly 1`] = `
       </button>
       <label
         className="screen-reader-text"
-        htmlFor={undefined}
+        htmlFor="list-search-20"
       >
         Enter Search Criteria
       </label>
       <input
-        id={undefined}
+        id="list-search-20"
         onChange={[Function]}
         placeholder="Search..."
         type="text"
@@ -372,12 +372,12 @@ exports[`Backend.List.Searchable component renders correctly when passed a compo
       </button>
       <label
         className="screen-reader-text"
-        htmlFor={undefined}
+        htmlFor="list-search-20"
       >
         Enter Search Criteria
       </label>
       <input
-        id={undefined}
+        id="list-search-20"
         onChange={[Function]}
         placeholder="Search..."
         type="text"

--- a/client/src/components/backend/Project/Form/__tests__/__snapshots__/Subjects-test.js.snap
+++ b/client/src/components/backend/Project/Form/__tests__/__snapshots__/Subjects-test.js.snap
@@ -55,6 +55,7 @@ exports[`Backend Project Form Subjects Component renders correctly 1`] = `
           className="manicon manicon-plus"
         />
         <input
+          aria-describedby={null}
           aria-label="Add a Subject"
           className="text-input"
           onBlur={[Function]}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Audio-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Audio-test.js.snap
@@ -13,14 +13,19 @@ exports[`Backend.Resource.Form.Audio component renders correctly 1`] = `
     >
       <label
         className=""
-        htmlFor={undefined}
+        htmlFor="upload-17"
       >
         Audio File
       </label>
       <react-dropzone
         accept="audio/*"
         className="form-dropzone style-square"
-        id={undefined}
+        inputProps={
+          Object {
+            "aria-describedby": "upload-error-18",
+            "id": "upload-17",
+          }
+        }
         multiple={false}
         onDrop={[Function]}
         style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Document-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Document-test.js.snap
@@ -10,14 +10,19 @@ exports[`Backend.Resource.Form.Document component renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="upload-17"
     >
       Document File
     </label>
     <react-dropzone
       accept="application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/msword,text/*,application/vnd.oasis.opendocument.text"
       className="form-dropzone style-square"
-      id={undefined}
+      inputProps={
+        Object {
+          "aria-describedby": "upload-error-18",
+          "id": "upload-17",
+        }
+      }
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/File-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/File-test.js.snap
@@ -10,13 +10,18 @@ exports[`Backend.Resource.Form.File component renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="upload-17"
     >
       File
     </label>
     <react-dropzone
       className="form-dropzone style-square"
-      id={undefined}
+      inputProps={
+        Object {
+          "aria-describedby": "upload-error-18",
+          "id": "upload-17",
+        }
+      }
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Image-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Image-test.js.snap
@@ -10,14 +10,19 @@ exports[`Backend.Resource.Form.Image component renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="upload-17"
     >
       Image File
     </label>
     <react-dropzone
       accept="image/*"
       className="form-dropzone style-square"
-      id={undefined}
+      inputProps={
+        Object {
+          "aria-describedby": "upload-error-18",
+          "id": "upload-17",
+        }
+      }
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Interactive-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Interactive-test.js.snap
@@ -10,12 +10,13 @@ exports[`Backend.Resource.Form.Interactive component when sub kind is embed rend
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="text-input-15"
     >
       Minimum Width
     </label>
     <input
-      id={undefined}
+      aria-describedby="text-input-error-16"
+      id="text-input-15"
       onChange={[Function]}
       placeholder="The minimum display width"
       type="text"
@@ -28,12 +29,13 @@ exports[`Backend.Resource.Form.Interactive component when sub kind is embed rend
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="text-input-15"
     >
       Minimum Height
     </label>
     <input
-      id={undefined}
+      aria-describedby="text-input-error-16"
+      id="text-input-15"
       onChange={[Function]}
       placeholder="The minimum display height"
       type="text"
@@ -46,12 +48,13 @@ exports[`Backend.Resource.Form.Interactive component when sub kind is embed rend
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="text-input-15"
     >
       iFrame URL
     </label>
     <input
-      id={undefined}
+      aria-describedby="text-input-error-16"
+      id="text-input-15"
       onChange={[Function]}
       placeholder="Enter iFrame URL"
       type="text"
@@ -71,12 +74,13 @@ exports[`Backend.Resource.Form.Interactive component when sub kind is iframe ren
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="text-input-15"
     >
       Minimum Width
     </label>
     <input
-      id={undefined}
+      aria-describedby="text-input-error-16"
+      id="text-input-15"
       onChange={[Function]}
       placeholder="The minimum display width"
       type="text"
@@ -89,12 +93,13 @@ exports[`Backend.Resource.Form.Interactive component when sub kind is iframe ren
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="text-input-15"
     >
       Minimum Height
     </label>
     <input
-      id={undefined}
+      aria-describedby="text-input-error-16"
+      id="text-input-15"
       onChange={[Function]}
       placeholder="The minimum display height"
       type="text"
@@ -107,12 +112,13 @@ exports[`Backend.Resource.Form.Interactive component when sub kind is iframe ren
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="text-input-15"
     >
       iFrame URL
     </label>
     <input
-      id={undefined}
+      aria-describedby="text-input-error-16"
+      id="text-input-15"
       onChange={[Function]}
       placeholder="Enter iFrame URL"
       type="text"

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Link-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Link-test.js.snap
@@ -10,12 +10,13 @@ exports[`Backend.Resource.Form.Link component renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="text-input-15"
     >
       Link URL
     </label>
     <input
-      id={undefined}
+      aria-describedby="text-input-error-16"
+      id="text-input-15"
       onChange={[Function]}
       placeholder="Enter link URL"
       type="text"

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Pdf-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Pdf-test.js.snap
@@ -10,14 +10,19 @@ exports[`Backend.Resource.Form.Pdf component renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="upload-17"
     >
       PDF File
     </label>
     <react-dropzone
       accept="application/pdf"
       className="form-dropzone style-square"
-      id={undefined}
+      inputProps={
+        Object {
+          "aria-describedby": "upload-error-18",
+          "id": "upload-17",
+        }
+      }
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Presentation-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Presentation-test.js.snap
@@ -10,14 +10,19 @@ exports[`Backend.Resource.Form.Presentation component renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="upload-17"
     >
       Presentation File
     </label>
     <react-dropzone
       accept="application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-powerpoint,application/vnd.oasis.opendocument.presentation"
       className="form-dropzone style-square"
-      id={undefined}
+      inputProps={
+        Object {
+          "aria-describedby": "upload-error-18",
+          "id": "upload-17",
+        }
+      }
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Spreadsheet-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Spreadsheet-test.js.snap
@@ -10,14 +10,19 @@ exports[`Backend.Resource.Form.Spreadsheet component renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="upload-17"
     >
       Spreadsheet File
     </label>
     <react-dropzone
       accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,application/vnd.oasis.opendocument.spreadsheet,"
       className="form-dropzone style-square"
-      id={undefined}
+      inputProps={
+        Object {
+          "aria-describedby": "upload-error-18",
+          "id": "upload-17",
+        }
+      }
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Variants-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Variants-test.js.snap
@@ -13,13 +13,18 @@ exports[`Backend.Resource.Form.Variants component renders correctly 1`] = `
     >
       <label
         className=""
-        htmlFor={undefined}
+        htmlFor="upload-17"
       >
         Variant
       </label>
       <react-dropzone
         className="form-dropzone style-square"
-        id={undefined}
+        inputProps={
+          Object {
+            "aria-describedby": "upload-error-18",
+            "id": "upload-17",
+          }
+        }
         multiple={false}
         onDrop={[Function]}
         style={undefined}
@@ -63,13 +68,18 @@ exports[`Backend.Resource.Form.Variants component renders correctly 1`] = `
     >
       <label
         className=""
-        htmlFor={undefined}
+        htmlFor="upload-17"
       >
         Variant
       </label>
       <react-dropzone
         className="form-dropzone style-square"
-        id={undefined}
+        inputProps={
+          Object {
+            "aria-describedby": "upload-error-18",
+            "id": "upload-17",
+          }
+        }
         multiple={false}
         onDrop={[Function]}
         style={undefined}
@@ -120,14 +130,19 @@ exports[`Backend.Resource.Form.Variants component when kind is image renders cor
     >
       <label
         className=""
-        htmlFor={undefined}
+        htmlFor="upload-17"
       >
         High Resolution Image
       </label>
       <react-dropzone
         accept="image/*"
         className="form-dropzone style-square"
-        id={undefined}
+        inputProps={
+          Object {
+            "aria-describedby": "upload-error-18",
+            "id": "upload-17",
+          }
+        }
         multiple={false}
         onDrop={[Function]}
         style={undefined}
@@ -176,14 +191,19 @@ exports[`Backend.Resource.Form.Variants component when kind is image renders cor
     >
       <label
         className=""
-        htmlFor={undefined}
+        htmlFor="upload-17"
       >
         Thumbnail Image
       </label>
       <react-dropzone
         accept="image/*"
         className="form-dropzone style-square"
-        id={undefined}
+        inputProps={
+          Object {
+            "aria-describedby": "upload-error-18",
+            "id": "upload-17",
+          }
+        }
         multiple={false}
         onDrop={[Function]}
         style={undefined}
@@ -239,14 +259,19 @@ exports[`Backend.Resource.Form.Variants component when kind is pdf renders corre
     >
       <label
         className=""
-        htmlFor={undefined}
+        htmlFor="upload-17"
       >
         Thumbnail Image
       </label>
       <react-dropzone
         accept="image/*"
         className="form-dropzone style-square"
-        id={undefined}
+        inputProps={
+          Object {
+            "aria-describedby": "upload-error-18",
+            "id": "upload-17",
+          }
+        }
         multiple={false}
         onDrop={[Function]}
         style={undefined}

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Video-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Video-test.js.snap
@@ -39,14 +39,19 @@ exports[`Backend.Resource.Form.Video component renders correctly 1`] = `
     >
       <label
         className=""
-        htmlFor={undefined}
+        htmlFor="upload-17"
       >
         Video File
       </label>
       <react-dropzone
         accept="video/*"
         className="form-dropzone style-square"
-        id={undefined}
+        inputProps={
+          Object {
+            "aria-describedby": "upload-error-18",
+            "id": "upload-17",
+          }
+        }
         multiple={false}
         onDrop={[Function]}
         style={undefined}
@@ -128,12 +133,13 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
     >
       <label
         className=""
-        htmlFor={undefined}
+        htmlFor="text-input-15"
       >
         Video ID
       </label>
       <input
-        id={undefined}
+        aria-describedby="text-input-error-16"
+        id="text-input-15"
         onChange={[Function]}
         placeholder="Video ID"
         type="text"
@@ -160,6 +166,7 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
             className="manicon manicon-caret-down"
           />
           <select
+            aria-describedby="select-error-12"
             id={undefined}
             onChange={[Function]}
             value={undefined}

--- a/client/src/components/backend/Resource/Form/KindPicker.js
+++ b/client/src/components/backend/Resource/Form/KindPicker.js
@@ -11,12 +11,13 @@ class KindPicker extends PureComponent {
   static propTypes = {
     getModelValue: PropTypes.func,
     includeButtons: PropTypes.bool,
-    set: PropTypes.func
+    set: PropTypes.func,
+    id: PropTypes.string
   };
 
-  componentDidMount() {
-    this.id = uniqueId("kind-");
-  }
+  static defaultProps = {
+    id: uniqueId("kind-")
+  };
 
   renderKindPickerButtons(kindList) {
     if (!kindList) return null;
@@ -87,12 +88,12 @@ class KindPicker extends PureComponent {
     return (
       <div className="resource-kind-picker form-secondary">
         <div className="form-input">
-          <label htmlFor={this.id}>Kind</label>
+          <label htmlFor={this.props.id}>Kind</label>
           <div className={selectClass}>
             <div className="form-select">
               <i className="manicon manicon-caret-down" aria-hidden="true" />
               <select
-                id={this.id}
+                id={this.props.id}
                 onChange={event => {
                   this.props.set(event.target.value);
                 }}

--- a/client/src/components/backend/Resource/Form/__tests__/__snapshots__/KindAttributes-test.js.snap
+++ b/client/src/components/backend/Resource/Form/__tests__/__snapshots__/KindAttributes-test.js.snap
@@ -10,14 +10,19 @@ exports[`Backend.Resource.Form.KindAttributes component when kind is audio rende
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="upload-17"
     >
       Image File
     </label>
     <react-dropzone
       accept="image/*"
       className="form-dropzone style-square"
-      id={undefined}
+      inputProps={
+        Object {
+          "aria-describedby": "upload-error-18",
+          "id": "upload-17",
+        }
+      }
       multiple={false}
       onDrop={[Function]}
       style={undefined}

--- a/client/src/components/backend/Resource/Form/__tests__/__snapshots__/KindPicker-test.js.snap
+++ b/client/src/components/backend/Resource/Form/__tests__/__snapshots__/KindPicker-test.js.snap
@@ -8,7 +8,7 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
     className="form-input"
   >
     <label
-      htmlFor={undefined}
+      htmlFor="kind-22"
     >
       Kind
     </label>
@@ -23,7 +23,7 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
           className="manicon manicon-caret-down"
         />
         <select
-          id={undefined}
+          id="kind-22"
           onChange={[Function]}
           value="image"
         >

--- a/client/src/components/backend/TwitterQuery/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/components/backend/TwitterQuery/__tests__/__snapshots__/Form-test.js.snap
@@ -13,7 +13,7 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
     >
       <label
         className=""
-        htmlFor={undefined}
+        htmlFor="text-input-9"
       >
         Query
       </label>
@@ -31,7 +31,8 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
         .
       </p>
       <input
-        id={undefined}
+        aria-describedby="text-input-error-10"
+        id="text-input-9"
         onChange={[Function]}
         placeholder="Enter query"
         type="text"
@@ -58,6 +59,7 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
             className="manicon manicon-caret-down"
           />
           <select
+            aria-describedby="select-error-6"
             id={undefined}
             onChange={[Function]}
             value={undefined}

--- a/client/src/components/frontend/Layout/__tests__/__snapshots__/Header-test.js.snap
+++ b/client/src/components/frontend/Layout/__tests__/__snapshots__/Header-test.js.snap
@@ -143,6 +143,7 @@ exports[`Frontend.Layout.Header component renders correctly 1`] = `
   />
   <section
     className="notifications-container"
+    role="alert"
   >
     <div
       className="notifications-list-header notifications-list"

--- a/client/src/components/frontend/Project/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/components/frontend/Project/__tests__/__snapshots__/Resources-test.js.snap
@@ -49,12 +49,12 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
         </button>
         <label
           className="screen-reader-text"
-          htmlFor={undefined}
+          htmlFor="filters-search-20"
         >
           Enter Search Criteria
         </label>
         <input
-          id={undefined}
+          id="filters-search-20"
           onChange={[Function]}
           placeholder="Search"
           type="text"

--- a/client/src/components/frontend/Resource/Player/Audio.js
+++ b/client/src/components/frontend/Resource/Player/Audio.js
@@ -7,7 +7,14 @@ import uniqueId from "lodash/uniqueId";
 
 export default class ResourcePlayerAudio extends Component {
   static propTypes = {
-    resource: PropTypes.object
+    resource: PropTypes.object,
+    progressBarId: PropTypes.string,
+    volumeBarId: PropTypes.string
+  };
+
+  static defaultProps = {
+    progressBarId: uniqueId("progress-bar-"),
+    volumeBarId: uniqueId("volume-bar-")
   };
 
   constructor() {
@@ -27,8 +34,6 @@ export default class ResourcePlayerAudio extends Component {
 
   componentDidMount() {
     // https://github.com/katspaugh/wavesurfer.js/issues/1334
-    this.progressBarId = uniqueId("progress-bar-");
-    this.volumeBarId = uniqueId("volume-bar-");
     this.WaveSurfer = require("wavesurfer"); // eslint-disable-line global-require
     this.throttleUpdateTime = throttle(this.updateTime, 900);
     this.debouncedResize = debounce(this.resizeWaveform, 120);
@@ -197,13 +202,13 @@ export default class ResourcePlayerAudio extends Component {
                 }}
               />
               <label
-                htmlFor={this.progressBarId}
+                htmlFor={this.props.progressBarId}
                 className="screen-reader-text"
               >
                 Progress Bar
               </label>
               <input
-                id={this.progressBarId}
+                id={this.props.progressBarId}
                 type="range"
                 min="0"
                 max="100"
@@ -227,11 +232,14 @@ export default class ResourcePlayerAudio extends Component {
                   left: `${volume * 0.7 - 10}px`
                 }}
               />
-              <label htmlFor={this.volumeBarId} className="screen-reader-text">
+              <label
+                htmlFor={this.props.volumeBarId}
+                className="screen-reader-text"
+              >
                 Adjust Volume
               </label>
               <input
-                id={this.volumeBarId}
+                id={this.props.volumeBarId}
                 type="range"
                 min="0"
                 max="100"

--- a/client/src/components/frontend/ResourceCollection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/components/frontend/ResourceCollection/__tests__/__snapshots__/Detail-test.js.snap
@@ -285,12 +285,12 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
         </button>
         <label
           className="screen-reader-text"
-          htmlFor={undefined}
+          htmlFor="filters-search-20"
         >
           Enter Search Criteria
         </label>
         <input
-          id={undefined}
+          id="filters-search-20"
           onChange={[Function]}
           placeholder="Search"
           type="text"

--- a/client/src/components/frontend/ResourceList/Filters.js
+++ b/client/src/components/frontend/ResourceList/Filters.js
@@ -11,7 +11,12 @@ export default class ResourceListFilters extends Component {
     kinds: PropTypes.array,
     tags: PropTypes.array,
     filterChangeHandler: PropTypes.func.isRequired,
-    initialFilterState: PropTypes.object
+    initialFilterState: PropTypes.object,
+    searchId: PropTypes.string
+  };
+
+  static defaultProps = {
+    searchId: uniqueId("filters-search-")
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -25,10 +30,6 @@ export default class ResourceListFilters extends Component {
   constructor(props) {
     super(props);
     this.state = this.initialState(props.initialFilterState);
-  }
-
-  componentDidMount() {
-    this.searchId = uniqueId("filters-search-");
   }
 
   setFilters = (event, label) => {
@@ -64,13 +65,13 @@ export default class ResourceListFilters extends Component {
             <span className="screen-reader-text">Search</span>
             <i className="manicon manicon-magnify" aria-hidden="true" />
           </button>
-          <label htmlFor={this.searchId} className="screen-reader-text">
+          <label htmlFor={this.props.searchId} className="screen-reader-text">
             Enter Search Criteria
           </label>
           <input
             value={this.state.filters.keyword || ""}
             type="text"
-            id={this.searchId}
+            id={this.props.searchId}
             onChange={event => this.setFilters(event, "keyword")}
             placeholder="Search"
           />

--- a/client/src/components/frontend/ResourceList/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/components/frontend/ResourceList/__tests__/__snapshots__/Filters-test.js.snap
@@ -24,12 +24,12 @@ exports[`Frontend.ResourceList.Filters Component renders correctly 1`] = `
     </button>
     <label
       className="screen-reader-text"
-      htmlFor={undefined}
+      htmlFor="filters-search-1"
     >
       Enter Search Criteria
     </label>
     <input
-      id={undefined}
+      id="filters-search-1"
       onChange={[Function]}
       placeholder="Search"
       type="text"

--- a/client/src/components/global/FatalError.js
+++ b/client/src/components/global/FatalError.js
@@ -36,7 +36,12 @@ export default class FatalError extends Component {
               </h3>
             </header>
 
-            <div className="error-description">
+            <div
+              className="error-description"
+              role="alert"
+              aria-live="assertive"
+              aria-atomic="true"
+            >
               <h1>
                 {statusMessage} {title}
               </h1>

--- a/client/src/components/global/Form/Errorable.js
+++ b/client/src/components/global/Form/Errorable.js
@@ -14,7 +14,8 @@ export default class Errorable extends PureComponent {
     className: PropTypes.string,
     name: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
     children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
-    nameForError: PropTypes.string
+    nameForError: PropTypes.string,
+    idForError: PropTypes.string
   };
 
   static defaultProps = {
@@ -68,7 +69,11 @@ export default class Errorable extends PureComponent {
       <div style={this.props.containerStyle} className={wrapperClass}>
         {children}
         {hasErrors ? (
-          <Form.InputError errors={fieldErrors} name={nameForError} />
+          <Form.InputError
+            errors={fieldErrors}
+            idForError={this.props.idForError ? this.props.idForError : null}
+            name={nameForError}
+          />
         ) : null}
       </div>
     );

--- a/client/src/components/global/Form/InputError.js
+++ b/client/src/components/global/Form/InputError.js
@@ -9,7 +9,8 @@ import config from "../../../config";
 export default class InputError extends Component {
   static propTypes = {
     errors: PropTypes.array,
-    name: PropTypes.string
+    name: PropTypes.string,
+    idForError: PropTypes.string
   };
 
   hasErrors = () => {
@@ -38,7 +39,13 @@ export default class InputError extends Component {
   render() {
     if (this.hasErrors()) {
       return (
-        <span className="errors">
+        <span
+          id={this.props.idForError ? this.props.idForError : null}
+          className="errors"
+          role="alert"
+          aria-live="polite"
+          aria-atomic="true"
+        >
           {this.props.errors.map((e, i) => {
             return (
               <span key={i} className="error">

--- a/client/src/components/global/Form/__tests__/__snapshots__/Errorable-test.js.snap
+++ b/client/src/components/global/Form/__tests__/__snapshots__/Errorable-test.js.snap
@@ -6,7 +6,11 @@ exports[`Global.Form.Errorable component renders correctly 1`] = `
   style={Object {}}
 >
   <span
+    aria-atomic="true"
+    aria-live="polite"
     className="errors"
+    id={null}
+    role="alert"
   >
     <span
       className="error"

--- a/client/src/components/global/Form/__tests__/__snapshots__/InputError-test.js.snap
+++ b/client/src/components/global/Form/__tests__/__snapshots__/InputError-test.js.snap
@@ -2,7 +2,11 @@
 
 exports[`Global.Form.InputError component renders correctly 1`] = `
 <span
+  aria-atomic="true"
+  aria-live="polite"
   className="errors"
+  id={null}
+  role="alert"
 >
   <span
     className="error"

--- a/client/src/components/global/Notification.js
+++ b/client/src/components/global/Notification.js
@@ -19,7 +19,11 @@ export default class Notification extends Component {
   bodyCopy() {
     let output = null;
     if (this.props.body) {
-      output = <p className="notification-body">{this.props.body}</p>;
+      output = (
+        <p className="notification-body" role="status" aria-live="polite">
+          {this.props.body}
+        </p>
+      );
     }
 
     return output;
@@ -36,7 +40,7 @@ export default class Notification extends Component {
     return (
       <div className={notificationClass} key={this.props.id}>
         <div className="container">
-          <header>
+          <header role="status" aria-live="polite" aria-atomic="true">
             <h5 className="notification-heading">{this.props.heading}</h5>
           </header>
           {this.bodyCopy()}

--- a/client/src/components/global/Search/Query/Form.js
+++ b/client/src/components/global/Search/Query/Form.js
@@ -12,7 +12,8 @@ export default class SearchQuery extends PureComponent {
     facets: PropTypes.array,
     scopes: PropTypes.array,
     description: PropTypes.string,
-    searchType: PropTypes.string
+    searchType: PropTypes.string,
+    searchId: PropTypes.string
   };
 
   /* eslint-disable no-console */
@@ -23,7 +24,8 @@ export default class SearchQuery extends PureComponent {
       console.warn("The SearchQuery component expects an doSearch callback.");
       console.warn("Current SearchQuery State");
       console.warn(state);
-    }
+    },
+    searchId: uniqueId("query-search-")
   };
   /* eslint-enable no-console */
 
@@ -43,10 +45,6 @@ export default class SearchQuery extends PureComponent {
     } else {
       this.state = Object.assign({}, defaultState);
     }
-  }
-
-  componentDidMount() {
-    this.searchId = uniqueId("query-search-");
   }
 
   componentDidUpdate() {
@@ -144,12 +142,12 @@ export default class SearchQuery extends PureComponent {
     return (
       <form className="search-query" onSubmit={this.doSearch}>
         <div className="input-magnify">
-          <label htmlFor={this.searchId} className="screen-reader-text">
+          <label htmlFor={this.props.searchId} className="screen-reader-text">
             Enter Search Criteria
           </label>
           <input
             type="text"
-            id={this.searchId}
+            id={this.props.searchId}
             autoFocus
             onChange={this.setKeyword}
             value={this.state.keyword}
@@ -168,8 +166,8 @@ export default class SearchQuery extends PureComponent {
               {this.props.searchType === "reader" ? (
                 <h4 className="group-label">{"Search within:"}</h4>
               ) : null}
-              {this.props.scopes.map(scope => {
-                const filterCheckboxId = uniqueId(scope.value + "-");
+              {this.props.scopes.map((scope, index) => {
+                const filterCheckboxId = scope.value + "-" + index;
 
                 return (
                   <label
@@ -211,8 +209,8 @@ export default class SearchQuery extends PureComponent {
                 </div>
                 {"Everything"}
               </label>
-              {this.props.facets.map(facet => {
-                const facetCheckboxId = uniqueId(facet.value + "-");
+              {this.props.facets.map((facet, index) => {
+                const facetCheckboxId = facet.value + "-" + index;
 
                 return (
                   <label

--- a/client/src/components/global/Search/__tests__/__snapshots__/menu-test.js.snap
+++ b/client/src/components/global/Search/__tests__/__snapshots__/menu-test.js.snap
@@ -22,13 +22,13 @@ exports[`Reader.Search.Menu component renders correctly when search is visible 1
       >
         <label
           className="screen-reader-text"
-          htmlFor={undefined}
+          htmlFor="query-search-22"
         >
           Enter Search Criteria
         </label>
         <input
           autoFocus={true}
-          id={undefined}
+          id="query-search-22"
           onChange={[Function]}
           placeholder="Search for..."
           type="text"

--- a/client/src/components/global/SignInUp/Create.js
+++ b/client/src/components/global/SignInUp/Create.js
@@ -118,6 +118,7 @@ export class CreateContainer extends Component {
               className="form-input"
               name="attributes[email]"
               errors={errors}
+              idForError="create-email-error"
             >
               <label htmlFor="create-email">Email</label>
               <input
@@ -125,6 +126,7 @@ export class CreateContainer extends Component {
                 type="text"
                 name="email"
                 id="create-email"
+                aria-describedby="create-email-error"
                 onChange={this.handleInputChange}
                 placeholder="Email"
               />
@@ -133,6 +135,7 @@ export class CreateContainer extends Component {
           <div className="row-1-p">
             <Form.Errorable
               className="form-input"
+              idForError="create-name-error"
               name={["attributes[firstName]", "attributes[lastName]"]}
               errors={errors}
             >
@@ -141,6 +144,7 @@ export class CreateContainer extends Component {
                 value={this.state.user.name}
                 type="text"
                 id="create-name"
+                aria-describedby="create-name-error"
                 name="name"
                 onChange={this.handleInputChange}
                 placeholder="Name"
@@ -150,6 +154,7 @@ export class CreateContainer extends Component {
           <div className="row-1-p">
             <Form.Errorable
               className="form-input"
+              idForError="create-password-error"
               name="attributes[password]"
               errors={errors}
             >
@@ -159,6 +164,7 @@ export class CreateContainer extends Component {
                 type="password"
                 name="password"
                 id="create-password"
+                aria-describedby="create-password-error"
                 onChange={this.handleInputChange}
                 placeholder="Password"
               />
@@ -167,6 +173,7 @@ export class CreateContainer extends Component {
           <div className="row-1-p">
             <Form.Errorable
               className="form-input"
+              idForError="create-password-confirmation-error"
               name="attributes[passwordConfirmation]"
               errors={errors}
             >
@@ -178,6 +185,7 @@ export class CreateContainer extends Component {
                 type="password"
                 name="passwordConfirmation"
                 id="create-password-confirmation"
+                aria-describedby="create-password-confirmation-error"
                 onChange={this.handleInputChange}
                 placeholder="Confirm Password"
               />

--- a/client/src/components/global/SignInUp/Login.js
+++ b/client/src/components/global/SignInUp/Login.js
@@ -104,7 +104,7 @@ export default class Login extends Component {
           <div className="row-1-p">
             <div className={submitClass}>
               {this.authenticationError() ? (
-                <span style={{ marginTop: 0 }} className="error">
+                <span style={{ marginTop: 0 }} role="alert" className="error">
                   {this.authenticationError()}
                 </span>
               ) : null}

--- a/client/src/components/global/SignInUp/Oauth/Monitor.js
+++ b/client/src/components/global/SignInUp/Oauth/Monitor.js
@@ -68,7 +68,9 @@ class Monitor extends Component {
 
     if (this.hasErrors()) {
       errorList = (
-        <ul>{this.errors.map(error => <li key={error}>{error}</li>)}</ul>
+        <ul role="alert">
+          {this.errors.map(error => <li key={error}>{error}</li>)}
+        </ul>
       );
     }
 

--- a/client/src/components/global/SignInUp/PasswordForgot.js
+++ b/client/src/components/global/SignInUp/PasswordForgot.js
@@ -112,6 +112,7 @@ class PasswordForgotContainer extends Component {
                 validation={["required"]}
                 name="email"
                 onChange={event => this.handleInputChange(event)}
+                idForError="password-forgot-email-error"
               >
                 <input
                   value={this.state.email}
@@ -119,6 +120,7 @@ class PasswordForgotContainer extends Component {
                   type="text"
                   id="password-forgot-email"
                   placeholder="Email"
+                  aria-describedby="password-forgot-email-error"
                 />
               </Form.HigherOrder.Validation>
             </div>

--- a/client/src/components/global/SignInUp/UpdateForm.js
+++ b/client/src/components/global/SignInUp/UpdateForm.js
@@ -183,6 +183,7 @@ class UpdateFormContainer extends Component {
             className="form-input"
             name="attributes[nickname]"
             errors={errors}
+            idForError="update-nickname-error"
           >
             <input
               value={this.state.nickname}
@@ -190,6 +191,7 @@ class UpdateFormContainer extends Component {
               name="nickname"
               id="update-nickname"
               aria-labelledby="update-nickname-label"
+              aria-describedby="update-nickname-error"
               onChange={this.handleInputChange}
               placeholder="Nickname"
             />
@@ -204,10 +206,15 @@ class UpdateFormContainer extends Component {
             )}
             <Form.Errorable
               className="form-input"
+              idForError="avatar-update-error"
               name="attributes[avatar]"
               errors={errors}
             >
               <Dropzone
+                inputProps={{
+                  id: "avatar-update",
+                  "aria-describedby": "avatar-update-error"
+                }}
                 className="form-dropzone"
                 style={{}}
                 activeStyle={{}}
@@ -263,6 +270,7 @@ class UpdateFormContainer extends Component {
             className="form-input"
             name="attributes[firstName]"
             errors={errors}
+            idForError="update-firstName-error"
           >
             <label htmlFor="update-firstName">First Name</label>
             <input
@@ -270,6 +278,7 @@ class UpdateFormContainer extends Component {
               type="text"
               name="firstName"
               id="update-firstName"
+              aria-describedby="update-firstName-error"
               onChange={this.handleInputChange}
               placeholder="First name"
             />
@@ -278,6 +287,7 @@ class UpdateFormContainer extends Component {
             className="form-input"
             name="attributes[lastName]"
             errors={errors}
+            idForError="update-lastName-error"
           >
             <label htmlFor="update-lastName">Last Name</label>
             <input
@@ -285,6 +295,7 @@ class UpdateFormContainer extends Component {
               type="text"
               name="lastName"
               id="update-lastName"
+              aria-describedby="update-lastName-error"
               onChange={this.handleInputChange}
               placeholder="Last name"
             />
@@ -293,6 +304,7 @@ class UpdateFormContainer extends Component {
             className="form-input"
             name="attributes[email]"
             errors={errors}
+            idForError="update-email-error"
           >
             <label htmlFor="update-email">Email</label>
             <input
@@ -300,6 +312,7 @@ class UpdateFormContainer extends Component {
               type="text"
               name="email"
               id="update-email"
+              aria-describedby="update-email-error"
               onChange={this.handleInputChange}
               placeholder="Email"
             />
@@ -308,6 +321,7 @@ class UpdateFormContainer extends Component {
             className="form-input"
             name="attributes[password]"
             errors={errors}
+            idForError="update-password-error"
           >
             <label htmlFor="update-password">Password</label>
             <input
@@ -315,6 +329,7 @@ class UpdateFormContainer extends Component {
               type="password"
               name="password"
               id="update-password"
+              aria-describedby="update-password-error"
               onChange={this.handleInputChange}
               placeholder="New password"
             />
@@ -323,6 +338,7 @@ class UpdateFormContainer extends Component {
             className="form-input"
             name="attributes[passwordConfirmation]"
             errors={errors}
+            idForError="update-passwordConfirmation-error"
           >
             <label htmlFor="update-passwordConfirmation">
               Confirm Password
@@ -332,6 +348,7 @@ class UpdateFormContainer extends Component {
               type="password"
               name="passwordConfirmation"
               id="update-passwordConfirmation"
+              aria-describedby="update-passwordConfirmation-error"
               onChange={this.handleInputChange}
               placeholder="Confirm new password"
             />

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/Create-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/Create-test.js.snap
@@ -24,6 +24,7 @@ exports[`Global.SignInUp.Create component renders correctly 1`] = `
           Email
         </label>
         <input
+          aria-describedby="create-email-error"
           id="create-email"
           name="email"
           onChange={[Function]}
@@ -46,6 +47,7 @@ exports[`Global.SignInUp.Create component renders correctly 1`] = `
           Name
         </label>
         <input
+          aria-describedby="create-name-error"
           id="create-name"
           name="name"
           onChange={[Function]}
@@ -68,6 +70,7 @@ exports[`Global.SignInUp.Create component renders correctly 1`] = `
           Password
         </label>
         <input
+          aria-describedby="create-password-error"
           id="create-password"
           name="password"
           onChange={[Function]}
@@ -90,6 +93,7 @@ exports[`Global.SignInUp.Create component renders correctly 1`] = `
           Confirm Password
         </label>
         <input
+          aria-describedby="create-password-confirmation-error"
           id="create-password-confirmation"
           name="passwordConfirmation"
           onChange={[Function]}

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/CreateUpdate-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/CreateUpdate-test.js.snap
@@ -38,6 +38,7 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
       style={Object {}}
     >
       <input
+        aria-describedby="update-nickname-error"
         aria-labelledby="update-nickname-label"
         id="update-nickname"
         name="nickname"
@@ -66,6 +67,7 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
         First Name
       </label>
       <input
+        aria-describedby="update-firstName-error"
         id="update-firstName"
         name="firstName"
         onChange={[Function]}
@@ -84,6 +86,7 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
         Last Name
       </label>
       <input
+        aria-describedby="update-lastName-error"
         id="update-lastName"
         name="lastName"
         onChange={[Function]}
@@ -102,6 +105,7 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
         Email
       </label>
       <input
+        aria-describedby="update-email-error"
         id="update-email"
         name="email"
         onChange={[Function]}
@@ -120,6 +124,7 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
         Password
       </label>
       <input
+        aria-describedby="update-password-error"
         id="update-password"
         name="password"
         onChange={[Function]}
@@ -138,6 +143,7 @@ exports[`Global.SignInUp.CreateUpdate component renders correctly 1`] = `
         Confirm Password
       </label>
       <input
+        aria-describedby="update-passwordConfirmation-error"
         id="update-passwordConfirmation"
         name="passwordConfirmation"
         onChange={[Function]}

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/PasswordForgot-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/PasswordForgot-test.js.snap
@@ -19,6 +19,7 @@ exports[`Global.SignInUp.PasswordForgot component renders correctly 1`] = `
         </label>
         <div>
           <input
+            aria-describedby="password-forgot-email-error"
             id="password-forgot-email"
             name="email"
             onChange={[Function]}

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/Update-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/Update-test.js.snap
@@ -34,6 +34,7 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
       style={Object {}}
     >
       <input
+        aria-describedby="update-nickname-error"
         aria-labelledby="update-nickname-label"
         id="update-nickname"
         name="nickname"
@@ -62,6 +63,7 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
         First Name
       </label>
       <input
+        aria-describedby="update-firstName-error"
         id="update-firstName"
         name="firstName"
         onChange={[Function]}
@@ -80,6 +82,7 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
         Last Name
       </label>
       <input
+        aria-describedby="update-lastName-error"
         id="update-lastName"
         name="lastName"
         onChange={[Function]}
@@ -98,6 +101,7 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
         Email
       </label>
       <input
+        aria-describedby="update-email-error"
         id="update-email"
         name="email"
         onChange={[Function]}
@@ -116,6 +120,7 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
         Password
       </label>
       <input
+        aria-describedby="update-password-error"
         id="update-password"
         name="password"
         onChange={[Function]}
@@ -134,6 +139,7 @@ exports[`Global.SignInUp.Update component renders correctly 1`] = `
         Confirm Password
       </label>
       <input
+        aria-describedby="update-passwordConfirmation-error"
         id="update-passwordConfirmation"
         name="passwordConfirmation"
         onChange={[Function]}

--- a/client/src/components/global/SignInUp/__tests__/__snapshots__/UpdateForm-test.js.snap
+++ b/client/src/components/global/SignInUp/__tests__/__snapshots__/UpdateForm-test.js.snap
@@ -34,6 +34,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
       style={Object {}}
     >
       <input
+        aria-describedby="update-nickname-error"
         aria-labelledby="update-nickname-label"
         id="update-nickname"
         name="nickname"
@@ -62,6 +63,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
         First Name
       </label>
       <input
+        aria-describedby="update-firstName-error"
         id="update-firstName"
         name="firstName"
         onChange={[Function]}
@@ -80,6 +82,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
         Last Name
       </label>
       <input
+        aria-describedby="update-lastName-error"
         id="update-lastName"
         name="lastName"
         onChange={[Function]}
@@ -98,6 +101,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
         Email
       </label>
       <input
+        aria-describedby="update-email-error"
         id="update-email"
         name="email"
         onChange={[Function]}
@@ -116,6 +120,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
         Password
       </label>
       <input
+        aria-describedby="update-password-error"
         id="update-password"
         name="password"
         onChange={[Function]}
@@ -134,6 +139,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is exi
         Confirm Password
       </label>
       <input
+        aria-describedby="update-passwordConfirmation-error"
         id="update-passwordConfirmation"
         name="passwordConfirmation"
         onChange={[Function]}
@@ -197,6 +203,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
       style={Object {}}
     >
       <input
+        aria-describedby="update-nickname-error"
         aria-labelledby="update-nickname-label"
         id="update-nickname"
         name="nickname"
@@ -225,6 +232,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
         First Name
       </label>
       <input
+        aria-describedby="update-firstName-error"
         id="update-firstName"
         name="firstName"
         onChange={[Function]}
@@ -243,6 +251,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
         Last Name
       </label>
       <input
+        aria-describedby="update-lastName-error"
         id="update-lastName"
         name="lastName"
         onChange={[Function]}
@@ -261,6 +270,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
         Email
       </label>
       <input
+        aria-describedby="update-email-error"
         id="update-email"
         name="email"
         onChange={[Function]}
@@ -279,6 +289,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
         Password
       </label>
       <input
+        aria-describedby="update-password-error"
         id="update-password"
         name="password"
         onChange={[Function]}
@@ -297,6 +308,7 @@ exports[`Global.SignInUp.UpdateForm component renders correctly when mode is new
         Confirm Password
       </label>
       <input
+        aria-describedby="update-passwordConfirmation-error"
         id="update-passwordConfirmation"
         name="passwordConfirmation"
         onChange={[Function]}

--- a/client/src/components/global/__tests__/__snapshots__/FatalError-test.js.snap
+++ b/client/src/components/global/__tests__/__snapshots__/FatalError-test.js.snap
@@ -29,7 +29,10 @@ exports[`Global.FatalError component renders correctly 1`] = `
         </h3>
       </header>
       <div
+        aria-atomic="true"
+        aria-live="assertive"
         className="error-description"
+        role="alert"
       >
         <h1>
           404 error.

--- a/client/src/components/global/__tests__/__snapshots__/Notification-test.js.snap
+++ b/client/src/components/global/__tests__/__snapshots__/Notification-test.js.snap
@@ -7,7 +7,11 @@ exports[`Global.HeaderNotification component renders correctly 1`] = `
   <div
     className="container"
   >
-    <header>
+    <header
+      aria-atomic="true"
+      aria-live="polite"
+      role="status"
+    >
       <h5
         className="notification-heading"
       >
@@ -15,7 +19,9 @@ exports[`Global.HeaderNotification component renders correctly 1`] = `
       </h5>
     </header>
     <p
+      aria-live="polite"
       className="notification-body"
+      role="status"
     >
       Here's your ticket.  Every time I get wicked.
     </p>

--- a/client/src/components/reader/Annotation/Editor.js
+++ b/client/src/components/reader/Annotation/Editor.js
@@ -105,6 +105,7 @@ export default class AnnotationSelectionEditor extends PureComponent {
           <GlobalForm.Errorable
             name="attributes[body]"
             errors={this.state.errors}
+            idForError="annotation-textarea-error"
           >
             <label htmlFor="annotation-textarea" className="screen-reader-text">
               Annotate this passage
@@ -114,6 +115,7 @@ export default class AnnotationSelectionEditor extends PureComponent {
                 this.ci = ci;
               }}
               id="annotation-textarea"
+              aria-describedby="annotation-textarea-error"
               style={{ width: "100%" }}
               placeholder={"Annotate this passage..."}
               onChange={this.handleBodyChange}

--- a/client/src/components/reader/Annotation/Selection/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/components/reader/Annotation/Selection/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -40,6 +40,7 @@ exports[`Reader.Annotation.Selection.Wrapper component renders correctly 1`] = `
           Annotate this passage
         </label>
         <textarea
+          aria-describedby="annotation-textarea-error"
           id="annotation-textarea"
           onChange={[Function]}
           placeholder="Annotate this passage..."

--- a/client/src/components/reader/Annotation/__tests__/__snapshots__/Editor-test.js.snap
+++ b/client/src/components/reader/Annotation/__tests__/__snapshots__/Editor-test.js.snap
@@ -18,6 +18,7 @@ exports[`Reader.Annotation.Editor component renders correctly 1`] = `
         Annotate this passage
       </label>
       <textarea
+        aria-describedby="annotation-textarea-error"
         id="annotation-textarea"
         onChange={[Function]}
         placeholder="Annotate this passage..."

--- a/client/src/components/reader/ControlMenu/VisibilityMenuBody.js
+++ b/client/src/components/reader/ControlMenu/VisibilityMenuBody.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import capitalize from "lodash/capitalize";
-import uniqueId from "lodash/uniqueId";
 
 export default class VisibilityMenuBody extends PureComponent {
   static displayName = "ControlMenu.VisibilityMenuBody";
@@ -45,17 +44,17 @@ export default class VisibilityMenuBody extends PureComponent {
         <i className={this.iconClasses(format)} aria-hidden="true" />
         <span>{label}</span>
         <div className="filters">
-          {Object.keys(filterState).map(key => {
-            return this.renderCheckbox(key, filterState, format);
+          {Object.keys(filterState).map((key, index) => {
+            return this.renderCheckbox(key, filterState, format, index);
           })}
         </div>
       </li>
     );
   }
 
-  renderCheckbox(key, filterState, format) {
+  renderCheckbox(key, filterState, format, index) {
     let label = capitalize(key);
-    const checkboxId = uniqueId(label + "-checkbox-");
+    const checkboxId = key + "-checkbox-" + index;
     if (key === "all") label = "Show All";
 
     return (

--- a/client/src/components/reader/ControlMenu/__tests__/__snapshots__/VisibilityMenuBody-test.js.snap
+++ b/client/src/components/reader/ControlMenu/__tests__/__snapshots__/VisibilityMenuBody-test.js.snap
@@ -18,11 +18,11 @@ exports[`Reader.ControlMenu.VisibilityMenuBody Component renders correctly 1`] =
       >
         <label
           className="checkbox"
-          htmlFor="Yours-checkbox-1"
+          htmlFor="yours-checkbox-0"
         >
           <input
             checked={true}
-            id="Yours-checkbox-1"
+            id="yours-checkbox-0"
             onChange={[Function]}
             type="checkbox"
           />
@@ -38,11 +38,11 @@ exports[`Reader.ControlMenu.VisibilityMenuBody Component renders correctly 1`] =
         </label>
         <label
           className="checkbox"
-          htmlFor="Others-checkbox-2"
+          htmlFor="others-checkbox-1"
         >
           <input
             checked={true}
-            id="Others-checkbox-2"
+            id="others-checkbox-1"
             onChange={[Function]}
             type="checkbox"
           />
@@ -71,11 +71,11 @@ exports[`Reader.ControlMenu.VisibilityMenuBody Component renders correctly 1`] =
       >
         <label
           className="checkbox"
-          htmlFor="Yours-checkbox-3"
+          htmlFor="yours-checkbox-0"
         >
           <input
             checked={true}
-            id="Yours-checkbox-3"
+            id="yours-checkbox-0"
             onChange={[Function]}
             type="checkbox"
           />
@@ -91,11 +91,11 @@ exports[`Reader.ControlMenu.VisibilityMenuBody Component renders correctly 1`] =
         </label>
         <label
           className="checkbox"
-          htmlFor="Others-checkbox-4"
+          htmlFor="others-checkbox-1"
         >
           <input
             checked={true}
-            id="Others-checkbox-4"
+            id="others-checkbox-1"
             onChange={[Function]}
             type="checkbox"
           />
@@ -124,11 +124,11 @@ exports[`Reader.ControlMenu.VisibilityMenuBody Component renders correctly 1`] =
       >
         <label
           className="checkbox"
-          htmlFor="All-checkbox-5"
+          htmlFor="all-checkbox-0"
         >
           <input
             checked={true}
-            id="All-checkbox-5"
+            id="all-checkbox-0"
             onChange={[Function]}
             type="checkbox"
           />

--- a/client/src/components/reader/Notes/Partial/Filters.js
+++ b/client/src/components/reader/Notes/Partial/Filters.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import uniqueId from "lodash/uniqueId";
 
 export default class Filters extends Component {
   static displayName = "Notes.List.Filters";
@@ -28,7 +27,7 @@ export default class Filters extends Component {
   renderCheckBox(label, format) {
     const formats = this.props.filter.formats;
     const checked = this.filteredBy(formats, format);
-    const checkboxId = uniqueId(label + "-checkbox-");
+    const checkboxId = format + "-checkbox";
 
     return (
       <label htmlFor={checkboxId} className="checkbox">

--- a/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/Filters-test.js.snap
@@ -14,11 +14,11 @@ exports[`Reader.Notes.Partial.Group Component renders correctly 1`] = `
   >
     <label
       className="checkbox"
-      htmlFor="Highlights-checkbox-1"
+      htmlFor="highlight-checkbox"
     >
       <input
         checked={true}
-        id="Highlights-checkbox-1"
+        id="highlight-checkbox"
         onChange={[Function]}
         type="checkbox"
       />
@@ -34,11 +34,11 @@ exports[`Reader.Notes.Partial.Group Component renders correctly 1`] = `
     </label>
     <label
       className="checkbox"
-      htmlFor="Annotations-checkbox-2"
+      htmlFor="annotation-checkbox"
     >
       <input
         checked={true}
-        id="Annotations-checkbox-2"
+        id="annotation-checkbox"
         onChange={[Function]}
         type="checkbox"
       />

--- a/client/src/components/reader/Notes/__tests__/__snapshots__/FilteredList-test.js.snap
+++ b/client/src/components/reader/Notes/__tests__/__snapshots__/FilteredList-test.js.snap
@@ -36,11 +36,11 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
     >
       <label
         className="checkbox"
-        htmlFor="Highlights-checkbox-1"
+        htmlFor="highlight-checkbox"
       >
         <input
           checked={true}
-          id="Highlights-checkbox-1"
+          id="highlight-checkbox"
           onChange={[Function]}
           type="checkbox"
         />
@@ -56,11 +56,11 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
       </label>
       <label
         className="checkbox"
-        htmlFor="Annotations-checkbox-2"
+        htmlFor="annotation-checkbox"
       >
         <input
           checked={true}
-          id="Annotations-checkbox-2"
+          id="annotation-checkbox"
           onChange={[Function]}
           type="checkbox"
         />

--- a/client/src/components/reader/__tests__/__snapshots__/Header-test.js.snap
+++ b/client/src/components/reader/__tests__/__snapshots__/Header-test.js.snap
@@ -415,6 +415,7 @@ exports[`Reader.Header Component renders correctly 1`] = `
   </nav>
   <section
     className="notifications-container"
+    role="alert"
   >
     <div
       className="notifications-list-header notifications-list"
@@ -830,6 +831,7 @@ exports[`Reader.Header Component renders correctly when no TOC or metadata 1`] =
   </nav>
   <section
     className="notifications-container"
+    role="alert"
   >
     <div
       className="notifications-list-header notifications-list"

--- a/client/src/containers/backend/Collection/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Collection/__tests__/__snapshots__/General-test.js.snap
@@ -14,12 +14,13 @@ exports[`Backend Collection General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Title
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter a title"
           type="text"
@@ -35,12 +36,13 @@ exports[`Backend Collection General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="textarea-13"
           >
             Description
           </label>
           <textarea
-            id={undefined}
+            aria-describedby="textarea-error-14"
+            id="textarea-13"
             onChange={[Function]}
             placeholder="Enter a description"
             style={
@@ -61,14 +63,19 @@ exports[`Backend Collection General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="upload-17"
           >
             Cover Image
           </label>
           <react-dropzone
             accept="image/*"
             className="form-dropzone style-landscape"
-            id={undefined}
+            inputProps={
+              Object {
+                "aria-describedby": "upload-error-18",
+                "id": "upload-17",
+              }
+            }
             multiple={false}
             onDrop={[Function]}
             style={undefined}

--- a/client/src/containers/backend/Collection/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Collection/__tests__/__snapshots__/New-test.js.snap
@@ -89,12 +89,13 @@ exports[`Backend Collection New Container renders correctly 1`] = `
             >
               <label
                 className=""
-                htmlFor={undefined}
+                htmlFor="text-input-9"
               >
                 Title
               </label>
               <input
-                id={undefined}
+                aria-describedby="text-input-error-10"
+                id="text-input-9"
                 onChange={[Function]}
                 placeholder="Enter a title"
                 type="text"
@@ -110,12 +111,13 @@ exports[`Backend Collection New Container renders correctly 1`] = `
               >
                 <label
                   className=""
-                  htmlFor={undefined}
+                  htmlFor="textarea-7"
                 >
                   Description
                 </label>
                 <textarea
-                  id={undefined}
+                  aria-describedby="textarea-error-8"
+                  id="textarea-7"
                   onChange={[Function]}
                   placeholder="Enter a description"
                   style={
@@ -136,14 +138,19 @@ exports[`Backend Collection New Container renders correctly 1`] = `
               >
                 <label
                   className=""
-                  htmlFor={undefined}
+                  htmlFor="upload-11"
                 >
                   Cover Image
                 </label>
                 <react-dropzone
                   accept="image/*"
                   className="form-dropzone style-landscape"
-                  id={undefined}
+                  inputProps={
+                    Object {
+                      "aria-describedby": "upload-error-12",
+                      "id": "upload-11",
+                    }
+                  }
                   multiple={false}
                   onDrop={[Function]}
                   style={undefined}

--- a/client/src/containers/backend/Collection/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/containers/backend/Collection/__tests__/__snapshots__/Resources-test.js.snap
@@ -39,12 +39,12 @@ exports[`Backend Collection Resources Container renders correctly 1`] = `
           </button>
           <label
             className="screen-reader-text"
-            htmlFor={undefined}
+            htmlFor="list-search-19"
           >
             Enter Search Criteria
           </label>
           <input
-            id={undefined}
+            id="list-search-19"
             onChange={[Function]}
             placeholder="Search..."
             type="text"

--- a/client/src/containers/backend/Dashboards/__tests__/__snapshots__/Admin-test.js.snap
+++ b/client/src/containers/backend/Dashboards/__tests__/__snapshots__/Admin-test.js.snap
@@ -45,12 +45,12 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                 </button>
                 <label
                   className="screen-reader-text"
-                  htmlFor={undefined}
+                  htmlFor="list-search-19"
                 >
                   Enter Search Criteria
                 </label>
                 <input
-                  id={undefined}
+                  id="list-search-19"
                   onChange={[Function]}
                   placeholder="Search..."
                   type="text"

--- a/client/src/containers/backend/Dashboards/__tests__/__snapshots__/Author-test.js.snap
+++ b/client/src/containers/backend/Dashboards/__tests__/__snapshots__/Author-test.js.snap
@@ -40,12 +40,12 @@ exports[`Backend Dashboards Author Container renders correctly 1`] = `
               </button>
               <label
                 className="screen-reader-text"
-                htmlFor={undefined}
+                htmlFor="list-search-19"
               >
                 Enter Search Criteria
               </label>
               <input
-                id={undefined}
+                id="list-search-19"
                 onChange={[Function]}
                 placeholder="Search..."
                 type="text"

--- a/client/src/containers/backend/Form/PredictiveInput.js
+++ b/client/src/containers/backend/Form/PredictiveInput.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import update from "immutability-helper";
 import debounce from "lodash/debounce";
-import uniqueId from "lodash/uniqueId";
 import classNames from "classnames";
 import { ApiClient } from "api";
 
@@ -24,7 +23,8 @@ class PredictiveInput extends PureComponent {
     fetch: PropTypes.func.isRequired,
     fetchOptions: PropTypes.object,
     placeholder: PropTypes.string,
-    authToken: PropTypes.string
+    authToken: PropTypes.string,
+    idForError: PropTypes.string
   };
 
   static defaultProps = {
@@ -41,10 +41,6 @@ class PredictiveInput extends PureComponent {
       options: [],
       highlighted: false
     };
-  }
-
-  componentDidMount() {
-    this.id = uniqueId("predictive-input-");
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -239,11 +235,12 @@ class PredictiveInput extends PureComponent {
             onChange={this.handleChange}
             value={this.state.value}
             placeholder={this.props.placeholder}
-            aria-label={this.props.placeholder}
             onBlur={this.handleBlur}
             onFocus={this.handleFocus}
             onKeyPress={this.handleKeyPress}
             onKeyDown={this.handleKeyDown}
+            aria-label={this.props.placeholder}
+            aria-describedby={this.idForError ? this.idForError : null}
           />
           {this.props.onNew ? (
             <button className="submit" onClick={this.handleNew}>

--- a/client/src/containers/backend/Form/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/containers/backend/Form/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -83,6 +83,7 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
               className="manicon manicon-plus"
             />
             <input
+              aria-describedby={null}
               aria-label="Add an Author"
               className="text-input"
               onBlur={[Function]}
@@ -187,6 +188,7 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
               className="manicon manicon-plus"
             />
             <input
+              aria-describedby={null}
               aria-label="Add a Contributor"
               className="text-input"
               onBlur={[Function]}

--- a/client/src/containers/backend/People/Makers/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/People/Makers/__tests__/__snapshots__/Edit-test.js.snap
@@ -40,12 +40,13 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             First Name
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="First Name"
             type="text"
@@ -58,12 +59,13 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Middle Name
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Middle Name"
             type="text"
@@ -76,12 +78,13 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Last Name
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Last Name"
             type="text"
@@ -94,12 +97,13 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Suffix
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Suffix"
             type="text"
@@ -115,14 +119,19 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor={undefined}
+              htmlFor="upload-17"
             >
               Avatar Image
             </label>
             <react-dropzone
               accept="image/*"
               className="form-dropzone style-square"
-              id={undefined}
+              inputProps={
+                Object {
+                  "aria-describedby": "upload-error-18",
+                  "id": "upload-17",
+                }
+              }
               multiple={false}
               onDrop={[Function]}
               style={undefined}

--- a/client/src/containers/backend/People/Makers/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/containers/backend/People/Makers/__tests__/__snapshots__/List-test.js.snap
@@ -36,12 +36,12 @@ exports[`Backend People Makers List Container renders correctly 1`] = `
         </button>
         <label
           className="screen-reader-text"
-          htmlFor={undefined}
+          htmlFor="list-search-19"
         >
           Enter Search Criteria
         </label>
         <input
-          id={undefined}
+          id="list-search-19"
           onChange={[Function]}
           placeholder="Search..."
           type="text"

--- a/client/src/containers/backend/People/Makers/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/People/Makers/__tests__/__snapshots__/New-test.js.snap
@@ -26,12 +26,13 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-9"
           >
             First Name
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-10"
+            id="text-input-9"
             onChange={[Function]}
             placeholder="First Name"
             type="text"
@@ -44,12 +45,13 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-9"
           >
             Middle Name
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-10"
+            id="text-input-9"
             onChange={[Function]}
             placeholder="Middle Name"
             type="text"
@@ -62,12 +64,13 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-9"
           >
             Last Name
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-10"
+            id="text-input-9"
             onChange={[Function]}
             placeholder="Last Name"
             type="text"
@@ -80,12 +83,13 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-9"
           >
             Suffix
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-10"
+            id="text-input-9"
             onChange={[Function]}
             placeholder="Suffix"
             type="text"
@@ -101,14 +105,19 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor={undefined}
+              htmlFor="upload-11"
             >
               Avatar Image
             </label>
             <react-dropzone
               accept="image/*"
               className="form-dropzone style-square"
-              id={undefined}
+              inputProps={
+                Object {
+                  "aria-describedby": "upload-error-12",
+                  "id": "upload-11",
+                }
+              }
               multiple={false}
               onDrop={[Function]}
               style={undefined}

--- a/client/src/containers/backend/People/Users/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/People/Users/__tests__/__snapshots__/Edit-test.js.snap
@@ -51,12 +51,13 @@ exports[`Backend People Users Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Email
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Email"
             type="text"
@@ -69,12 +70,13 @@ exports[`Backend People Users Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             First Name
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="First Name"
             type="text"
@@ -87,12 +89,13 @@ exports[`Backend People Users Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Last Name
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Last Name"
             type="text"
@@ -119,6 +122,7 @@ exports[`Backend People Users Edit Container renders correctly 1`] = `
                 className="manicon manicon-caret-down"
               />
               <select
+                aria-describedby="select-error-12"
                 id={undefined}
                 onChange={[Function]}
                 value="admin"

--- a/client/src/containers/backend/People/Users/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/containers/backend/People/Users/__tests__/__snapshots__/List-test.js.snap
@@ -36,12 +36,12 @@ exports[`Backend People Users List Container renders correctly 1`] = `
         </button>
         <label
           className="screen-reader-text"
-          htmlFor={undefined}
+          htmlFor="list-search-19"
         >
           Enter Search Criteria
         </label>
         <input
-          id={undefined}
+          id="list-search-19"
           onChange={[Function]}
           placeholder="Search..."
           type="text"

--- a/client/src/containers/backend/People/Users/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/People/Users/__tests__/__snapshots__/New-test.js.snap
@@ -23,12 +23,13 @@ exports[`Backend Users New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="text-input-1"
+          htmlFor="text-input-15"
         >
           Email
         </label>
         <input
-          id="text-input-1"
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Email"
           type="text"
@@ -43,7 +44,7 @@ exports[`Backend Users New Container renders correctly 1`] = `
           style={Object {}}
         >
           <label
-            htmlFor="select-2"
+            htmlFor={undefined}
           >
             Role
           </label>
@@ -55,7 +56,8 @@ exports[`Backend Users New Container renders correctly 1`] = `
               className="manicon manicon-caret-down"
             />
             <select
-              id="select-2"
+              aria-describedby="select-error-12"
+              id={undefined}
               onChange={[Function]}
               value="reader"
             >
@@ -94,12 +96,13 @@ exports[`Backend Users New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="text-input-3"
+          htmlFor="text-input-15"
         >
           First Name
         </label>
         <input
-          id="text-input-3"
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="First Name"
           type="text"
@@ -112,12 +115,13 @@ exports[`Backend Users New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="text-input-4"
+          htmlFor="text-input-15"
         >
           Last Name
         </label>
         <input
-          id="text-input-4"
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Last Name"
           type="text"
@@ -129,7 +133,7 @@ exports[`Backend Users New Container renders correctly 1`] = `
         style={Object {}}
       >
         <label
-          htmlFor="generated-password-5"
+          htmlFor="generated-password-7"
         >
           Password
         </label>
@@ -150,7 +154,8 @@ exports[`Backend Users New Container renders correctly 1`] = `
           </span>
         </span>
         <input
-          id="generated-password-5"
+          aria-describedby="generated-password-error-8"
+          id="generated-password-7"
           onChange={[Function]}
           placeholder="Enter a password"
           type="password"

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/Form-test.js.snap
@@ -26,6 +26,7 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
                 className="manicon manicon-plus"
               />
               <input
+                aria-describedby={null}
                 aria-label="Select User"
                 className="text-input"
                 onBlur={[Function]}

--- a/client/src/containers/backend/Permission/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Permission/__tests__/__snapshots__/New-test.js.snap
@@ -36,6 +36,7 @@ exports[`Backend Permission New Container renders correctly 1`] = `
                   className="manicon manicon-plus"
                 />
                 <input
+                  aria-describedby={null}
                   aria-label="Select User"
                   className="text-input"
                   onBlur={[Function]}

--- a/client/src/containers/backend/Project/Category/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/Project/Category/__tests__/__snapshots__/Edit-test.js.snap
@@ -23,12 +23,13 @@ exports[`Backend Project Category Edit Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Title
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="What would you like to call this category?"
           type="text"

--- a/client/src/containers/backend/Project/Category/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Project/Category/__tests__/__snapshots__/New-test.js.snap
@@ -21,12 +21,13 @@ exports[`Backend Project Category New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Title
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="What would you like to call this category?"
           type="text"

--- a/client/src/containers/backend/Project/Resource/__tests__/__snapshots__/CollectionsList-test.js.snap
+++ b/client/src/containers/backend/Project/Resource/__tests__/__snapshots__/CollectionsList-test.js.snap
@@ -37,12 +37,12 @@ exports[`Backend Project Resource CollectionList Container renders correctly 1`]
         </button>
         <label
           className="screen-reader-text"
-          htmlFor={undefined}
+          htmlFor="list-search-19"
         >
           Enter Search Criteria
         </label>
         <input
-          id={undefined}
+          id="list-search-19"
           onChange={[Function]}
           placeholder="Search..."
           type="text"

--- a/client/src/containers/backend/Project/Resource/__tests__/__snapshots__/ResourcesList-test.js.snap
+++ b/client/src/containers/backend/Project/Resource/__tests__/__snapshots__/ResourcesList-test.js.snap
@@ -37,12 +37,12 @@ exports[`Backend Project Resource ResourcesList Container renders correctly 1`] 
         </button>
         <label
           className="screen-reader-text"
-          htmlFor={undefined}
+          htmlFor="list-search-19"
         >
           Enter Search Criteria
         </label>
         <input
-          id={undefined}
+          id="list-search-19"
           onChange={[Function]}
           placeholder="Search..."
           type="text"

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -84,6 +84,7 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
                 className="manicon manicon-plus"
               />
               <input
+                aria-describedby={null}
                 aria-label="Add an Author"
                 className="text-input"
                 onBlur={[Function]}
@@ -188,6 +189,7 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
                 className="manicon manicon-plus"
               />
               <input
+                aria-describedby={null}
                 aria-label="Add a Contributor"
                 className="text-input"
                 onBlur={[Function]}

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/Collections-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/Collections-test.js.snap
@@ -38,12 +38,12 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
           </button>
           <label
             className="screen-reader-text"
-            htmlFor={undefined}
+            htmlFor="list-search-19"
           >
             Enter Search Criteria
           </label>
           <input
-            id={undefined}
+            id="list-search-19"
             onChange={[Function]}
             placeholder="Search..."
             type="text"

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/Events-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/Events-test.js.snap
@@ -35,12 +35,12 @@ exports[`Backend Project Events Container renders correctly 1`] = `
         </button>
         <label
           className="screen-reader-text"
-          htmlFor={undefined}
+          htmlFor="list-search-19"
         >
           Enter Search Criteria
         </label>
         <input
-          id={undefined}
+          id="list-search-19"
           onChange={[Function]}
           placeholder="Search..."
           type="text"

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/General-test.js.snap
@@ -24,12 +24,13 @@ exports[`Backend Project General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Title
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Enter Project Title"
             type="text"
@@ -42,12 +43,13 @@ exports[`Backend Project General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Subtitle
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Enter Project Subtitle"
             type="text"
@@ -60,12 +62,13 @@ exports[`Backend Project General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Slug
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Enter Project Slug"
             type="text"
@@ -156,7 +159,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="masked-text-10"
           >
             Hashtag
           </label>
@@ -168,12 +171,13 @@ exports[`Backend Project General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Facebook ID
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={undefined}
             type="text"
@@ -186,12 +190,13 @@ exports[`Backend Project General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Twitter ID
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={undefined}
             type="text"
@@ -204,12 +209,13 @@ exports[`Backend Project General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Instagram ID
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={undefined}
             type="text"
@@ -233,12 +239,13 @@ exports[`Backend Project General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Publisher
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={undefined}
             type="text"
@@ -498,6 +505,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
                   className="manicon manicon-plus"
                 />
                 <input
+                  aria-describedby={null}
                   aria-label="Add a Subject"
                   className="text-input"
                   onBlur={[Function]}
@@ -733,7 +741,12 @@ exports[`Backend Project General Container renders correctly 1`] = `
                   <react-dropzone
                     accept="image/*"
                     className="form-dropzone style-embed"
-                    id={undefined}
+                    inputProps={
+                      Object {
+                        "aria-describedby": "upload-error-18",
+                        "id": "upload-17",
+                      }
+                    }
                     multiple={false}
                     onDrop={[Function]}
                     style={undefined}

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/Metadata-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/Metadata-test.js.snap
@@ -24,12 +24,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             isbn
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="International Standard Book Number"
             type="text"
@@ -42,12 +43,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             issn
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="International Standard Serial Number"
             type="text"
@@ -71,12 +73,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             publisher
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="The Publisher"
             type="text"
@@ -89,7 +92,7 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className="has-instructions"
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             publisher place
           </label>
@@ -99,7 +102,8 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
             e.g "Minneapolis, MN"
           </span>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Geographic location of the publisher"
             type="text"
@@ -112,12 +116,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             original publisher
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Original publisher, for items that have been republished by a different publisher"
             type="text"
@@ -130,12 +135,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             original publisher place
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Geographic location of the original publisher"
             type="text"
@@ -159,7 +165,7 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className="has-instructions"
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             container title
           </label>
@@ -169,7 +175,8 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
             e.g. the book title for a book chapter, the journal title for a journal article
           </span>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Title of the container holding the item"
             type="text"
@@ -182,12 +189,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             version
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Version of the item"
             type="text"
@@ -200,7 +208,7 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className="has-instructions"
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             edition
           </label>
@@ -210,7 +218,8 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
             e.g. "3" when citing a chapter in the third edition of a book
           </span>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="(Container) edition holding the item"
             type="text"
@@ -223,7 +232,7 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className="has-instructions"
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             issue
           </label>
@@ -233,7 +242,8 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
             e.g. "5" when citing a journal article from journal volume 2, issue 5
           </span>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="(Container) issue holding the item"
             type="text"
@@ -246,7 +256,7 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className="has-instructions"
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             volume
           </label>
@@ -256,7 +266,8 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
             e.g. “2” when citing a chapter from book volume 2
           </span>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="(Container) volume holding the item "
             type="text"
@@ -269,12 +280,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             original title
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Title of the original version"
             type="text"
@@ -298,12 +310,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             abstract
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -316,12 +329,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             archive
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -334,12 +348,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             archive location
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -352,12 +367,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             archive place
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -370,12 +386,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             authority
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -388,12 +405,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             call number
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -406,12 +424,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             chapter number
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -424,12 +443,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             collection number
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -442,12 +462,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             collection title
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -460,12 +481,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             dimensions
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -478,12 +500,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             event
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -496,12 +519,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             event place
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -514,12 +538,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             jurisdiction
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -532,12 +557,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             medium
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -550,12 +576,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             number
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -568,12 +595,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             number of pages
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -586,12 +614,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             number of volumes
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -604,12 +633,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             pmcid
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -622,12 +652,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             pmid
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -640,12 +671,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             reviewed title
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -658,12 +690,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             section
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"
@@ -676,12 +709,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             year suffix
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={null}
             type="text"

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/New-test.js.snap
@@ -90,12 +90,13 @@ exports[`Backend Project New Container renders correctly 1`] = `
               >
                 <label
                   className=""
-                  htmlFor={undefined}
+                  htmlFor="text-input-15"
                 >
                   Title
                 </label>
                 <input
-                  id={undefined}
+                  aria-describedby="text-input-error-16"
+                  id="text-input-15"
                   onChange={[Function]}
                   placeholder="Enter Project Title"
                   type="text"
@@ -108,12 +109,13 @@ exports[`Backend Project New Container renders correctly 1`] = `
               >
                 <label
                   className=""
-                  htmlFor={undefined}
+                  htmlFor="text-input-15"
                 >
                   Subtitle
                 </label>
                 <input
-                  id={undefined}
+                  aria-describedby="text-input-error-16"
+                  id="text-input-15"
                   onChange={[Function]}
                   placeholder="Enter Project Subtitle"
                   type="text"
@@ -129,12 +131,13 @@ exports[`Backend Project New Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor={undefined}
+                    htmlFor="textarea-13"
                   >
                     Description
                   </label>
                   <textarea
-                    id={undefined}
+                    aria-describedby="textarea-error-14"
+                    id="textarea-13"
                     onChange={[Function]}
                     placeholder={undefined}
                     style={

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/ProjectPage-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/ProjectPage-test.js.snap
@@ -17,7 +17,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
         >
           <label
             className="has-instructions"
-            htmlFor={undefined}
+            htmlFor="textarea-13"
           >
             Description
           </label>
@@ -27,7 +27,8 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
             Enter a brief description of your project. This field accepts basic Markdown.
           </span>
           <textarea
-            id={undefined}
+            aria-describedby="textarea-error-14"
+            id="textarea-13"
             onChange={[Function]}
             placeholder={undefined}
             style={
@@ -48,7 +49,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="upload-17"
           >
             Hero Image
           </label>
@@ -64,7 +65,12 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           <react-dropzone
             accept="image/*"
             className="form-dropzone style-landscape"
-            id={undefined}
+            inputProps={
+              Object {
+                "aria-describedby": "upload-error-18",
+                "id": "upload-17",
+              }
+            }
             multiple={false}
             onDrop={[Function]}
             style={undefined}
@@ -113,7 +119,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
         >
           <label
             className="has-instructions"
-            htmlFor={undefined}
+            htmlFor="upload-17"
           >
             Cover
           </label>
@@ -125,7 +131,12 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           <react-dropzone
             accept="image/*"
             className="form-dropzone style-portrait"
-            id={undefined}
+            inputProps={
+              Object {
+                "aria-describedby": "upload-error-18",
+                "id": "upload-17",
+              }
+            }
             multiple={false}
             onDrop={[Function]}
             style={undefined}
@@ -171,7 +182,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Purchase URL
         </label>
@@ -181,7 +192,8 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           A URL where users can purchase the published edition
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter Purchase URL"
           type="text"
@@ -194,7 +206,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Purchase Call To Action
         </label>
@@ -204,7 +216,8 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           If set, this text will appear in the buy button on the project page
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Buy Print Version"
           type="text"
@@ -216,7 +229,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="masked-text-10"
         >
           Purchase Price
         </label>
@@ -226,7 +239,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           The cost of the published edition
         </span>
         <react-text-mask
-          id={undefined}
+          id="masked-text-10"
           mask={[Function]}
           onChange={[Function]}
           placeholder={undefined}
@@ -241,7 +254,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Currency
         </label>
@@ -251,7 +264,8 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           For example, USD for US Dollars
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter Purchase Price Currency Code"
           type="text"
@@ -264,7 +278,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Twitter Username
         </label>
@@ -274,7 +288,8 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           If set, a twitter icon linked to the account will appear below the description.
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter Twitter username"
           type="text"
@@ -287,7 +302,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Instagram Username
         </label>
@@ -297,7 +312,8 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           If set, a instagram icon linked to the account will appear below the description.
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter Instagram username"
           type="text"

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/Resources-test.js.snap
@@ -38,12 +38,12 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
           </button>
           <label
             className="screen-reader-text"
-            htmlFor={undefined}
+            htmlFor="list-search-19"
           >
             Enter Search Criteria
           </label>
           <input
-            id={undefined}
+            id="list-search-19"
             onChange={[Function]}
             placeholder="Search..."
             type="text"

--- a/client/src/containers/backend/Resource/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Resource/__tests__/__snapshots__/General-test.js.snap
@@ -15,7 +15,7 @@ exports[`Backend Resource General Container renders correctly 1`] = `
           className="form-input"
         >
           <label
-            htmlFor={undefined}
+            htmlFor="kind-22"
           >
             Kind
           </label>
@@ -30,7 +30,7 @@ exports[`Backend Resource General Container renders correctly 1`] = `
                 className="manicon manicon-caret-down"
               />
               <select
-                id={undefined}
+                id="kind-22"
                 onChange={[Function]}
                 value="image"
               >
@@ -105,12 +105,13 @@ exports[`Backend Resource General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Title
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter a title"
           type="text"
@@ -123,12 +124,13 @@ exports[`Backend Resource General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Fingerprint
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter fingerprint"
           type="text"
@@ -141,12 +143,13 @@ exports[`Backend Resource General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Slug
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter slug"
           type="text"
@@ -159,7 +162,7 @@ exports[`Backend Resource General Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Tags
         </label>
@@ -169,7 +172,8 @@ exports[`Backend Resource General Container renders correctly 1`] = `
           Separate tags with "," or ";"
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter tags"
           type="text"
@@ -185,12 +189,13 @@ exports[`Backend Resource General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="textarea-13"
           >
             Description
           </label>
           <textarea
-            id={undefined}
+            aria-describedby="textarea-error-14"
+            id="textarea-13"
             onChange={[Function]}
             placeholder="Enter a description"
             style={
@@ -211,12 +216,13 @@ exports[`Backend Resource General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="textarea-13"
           >
             Caption
           </label>
           <textarea
-            id={undefined}
+            aria-describedby="textarea-error-14"
+            id="textarea-13"
             onChange={[Function]}
             placeholder="Enter a short description"
             style={
@@ -237,14 +243,19 @@ exports[`Backend Resource General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="upload-17"
           >
             Image File
           </label>
           <react-dropzone
             accept="image/*"
             className="form-dropzone style-square"
-            id={undefined}
+            inputProps={
+              Object {
+                "aria-describedby": "upload-error-18",
+                "id": "upload-17",
+              }
+            }
             multiple={false}
             onDrop={[Function]}
             style={undefined}

--- a/client/src/containers/backend/Resource/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Resource/__tests__/__snapshots__/New-test.js.snap
@@ -90,7 +90,7 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                 className="form-input"
               >
                 <label
-                  htmlFor={undefined}
+                  htmlFor="kind-21"
                 >
                   Kind
                 </label>
@@ -105,7 +105,7 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                       className="manicon manicon-caret-down"
                     />
                     <select
-                      id={undefined}
+                      id="kind-21"
                       onChange={[Function]}
                       value="image"
                     >
@@ -562,12 +562,13 @@ exports[`Backend Resource New Container renders correctly 1`] = `
             >
               <label
                 className=""
-                htmlFor={undefined}
+                htmlFor="text-input-9"
               >
                 Title
               </label>
               <input
-                id={undefined}
+                aria-describedby="text-input-error-10"
+                id="text-input-9"
                 onChange={[Function]}
                 placeholder="Enter a resource title"
                 type="text"
@@ -583,12 +584,13 @@ exports[`Backend Resource New Container renders correctly 1`] = `
               >
                 <label
                   className=""
-                  htmlFor={undefined}
+                  htmlFor="textarea-7"
                 >
                   Description
                 </label>
                 <textarea
-                  id={undefined}
+                  aria-describedby="textarea-error-8"
+                  id="textarea-7"
                   onChange={[Function]}
                   placeholder="Enter a description"
                   style={
@@ -609,14 +611,19 @@ exports[`Backend Resource New Container renders correctly 1`] = `
               >
                 <label
                   className=""
-                  htmlFor={undefined}
+                  htmlFor="upload-11"
                 >
                   Image File
                 </label>
                 <react-dropzone
                   accept="image/*"
                   className="form-dropzone style-square"
-                  id={undefined}
+                  inputProps={
+                    Object {
+                      "aria-describedby": "upload-error-12",
+                      "id": "upload-11",
+                    }
+                  }
                   multiple={false}
                   onDrop={[Function]}
                   style={undefined}

--- a/client/src/containers/backend/Resource/__tests__/__snapshots__/Variants-test.js.snap
+++ b/client/src/containers/backend/Resource/__tests__/__snapshots__/Variants-test.js.snap
@@ -20,14 +20,19 @@ exports[`Backend Resource Variants Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor={undefined}
+              htmlFor="upload-17"
             >
               High Resolution Image
             </label>
             <react-dropzone
               accept="image/*"
               className="form-dropzone style-square"
-              id={undefined}
+              inputProps={
+                Object {
+                  "aria-describedby": "upload-error-18",
+                  "id": "upload-17",
+                }
+              }
               multiple={false}
               onDrop={[Function]}
               style={undefined}
@@ -76,14 +81,19 @@ exports[`Backend Resource Variants Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor={undefined}
+              htmlFor="upload-17"
             >
               Thumbnail Image
             </label>
             <react-dropzone
               accept="image/*"
               className="form-dropzone style-square"
-              id={undefined}
+              inputProps={
+                Object {
+                  "aria-describedby": "upload-error-18",
+                  "id": "upload-17",
+                }
+              }
               multiple={false}
               onDrop={[Function]}
               style={undefined}

--- a/client/src/containers/backend/ResourceImport/New.js
+++ b/client/src/containers/backend/ResourceImport/New.js
@@ -74,7 +74,7 @@ export class ResourceImportNew extends PureComponent {
         {resourceImport && resourceImport.attributes.parseError ? (
           <div className="form-error form-input form-error-grouped">
             <span className="errors">
-              <span className="error">
+              <span className="error" role="alert">
                 {`Manifold was unable to parse the import data. If the source is a google
                 sheet, check to be sure that the sheet is publicly accessible (or that
                 it's accessible to your Google integration service account) and that the

--- a/client/src/containers/backend/Settings/Subjects/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/Settings/Subjects/__tests__/__snapshots__/Edit-test.js.snap
@@ -40,12 +40,13 @@ exports[`Backend Settings Subjects Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Name
           </label>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Name"
             type="text"

--- a/client/src/containers/backend/Settings/Subjects/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/containers/backend/Settings/Subjects/__tests__/__snapshots__/List-test.js.snap
@@ -36,12 +36,12 @@ exports[`Backend Settings Subjects List Container renders correctly 1`] = `
         </button>
         <label
           className="screen-reader-text"
-          htmlFor={undefined}
+          htmlFor="list-search-19"
         >
           Enter Search Criteria
         </label>
         <input
-          id={undefined}
+          id="list-search-19"
           onChange={[Function]}
           placeholder="Search..."
           type="text"

--- a/client/src/containers/backend/Settings/Subjects/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Settings/Subjects/__tests__/__snapshots__/New-test.js.snap
@@ -23,12 +23,13 @@ exports[`Backend Settings Subjects New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Name
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter Subject Name"
           type="text"

--- a/client/src/containers/backend/Settings/__tests__/__snapshots__/Email-test.js.snap
+++ b/client/src/containers/backend/Settings/__tests__/__snapshots__/Email-test.js.snap
@@ -29,7 +29,7 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
       >
         <label
           className="has-instructions"
-          htmlFor="text-input-11"
+          htmlFor="text-input-15"
         >
           Email from address
         </label>
@@ -39,7 +39,8 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
           All emails sent by manifold will be from this address.
         </span>
         <input
-          id="text-input-11"
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="do-not-reply@manifoldapp.org"
           type="text"
@@ -52,7 +53,7 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
       >
         <label
           className="has-instructions"
-          htmlFor="text-input-12"
+          htmlFor="text-input-15"
         >
           Email from name
         </label>
@@ -62,7 +63,8 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
           All emails sent by manifold will appear to be sent by this name.
         </span>
         <input
-          id="text-input-12"
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Manifold Scholarship"
           type="text"
@@ -75,7 +77,7 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
       >
         <label
           className="has-instructions"
-          htmlFor="text-input-13"
+          htmlFor="text-input-15"
         >
           Email reply-to address
         </label>
@@ -85,7 +87,8 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
           Replies to emails sent by Manifold will go to this address.
         </span>
         <input
-          id="text-input-13"
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="do-not-reply@manifoldapp.org"
           type="text"
@@ -98,7 +101,7 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
       >
         <label
           className="has-instructions"
-          htmlFor="text-input-14"
+          htmlFor="text-input-15"
         >
           Email reply-to name
         </label>
@@ -108,7 +111,8 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
           Replies to emails sent by Manifold will appear to be sent by this name.
         </span>
         <input
-          id="text-input-14"
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="text"
@@ -124,7 +128,7 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
         >
           <label
             className="has-instructions"
-            htmlFor="textarea-15"
+            htmlFor="textarea-13"
           >
             Email closing
           </label>
@@ -134,7 +138,8 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
             How do you want to close emails sent by Manifold?
           </span>
           <textarea
-            id="textarea-15"
+            aria-describedby="textarea-error-14"
+            id="textarea-13"
             onChange={[Function]}
             placeholder="Sincerely,
 The Manifold Team"
@@ -155,7 +160,7 @@ The Manifold Team"
           style={Object {}}
         >
           <label
-            htmlFor="select-16"
+            htmlFor={undefined}
           >
             Email Delivery Method
           </label>
@@ -167,7 +172,8 @@ The Manifold Team"
               className="manicon manicon-caret-down"
             />
             <select
-              id="select-16"
+              aria-describedby="select-error-12"
+              id={undefined}
               onChange={[Function]}
               value={undefined}
             >
@@ -199,7 +205,7 @@ The Manifold Team"
         >
           <label
             className="has-instructions"
-            htmlFor="text-input-17"
+            htmlFor="text-input-15"
           >
             Sendmail Location
           </label>
@@ -209,7 +215,8 @@ The Manifold Team"
             The location of the sendmail executable. Defaults to /usr/sbin/sendmail.
           </span>
           <input
-            id="text-input-17"
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={undefined}
             type="text"
@@ -222,7 +229,7 @@ The Manifold Team"
         >
           <label
             className="has-instructions"
-            htmlFor="text-input-18"
+            htmlFor="text-input-15"
           >
             Sendmail Arguments
           </label>
@@ -232,7 +239,8 @@ The Manifold Team"
             The command line arguments. Defaults to -i with -f sender@address added automatically before the message is sent.
           </span>
           <input
-            id="text-input-18"
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={undefined}
             type="text"
@@ -283,7 +291,7 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
       >
         <label
           className="has-instructions"
-          htmlFor="text-input-1"
+          htmlFor="text-input-15"
         >
           Email from address
         </label>
@@ -293,7 +301,8 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
           All emails sent by manifold will be from this address.
         </span>
         <input
-          id="text-input-1"
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="do-not-reply@manifoldapp.org"
           type="text"
@@ -306,7 +315,7 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
       >
         <label
           className="has-instructions"
-          htmlFor="text-input-2"
+          htmlFor="text-input-15"
         >
           Email from name
         </label>
@@ -316,7 +325,8 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
           All emails sent by manifold will appear to be sent by this name.
         </span>
         <input
-          id="text-input-2"
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Manifold Scholarship"
           type="text"
@@ -329,7 +339,7 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
       >
         <label
           className="has-instructions"
-          htmlFor="text-input-3"
+          htmlFor="text-input-15"
         >
           Email reply-to address
         </label>
@@ -339,7 +349,8 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
           Replies to emails sent by Manifold will go to this address.
         </span>
         <input
-          id="text-input-3"
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="do-not-reply@manifoldapp.org"
           type="text"
@@ -352,7 +363,7 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
       >
         <label
           className="has-instructions"
-          htmlFor="text-input-4"
+          htmlFor="text-input-15"
         >
           Email reply-to name
         </label>
@@ -362,7 +373,8 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
           Replies to emails sent by Manifold will appear to be sent by this name.
         </span>
         <input
-          id="text-input-4"
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="text"
@@ -378,7 +390,7 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
         >
           <label
             className="has-instructions"
-            htmlFor="textarea-5"
+            htmlFor="textarea-13"
           >
             Email closing
           </label>
@@ -388,7 +400,8 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
             How do you want to close emails sent by Manifold?
           </span>
           <textarea
-            id="textarea-5"
+            aria-describedby="textarea-error-14"
+            id="textarea-13"
             onChange={[Function]}
             placeholder="Sincerely,
 The Manifold Team"
@@ -409,7 +422,7 @@ The Manifold Team"
           style={Object {}}
         >
           <label
-            htmlFor="select-6"
+            htmlFor={undefined}
           >
             Email Delivery Method
           </label>
@@ -421,7 +434,8 @@ The Manifold Team"
               className="manicon manicon-caret-down"
             />
             <select
-              id="select-6"
+              aria-describedby="select-error-12"
+              id={undefined}
               onChange={[Function]}
               value={undefined}
             >
@@ -453,7 +467,7 @@ The Manifold Team"
         >
           <label
             className="has-instructions"
-            htmlFor="text-input-7"
+            htmlFor="text-input-15"
           >
             SMTP Address
           </label>
@@ -463,7 +477,8 @@ The Manifold Team"
             Allows you to use a remote mail server.
           </span>
           <input
-            id="text-input-7"
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={undefined}
             type="text"
@@ -476,7 +491,7 @@ The Manifold Team"
         >
           <label
             className="has-instructions"
-            htmlFor="text-input-8"
+            htmlFor="text-input-15"
           >
             SMTP Port
           </label>
@@ -486,7 +501,8 @@ The Manifold Team"
             On the off chance that your mail server doesn't run on port 25, you can change it.
           </span>
           <input
-            id="text-input-8"
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={undefined}
             type="text"
@@ -499,7 +515,7 @@ The Manifold Team"
         >
           <label
             className="has-instructions"
-            htmlFor="text-input-9"
+            htmlFor="text-input-15"
           >
             SMTP Username
           </label>
@@ -509,7 +525,8 @@ The Manifold Team"
             If your mail server requires authentication, set the username in this setting.
           </span>
           <input
-            id="text-input-9"
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={undefined}
             type="text"
@@ -522,7 +539,7 @@ The Manifold Team"
         >
           <label
             className="has-instructions"
-            htmlFor="text-input-10"
+            htmlFor="text-input-15"
           >
             SMTP Password
           </label>
@@ -532,7 +549,8 @@ The Manifold Team"
             If your mail server requires authentication, set the password in this setting.
           </span>
           <input
-            id="text-input-10"
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder={undefined}
             type="password"

--- a/client/src/containers/backend/Settings/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Settings/__tests__/__snapshots__/General-test.js.snap
@@ -14,7 +14,7 @@ exports[`Backend Settings General Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           How do you refer to your Manifold installation?
         </label>
@@ -24,7 +24,8 @@ exports[`Backend Settings General Container renders correctly 1`] = `
           There are various places throughout the application where             Manifold refers to itself. If you set a value here, Manifold will use it where             appropriate. For example, you could call it "Manifold at the University of             Minnesota Press" or just "University of Minnesota Digital Books." Or, if you            prefer, you can leave this blank, and Manifold will just refer to itself as             "Manifold."
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Manifold"
           type="text"
@@ -37,7 +38,7 @@ exports[`Backend Settings General Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Default Page Title
         </label>
@@ -47,7 +48,8 @@ exports[`Backend Settings General Container renders correctly 1`] = `
           This field will be used as the page title on the home page, and will be appended to the page title on core Manifold pages. Defaults to 'Manifold Scholarship'.
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter page title"
           type="text"
@@ -60,12 +62,13 @@ exports[`Backend Settings General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Default Publisher
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter Default Publisher"
           type="text"
@@ -78,12 +81,13 @@ exports[`Backend Settings General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Default Place of Publication
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter Default Place of Publication"
           type="text"
@@ -96,7 +100,7 @@ exports[`Backend Settings General Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Copyright
         </label>
@@ -106,7 +110,8 @@ exports[`Backend Settings General Container renders correctly 1`] = `
           Enter the installation copyright information to be displayed in the footer.
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter Copyright Information"
           type="text"
@@ -119,7 +124,7 @@ exports[`Backend Settings General Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Social Sharing Message
         </label>
@@ -129,7 +134,8 @@ exports[`Backend Settings General Container renders correctly 1`] = `
           Enter the text you would like to appear when a page is shared.
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="text"
@@ -142,7 +148,7 @@ exports[`Backend Settings General Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Twitter Account
         </label>
@@ -152,7 +158,8 @@ exports[`Backend Settings General Container renders correctly 1`] = `
           Enter the twitter account associated with this installation.
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter Twitter account"
           type="text"
@@ -165,7 +172,7 @@ exports[`Backend Settings General Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Facebook Page ID
         </label>
@@ -175,7 +182,8 @@ exports[`Backend Settings General Container renders correctly 1`] = `
           Enter an ID for this installation/organization's Facebook page.
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter Facebook ID"
           type="text"
@@ -188,7 +196,7 @@ exports[`Backend Settings General Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Contact Email
         </label>
@@ -198,7 +206,8 @@ exports[`Backend Settings General Container renders correctly 1`] = `
           If present, the footer will contain a link to a contact form that will be delivered to this address.
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter an email address"
           type="text"

--- a/client/src/containers/backend/Settings/__tests__/__snapshots__/Integrations-test.js.snap
+++ b/client/src/containers/backend/Settings/__tests__/__snapshots__/Integrations-test.js.snap
@@ -25,12 +25,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Facebook App ID
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="text"
@@ -43,12 +44,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Facebook App Secret
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="password"
@@ -72,12 +74,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Twitter Consumer Key
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="text"
@@ -90,12 +93,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Twitter Consumer Secret
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="password"
@@ -108,12 +112,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Twitter Access Token
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="text"
@@ -126,12 +131,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Twitter Access Token Secret
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="password"
@@ -158,14 +164,19 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="upload-17"
           >
             Google Service Config File
           </label>
           <react-dropzone
             accept="application/json"
             className="form-dropzone style-square"
-            id={undefined}
+            inputProps={
+              Object {
+                "aria-describedby": "upload-error-18",
+                "id": "upload-17",
+              }
+            }
             multiple={false}
             onDrop={[Function]}
             style={undefined}
@@ -214,12 +225,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="textarea-13"
           >
             Google Private Key
           </label>
           <textarea
-            id={undefined}
+            aria-describedby="textarea-error-14"
+            id="textarea-13"
             onChange={[Function]}
             placeholder={undefined}
             style={
@@ -237,12 +249,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Google Project Id
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="text"
@@ -255,12 +268,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Google Private Key ID
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="text"
@@ -273,12 +287,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Google Client Email
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="text"
@@ -291,12 +306,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Google Client ID
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="text"
@@ -320,12 +336,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Google OAuth Client ID
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="text"
@@ -338,12 +355,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Google Client Secret
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder={undefined}
           type="password"
@@ -366,12 +384,12 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="masked-text-10"
         >
           Google Analytics Profile ID
         </label>
         <react-text-mask
-          id={undefined}
+          id="masked-text-10"
           mask={
             Array [
               "g",
@@ -401,12 +419,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Google Analytics Tracking ID
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="UA-000000-00"
           type="text"

--- a/client/src/containers/backend/Settings/__tests__/__snapshots__/Placeholder-test.js.snap
+++ b/client/src/containers/backend/Settings/__tests__/__snapshots__/Placeholder-test.js.snap
@@ -10,12 +10,13 @@ exports[`Backend Settings Placeholder Container renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="text-input-15"
     >
       A All temporary stuff setting
     </label>
     <input
-      id={undefined}
+      aria-describedby="text-input-error-16"
+      id="text-input-15"
       onChange={[Function]}
       placeholder="Some setting could go here"
       type="text"
@@ -28,12 +29,13 @@ exports[`Backend Settings Placeholder Container renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor={undefined}
+      htmlFor="text-input-15"
     >
       Another All temporary stuff setting
     </label>
     <input
-      id={undefined}
+      aria-describedby="text-input-error-16"
+      id="text-input-15"
       onChange={[Function]}
       placeholder="Some other setting could go here"
       type="text"

--- a/client/src/containers/backend/Settings/__tests__/__snapshots__/Theme-test.js.snap
+++ b/client/src/containers/backend/Settings/__tests__/__snapshots__/Theme-test.js.snap
@@ -17,7 +17,7 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
         >
           <label
             className="has-instructions"
-            htmlFor={undefined}
+            htmlFor="upload-17"
           >
             Press Logo
           </label>
@@ -29,7 +29,12 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
           <react-dropzone
             accept="image/*"
             className="form-dropzone style-square"
-            id={undefined}
+            inputProps={
+              Object {
+                "aria-describedby": "upload-error-18",
+                "id": "upload-17",
+              }
+            }
             multiple={false}
             onDrop={[Function]}
             style={undefined}
@@ -75,7 +80,7 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Press Website URL
         </label>
@@ -85,7 +90,8 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
           If present, the press logo image will link to this URL.
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter URL"
           type="text"
@@ -98,7 +104,7 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Logo Styles
         </label>
@@ -108,7 +114,8 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
           Enter a JSON style object, which will be applied to the logo image. For example: {"left": -1}
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Additional Logo CSS"
           type="text"
@@ -121,12 +128,13 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Typekit ID
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter Typekit ID"
           type="text"

--- a/client/src/containers/backend/Stylesheet/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/Stylesheet/__tests__/__snapshots__/Edit-test.js.snap
@@ -35,14 +35,14 @@ exports[`Backend Stylesheet Edit Container renders correctly 1`] = `
                                         <p className=\\"instructions\\" />
                                       </div>
                                       <Form.Setter('Form.TextInput) label=\\"Name\\" name=\\"attributes[name]\\" placeholder=\\"Name\\" actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-stylesheet-create\\" submitKey={{...}} errors={{...}}>
-                                        <Form.TextInput label=\\"Name\\" name=\\"attributes[name]\\" placeholder=\\"Name\\" getModelValue={[Function: getModelValue]} sessionKey=\\"backend-stylesheet-create\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} focusOnMount={false} password={false} join={[Function: join]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[name]\\" errors={{...}} label=\\"Name\\" containerStyle={{...}}>
+                                        <Form.TextInput label=\\"Name\\" name=\\"attributes[name]\\" placeholder=\\"Name\\" getModelValue={[Function: getModelValue]} sessionKey=\\"backend-stylesheet-create\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} focusOnMount={false} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[name]\\" errors={{...}} label=\\"Name\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                             <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor={[undefined]} className=\\"\\">
+                                              <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                                 Name
                                               </label>
                                               <Instructions instructions={{...}} />
-                                              <input id={[undefined]} type=\\"text\\" placeholder=\\"Name\\" onChange={[Function]} value=\\"\\" />
+                                              <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"Name\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                             </div>
                                           </Errorable>
                                         </Form.TextInput>

--- a/client/src/containers/backend/Text/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/containers/backend/Text/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -84,6 +84,7 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
                 className="manicon manicon-plus"
               />
               <input
+                aria-describedby={null}
                 aria-label="Add an Author"
                 className="text-input"
                 onBlur={[Function]}
@@ -188,6 +189,7 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
                 className="manicon manicon-plus"
               />
               <input
+                aria-describedby={null}
                 aria-label="Add a Contributor"
                 className="text-input"
                 onBlur={[Function]}

--- a/client/src/containers/backend/Text/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Text/__tests__/__snapshots__/General-test.js.snap
@@ -14,12 +14,13 @@ exports[`Backend Text General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Title
         </label>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter Text Title"
           type="text"
@@ -247,12 +248,13 @@ exports[`Backend Text General Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="textarea-13"
           >
             Description
           </label>
           <textarea
-            id={undefined}
+            aria-describedby="textarea-error-14"
+            id="textarea-13"
             onChange={[Function]}
             placeholder="Enter a Brief Description"
             style={
@@ -270,7 +272,7 @@ exports[`Backend Text General Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Section Label
         </label>
@@ -280,7 +282,8 @@ exports[`Backend Text General Container renders correctly 1`] = `
           For example, “chapter” for books or “article” for journals
         </span>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter a label for sections in this text"
           type="text"

--- a/client/src/containers/backend/Text/__tests__/__snapshots__/Metadata-test.js.snap
+++ b/client/src/containers/backend/Text/__tests__/__snapshots__/Metadata-test.js.snap
@@ -24,27 +24,27 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                               </header>
                               <Instructions instructions={{...}} />
                               <Form.Setter('Form.TextInput) focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][isbn]\\" errors={{...}} label=\\"isbn\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][isbn]\\" errors={{...}} label=\\"isbn\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         isbn
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder=\\"International Standard Book Number\\" onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"International Standard Book Number\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][issn]\\" errors={{...}} label=\\"issn\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][issn]\\" errors={{...}} label=\\"issn\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         issn
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder=\\"International Standard Serial Number\\" onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"International Standard Serial Number\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
@@ -60,23 +60,23 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                               </header>
                               <Instructions instructions={{...}} />
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][publisher]\\" errors={{...}} label=\\"publisher\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][publisher]\\" errors={{...}} label=\\"publisher\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         publisher
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder=\\"The Publisher\\" onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"The Publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][publisherPlace]\\" errors={{...}} label=\\"publisher place\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][publisherPlace]\\" errors={{...}} label=\\"publisher place\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"has-instructions\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"has-instructions\\">
                                         publisher place
                                       </label>
                                       <Instructions instructions=\\"e.g \\"Minneapolis, MN\\"\\">
@@ -84,33 +84,33 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                                           e.g &quot;Minneapolis, MN&quot;
                                         </span>
                                       </Instructions>
-                                      <input id={[undefined]} type=\\"text\\" placeholder=\\"Geographic location of the publisher\\" onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"Geographic location of the publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalPublisher]\\" errors={{...}} label=\\"original publisher\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalPublisher]\\" errors={{...}} label=\\"original publisher\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         original publisher
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalPublisherPlace]\\" errors={{...}} label=\\"original publisher place\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalPublisherPlace]\\" errors={{...}} label=\\"original publisher place\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         original publisher place
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder=\\"Geographic location of the original publisher\\" onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"Geographic location of the original publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
@@ -126,10 +126,10 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                               </header>
                               <Instructions instructions={{...}} />
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][containerTitle]\\" errors={{...}} label=\\"container title\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][containerTitle]\\" errors={{...}} label=\\"container title\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"has-instructions\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"has-instructions\\">
                                         container title
                                       </label>
                                       <Instructions instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\">
@@ -137,29 +137,29 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                                           e.g. the book title for a book chapter, the journal title for a journal article
                                         </span>
                                       </Instructions>
-                                      <input id={[undefined]} type=\\"text\\" placeholder=\\"Title of the container holding the item\\" onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"Title of the container holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][version]\\" errors={{...}} label=\\"version\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][version]\\" errors={{...}} label=\\"version\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         version
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder=\\"Version of the item\\" onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"Version of the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][edition]\\" errors={{...}} label=\\"edition\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][edition]\\" errors={{...}} label=\\"edition\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"has-instructions\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"has-instructions\\">
                                         edition
                                       </label>
                                       <Instructions instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\">
@@ -167,16 +167,16 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                                           e.g. &quot;3&quot; when citing a chapter in the third edition of a book
                                         </span>
                                       </Instructions>
-                                      <input id={[undefined]} type=\\"text\\" placeholder=\\"(Container) edition holding the item\\" onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"(Container) edition holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][issue]\\" errors={{...}} label=\\"issue\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][issue]\\" errors={{...}} label=\\"issue\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"has-instructions\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"has-instructions\\">
                                         issue
                                       </label>
                                       <Instructions instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\">
@@ -184,16 +184,16 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                                           e.g. &quot;5&quot; when citing a journal article from journal volume 2, issue 5
                                         </span>
                                       </Instructions>
-                                      <input id={[undefined]} type=\\"text\\" placeholder=\\"(Container) issue holding the item\\" onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"(Container) issue holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][volume]\\" errors={{...}} label=\\"volume\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][volume]\\" errors={{...}} label=\\"volume\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"has-instructions\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"has-instructions\\">
                                         volume
                                       </label>
                                       <Instructions instructions=\\"e.g. “2” when citing a chapter from book volume 2\\">
@@ -201,20 +201,20 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                                           e.g. “2” when citing a chapter from book volume 2
                                         </span>
                                       </Instructions>
-                                      <input id={[undefined]} type=\\"text\\" placeholder=\\"(Container) volume holding the item \\" onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"(Container) volume holding the item \\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalTitle]\\" errors={{...}} label=\\"original title\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalTitle]\\" errors={{...}} label=\\"original title\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         original title
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder=\\"Title of the original version\\" onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder=\\"Title of the original version\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
@@ -230,287 +230,287 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                               </header>
                               <Instructions instructions={{...}} />
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][abstract]\\" errors={{...}} label=\\"abstract\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][abstract]\\" errors={{...}} label=\\"abstract\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         abstract
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archive]\\" errors={{...}} label=\\"archive\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archive]\\" errors={{...}} label=\\"archive\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         archive
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archiveLocation]\\" errors={{...}} label=\\"archive location\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archiveLocation]\\" errors={{...}} label=\\"archive location\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         archive location
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archivePlace]\\" errors={{...}} label=\\"archive place\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archivePlace]\\" errors={{...}} label=\\"archive place\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         archive place
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][authority]\\" errors={{...}} label=\\"authority\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][authority]\\" errors={{...}} label=\\"authority\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         authority
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][callNumber]\\" errors={{...}} label=\\"call number\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][callNumber]\\" errors={{...}} label=\\"call number\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         call number
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][chapterNumber]\\" errors={{...}} label=\\"chapter number\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][chapterNumber]\\" errors={{...}} label=\\"chapter number\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         chapter number
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][collectionNumber]\\" errors={{...}} label=\\"collection number\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][collectionNumber]\\" errors={{...}} label=\\"collection number\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         collection number
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][collectionTitle]\\" errors={{...}} label=\\"collection title\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][collectionTitle]\\" errors={{...}} label=\\"collection title\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         collection title
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][dimensions]\\" errors={{...}} label=\\"dimensions\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][dimensions]\\" errors={{...}} label=\\"dimensions\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         dimensions
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][event]\\" errors={{...}} label=\\"event\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][event]\\" errors={{...}} label=\\"event\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         event
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][eventPlace]\\" errors={{...}} label=\\"event place\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][eventPlace]\\" errors={{...}} label=\\"event place\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         event place
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][jurisdiction]\\" errors={{...}} label=\\"jurisdiction\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][jurisdiction]\\" errors={{...}} label=\\"jurisdiction\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         jurisdiction
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][medium]\\" errors={{...}} label=\\"medium\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][medium]\\" errors={{...}} label=\\"medium\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         medium
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][number]\\" errors={{...}} label=\\"number\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][number]\\" errors={{...}} label=\\"number\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         number
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][numberOfPages]\\" errors={{...}} label=\\"number of pages\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][numberOfPages]\\" errors={{...}} label=\\"number of pages\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         number of pages
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][numberOfVolumes]\\" errors={{...}} label=\\"number of volumes\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][numberOfVolumes]\\" errors={{...}} label=\\"number of volumes\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         number of volumes
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][pmcid]\\" errors={{...}} label=\\"pmcid\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][pmcid]\\" errors={{...}} label=\\"pmcid\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         pmcid
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][pmid]\\" errors={{...}} label=\\"pmid\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][pmid]\\" errors={{...}} label=\\"pmid\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         pmid
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][reviewedTitle]\\" errors={{...}} label=\\"reviewed title\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][reviewedTitle]\\" errors={{...}} label=\\"reviewed title\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         reviewed title
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][section]\\" errors={{...}} label=\\"section\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][section]\\" errors={{...}} label=\\"section\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         section
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>
                               </Form.Setter('Form.TextInput)>
                               <Form.Setter('Form.TextInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" actions={{...}} disabled={false} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}}>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]}>
-                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][yearSuffix]\\" errors={{...}} label=\\"year suffix\\" containerStyle={{...}}>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" disabled={false} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]} password={false} join={[Function: join]} id=\\"text-input-15\\" idForError=\\"text-input-error-16\\">
+                                  <Errorable className=\\"form-input\\" name=\\"attributes[metadata][yearSuffix]\\" errors={{...}} label=\\"year suffix\\" idForError=\\"text-input-error-16\\" containerStyle={{...}}>
                                     <div style={{...}} className=\\"form-input\\">
-                                      <label htmlFor={[undefined]} className=\\"\\">
+                                      <label htmlFor=\\"text-input-15\\" className=\\"\\">
                                         year suffix
                                       </label>
                                       <Instructions instructions={{...}} />
-                                      <input id={[undefined]} type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" />
+                                      <input id=\\"text-input-15\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-16\\" />
                                     </div>
                                   </Errorable>
                                 </Form.TextInput>

--- a/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/Edit-test.js.snap
@@ -55,7 +55,7 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor={undefined}
+            htmlFor="text-input-15"
           >
             Query
           </label>
@@ -73,7 +73,8 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
             .
           </p>
           <input
-            id={undefined}
+            aria-describedby="text-input-error-16"
+            id="text-input-15"
             onChange={[Function]}
             placeholder="Enter query"
             type="text"
@@ -100,6 +101,7 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
                 className="manicon manicon-caret-down"
               />
               <select
+                aria-describedby="select-error-12"
                 id={undefined}
                 onChange={[Function]}
                 value={undefined}

--- a/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/TwitterQuery/__tests__/__snapshots__/New-test.js.snap
@@ -23,7 +23,7 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor={undefined}
+          htmlFor="text-input-15"
         >
           Query
         </label>
@@ -41,7 +41,8 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
           .
         </p>
         <input
-          id={undefined}
+          aria-describedby="text-input-error-16"
+          id="text-input-15"
           onChange={[Function]}
           placeholder="Enter query"
           type="text"
@@ -68,6 +69,7 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
               className="manicon manicon-caret-down"
             />
             <select
+              aria-describedby="select-error-12"
               id={undefined}
               onChange={[Function]}
               value={undefined}

--- a/client/src/containers/backend/__tests__/__snapshots__/Backend-test.js.snap
+++ b/client/src/containers/backend/__tests__/__snapshots__/Backend-test.js.snap
@@ -112,7 +112,7 @@ exports[`Backend Backend Container renders correctly 1`] = `
                       <HeaderNotification scope=\\"global\\">
                         <Connect(NotificationsComponent) scope=\\"global\\">
                           <NotificationsComponent scope=\\"global\\" notifications={{...}} dispatch={[Function]} animate={true} style=\\"header\\">
-                            <section className=\\"notifications-container\\">
+                            <section className=\\"notifications-container\\" role=\\"alert\\">
                               <div className=\\"notifications-list-header notifications-list\\">
                                 <CSSTransitionGroup transitionName=\\"notification\\" transitionEnterTimeout={500} transitionLeaveTimeout={500} transitionAppear={false} transitionEnter={true} transitionLeave={true}>
                                   <TransitionGroup transitionName=\\"notification\\" transitionEnterTimeout={500} transitionLeaveTimeout={500} transitionAppear={false} transitionEnter={true} transitionLeave={true} childFactory={[Function]} component=\\"span\\">

--- a/client/src/containers/frontend/Contact.js
+++ b/client/src/containers/frontend/Contact.js
@@ -74,6 +74,7 @@ export class ContactContainer extends Component {
                 className="form-input"
                 name="attributes[email]"
                 errors={errors}
+                idForError="create-email-error"
               >
                 <label htmlFor="create-email">Email</label>
                 <input
@@ -81,6 +82,7 @@ export class ContactContainer extends Component {
                   type="text"
                   name="email"
                   id="create-email"
+                  aria-describedby="create-email-error"
                   onChange={this.handleInputChange}
                   placeholder="Email"
                 />
@@ -91,12 +93,14 @@ export class ContactContainer extends Component {
                 className="form-input"
                 name={"attributes[fullName]"}
                 errors={errors}
+                idForError="create-name-error"
               >
                 <label htmlFor="create-name">Name</label>
                 <input
                   value={this.state.contact.fullName}
                   type="text"
                   id="create-name"
+                  aria-describedby="create-name-error"
                   name="fullName"
                   onChange={this.handleInputChange}
                   placeholder="Name"
@@ -108,6 +112,7 @@ export class ContactContainer extends Component {
                 className="form-input"
                 name="attributes[message]"
                 errors={errors}
+                idForError="create-message-error"
               >
                 <label htmlFor="create-message">Message</label>
                 <textarea
@@ -118,6 +123,7 @@ export class ContactContainer extends Component {
                   onChange={this.handleInputChange}
                   placeholder="Message"
                   className="dark-placeholder wide large"
+                  aria-describedby="create-message-error"
                 />
               </Form.Errorable>
             </div>

--- a/client/src/containers/frontend/PasswordReset.js
+++ b/client/src/containers/frontend/PasswordReset.js
@@ -86,6 +86,7 @@ export class PasswordResetContainer extends Component {
                 className="form-input"
                 name="attributes[password]"
                 errors={errors}
+                idForError="reset-password-error"
               >
                 <label htmlFor="reset-password">New Password</label>
                 <input
@@ -95,6 +96,7 @@ export class PasswordResetContainer extends Component {
                   id="reset-password"
                   onChange={this.handleInputChange}
                   placeholder="Password"
+                  aria-describedby="reset-password-error"
                 />
               </Form.Errorable>
             </div>
@@ -103,6 +105,7 @@ export class PasswordResetContainer extends Component {
                 className="form-input"
                 name="attributes[passwordConfirmation]"
                 errors={errors}
+                idForError="reset-password-confirmation-error"
               >
                 <label htmlFor="reset-password-confirmation">
                   Confirm Password
@@ -114,6 +117,7 @@ export class PasswordResetContainer extends Component {
                   id="reset-password-confirmation"
                   onChange={this.handleInputChange}
                   placeholder="Confirm Password"
+                  aria-describedby="reset-password-confirmation-error"
                 />
               </Form.Errorable>
             </div>

--- a/client/src/containers/frontend/__tests__/__snapshots__/CollectionDetail-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/CollectionDetail-test.js.snap
@@ -315,12 +315,12 @@ exports[`Frontend CollectionDetail Container renders correctly 1`] = `
           </button>
           <label
             className="screen-reader-text"
-            htmlFor={undefined}
+            htmlFor="filters-search-20"
           >
             Enter Search Criteria
           </label>
           <input
-            id={undefined}
+            id="filters-search-20"
             onChange={[Function]}
             placeholder="Search"
             type="text"

--- a/client/src/containers/frontend/__tests__/__snapshots__/Frontend-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/Frontend-test.js.snap
@@ -147,6 +147,7 @@ exports[`Frontend Frontend Container renders correctly 1`] = `
       />
       <section
         className="notifications-container"
+        role="alert"
       >
         <div
           className="notifications-list-header notifications-list"

--- a/client/src/containers/frontend/__tests__/__snapshots__/NotFound-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/NotFound-test.js.snap
@@ -29,7 +29,10 @@ exports[`Frontend Not Found Container renders correctly 1`] = `
         </h3>
       </header>
       <div
+        aria-atomic="true"
+        aria-live="assertive"
         className="error-description"
+        role="alert"
       >
         <h1>
           404 error.

--- a/client/src/containers/frontend/__tests__/__snapshots__/PasswordReset-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/PasswordReset-test.js.snap
@@ -30,6 +30,7 @@ exports[`Frontend PasswordReset Container renders correctly 1`] = `
             New Password
           </label>
           <input
+            aria-describedby="reset-password-error"
             id="reset-password"
             name="password"
             onChange={[Function]}
@@ -52,6 +53,7 @@ exports[`Frontend PasswordReset Container renders correctly 1`] = `
             Confirm Password
           </label>
           <input
+            aria-describedby="reset-password-confirmation-error"
             id="reset-password-confirmation"
             name="passwordConfirmation"
             onChange={[Function]}

--- a/client/src/containers/frontend/__tests__/__snapshots__/ProjectResources-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/ProjectResources-test.js.snap
@@ -72,12 +72,12 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
           </button>
           <label
             className="screen-reader-text"
-            htmlFor={undefined}
+            htmlFor="filters-search-20"
           >
             Enter Search Criteria
           </label>
           <input
-            id={undefined}
+            id="filters-search-20"
             onChange={[Function]}
             placeholder="Search"
             type="text"

--- a/client/src/containers/global/Comment/Editor.js
+++ b/client/src/containers/global/Comment/Editor.js
@@ -31,11 +31,15 @@ export class CommentEditor extends PureComponent {
     onSuccess: PropTypes.func,
     subject: PropTypes.object.isRequired,
     parentId: PropTypes.string,
-    focus: PropTypes.bool
+    focus: PropTypes.bool,
+    id: PropTypes.string,
+    idForError: PropTypes.string
   };
 
   static defaultProps = {
-    focus: true
+    focus: true,
+    id: uniqueId("comment-textarea-"),
+    idForError: uniqueId("comment-textarea-error-")
   };
 
   constructor(props) {
@@ -44,8 +48,6 @@ export class CommentEditor extends PureComponent {
   }
 
   componentDidMount() {
-    this.id = uniqueId("cooment-textarea-");
-
     if (!this.ci) return null;
     if (this.props.focus) {
       this.ci.focus();
@@ -181,20 +183,22 @@ export class CommentEditor extends PureComponent {
             <GlobalForm.Errorable
               name="attributes[body]"
               errors={this.state.errors}
+              idForError={this.props.idForError}
             >
-              <label htmlFor={this.id} className="screen-reader-text">
+              <label htmlFor={this.props.id} className="screen-reader-text">
                 {this.placeholder(this.props)}
               </label>
               <textarea
                 ref={ci => {
                   this.ci = ci;
                 }}
-                id={this.id}
+                id={this.props.id}
                 onKeyDown={this.submitOnReturnKey}
                 className={textClass}
                 placeholder={this.placeholder(this.props)}
                 onChange={this.handleBodyChange}
                 value={this.state.body}
+                aria-describedby={this.props.idForError}
               />
               <div className="utility">
                 <div className="buttons">

--- a/client/src/containers/global/Comment/__tests__/__snapshots__/Editor-test.js.snap
+++ b/client/src/containers/global/Comment/__tests__/__snapshots__/Editor-test.js.snap
@@ -13,13 +13,14 @@ exports[`Global Comment Editor Container renders correctly when logged in 1`] = 
     >
       <label
         className="screen-reader-text"
-        htmlFor={undefined}
+        htmlFor="comment-textarea-21"
       >
         Edit this comment...
       </label>
       <textarea
+        aria-describedby="comment-textarea-error-22"
         className="expanded"
-        id={undefined}
+        id="comment-textarea-21"
         onChange={[Function]}
         onKeyDown={[Function]}
         placeholder="Edit this comment..."

--- a/client/src/containers/global/Notifications.js
+++ b/client/src/containers/global/Notifications.js
@@ -166,7 +166,7 @@ export class NotificationsComponent extends Component {
 
   render() {
     return (
-      <section className="notifications-container">
+      <section className="notifications-container" role="alert">
         <div
           ref={notificationList => {
             this.notificationList = notificationList;

--- a/client/src/containers/reader/Notation/__tests__/__snapshots__/Picker-test.js.snap
+++ b/client/src/containers/reader/Notation/__tests__/__snapshots__/Picker-test.js.snap
@@ -58,12 +58,12 @@ exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
           </button>
           <label
             className="screen-reader-text"
-            htmlFor={undefined}
+            htmlFor="list-search-19"
           >
             Enter Search Criteria
           </label>
           <input
-            id={undefined}
+            id="list-search-19"
             onChange={[Function]}
             placeholder="Search..."
             type="text"

--- a/client/src/containers/reader/__tests__/__snapshots__/Reader-test.js.snap
+++ b/client/src/containers/reader/__tests__/__snapshots__/Reader-test.js.snap
@@ -441,6 +441,7 @@ exports[`Reader Reader Container renders correctly 1`] = `
       </nav>
       <section
         className="notifications-container"
+        role="alert"
       >
         <div
           className="notifications-list-header notifications-list"


### PR DESCRIPTION
Additionally, makes the error text "describedby" text for associated form field so that inline errors are read whenever form field gains focus.

Also includes a refactor of the implementation `lodash.uniqueId` that avoids unnecessary changes to state and unnecessary re-generation of ids used for labels and error text (Ordinarily this should have been its own PR but it was done as a part of this PR because so much of the use of the uniqueId method was directly tied implementing `aria-describedby` error text).

Resolves #1133 