### PR TITLE
Update follow/unfollow project interaction accessibility

### DIFF
--- a/client/src/components/frontend/Project/Follow.js
+++ b/client/src/components/frontend/Project/Follow.js
@@ -68,6 +68,31 @@ export default class ProjectFollow extends Component {
     }
   };
 
+  toggleFollow = event => {
+    event.preventDefault();
+    event.stopPropagation();
+    const followed = this.getFollowed(this.props);
+    if (followed) {
+      this.props.dispatch(
+        currentUserActions.unfollow(this.props.project.id, followed.id)
+      );
+    } else {
+      const { id, type } = this.props.project;
+      this.props.dispatch(currentUserActions.follow({ id, type }));
+    }
+  };
+
+  screenReaderButtonText() {
+    if (this.state.view === "follow" || this.state.view === "follow-active") {
+      return "Unfollow " + this.props.project.attributes.title;
+    } else if (
+      this.state.view === "unfollow" ||
+      this.state.view === "unfollow-active"
+    ) {
+      return "Follow " + this.props.project.attributes.title;
+    }
+  }
+
   activate = () => {
     if (this.state.view === "follow") {
       this.setView("follow-active");
@@ -118,51 +143,56 @@ export default class ProjectFollow extends Component {
       clickHandler = this.handleUnfollowConfirmed;
 
     return (
-      <div
-        onClick={clickHandler}
-        onMouseEnter={this.activate}
-        onMouseLeave={this.deactivate}
-        className={wrapperClasses}
-        role="button"
-        tabIndex="0"
-      >
-        <div className="following-button">
-          <div className="icons" aria-hidden="true">
-            <i key="minus" className="manicon manicon-minus-bold" />
-            <i key="check" className="manicon manicon-check-bold" />
-            <i key="plus" className="manicon manicon-plus-bold" />
-          </div>
+      <div>
+        <button className="screen-reader-text" onClick={this.toggleFollow}>
+          {this.screenReaderButtonText()}
+        </button>
+        <div
+          onClick={clickHandler}
+          onMouseEnter={this.activate}
+          onMouseLeave={this.deactivate}
+          className={wrapperClasses}
+          role="presentation"
+          aria-hidden="true"
+        >
+          <div className="following-button" aria-hidden="true">
+            <div className="icons">
+              <i key="minus" className="manicon manicon-minus-bold" />
+              <i key="check" className="manicon manicon-check-bold" />
+              <i key="plus" className="manicon manicon-plus-bold" />
+            </div>
 
-          <ReactCSSTransitionGroup
-            transitionName="following"
-            transitionEnterTimeout={300}
-            transitionLeaveTimeout={300}
-          >
-            {this.state.view === "follow" ||
-            this.state.view === "follow-active" ? (
-              <span key="follow" className="follow-text">
-                Follow
-              </span>
-            ) : null}
-            {this.state.view === "unfollow" ||
-            this.state.view === "unfollow-active" ? (
-              <span
-                key="unfollow"
-                className="follow-text follow-text-hide-immediately"
-              >
-                Unfollow
-              </span>
-            ) : null}
-            {this.state.view === "unfollow-confirm" ||
-            this.state.view === "unfollow-confirm-active" ? (
-              <span
-                key="unfollow-confirm"
-                className="follow-text follow-text-show-immediately"
-              >
-                Are You Sure?
-              </span>
-            ) : null}
-          </ReactCSSTransitionGroup>
+            <ReactCSSTransitionGroup
+              transitionName="following"
+              transitionEnterTimeout={300}
+              transitionLeaveTimeout={300}
+            >
+              {this.state.view === "follow" ||
+              this.state.view === "follow-active" ? (
+                <span key="follow" className="follow-text">
+                  Follow
+                </span>
+              ) : null}
+              {this.state.view === "unfollow" ||
+              this.state.view === "unfollow-active" ? (
+                <span
+                  key="unfollow"
+                  className="follow-text follow-text-hide-immediately"
+                >
+                  Unfollow
+                </span>
+              ) : null}
+              {this.state.view === "unfollow-confirm" ||
+              this.state.view === "unfollow-confirm-active" ? (
+                <span
+                  key="unfollow-confirm"
+                  className="follow-text follow-text-show-immediately"
+                >
+                  Are You Sure?
+                </span>
+              ) : null}
+            </ReactCSSTransitionGroup>
+          </div>
         </div>
       </div>
     );

--- a/client/src/components/frontend/Project/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/components/frontend/Project/__tests__/__snapshots__/Following-test.js.snap
@@ -1,38 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frontend.Project.Follow component renders correctly 1`] = `
-<div
-  className="follow-button-wrapper follow"
-  onClick={[Function]}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
-  role="button"
-  tabIndex="0"
->
+<div>
+  <button
+    className="screen-reader-text"
+    onClick={[Function]}
+  >
+    Unfollow Rowan Test
+  </button>
   <div
-    className="following-button"
+    aria-hidden="true"
+    className="follow-button-wrapper follow"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    role="presentation"
   >
     <div
       aria-hidden="true"
-      className="icons"
+      className="following-button"
     >
-      <i
-        className="manicon manicon-minus-bold"
-      />
-      <i
-        className="manicon manicon-check-bold"
-      />
-      <i
-        className="manicon manicon-plus-bold"
-      />
-    </div>
-    <span>
-      <span
-        className="follow-text"
+      <div
+        className="icons"
       >
-        Follow
+        <i
+          className="manicon manicon-minus-bold"
+        />
+        <i
+          className="manicon manicon-check-bold"
+        />
+        <i
+          className="manicon manicon-plus-bold"
+        />
+      </div>
+      <span>
+        <span
+          className="follow-text"
+        >
+          Follow
+        </span>
       </span>
-    </span>
+    </div>
   </div>
 </div>
 `;

--- a/client/src/components/frontend/Project/__tests__/__snapshots__/Thumbnail-test.js.snap
+++ b/client/src/components/frontend/Project/__tests__/__snapshots__/Thumbnail-test.js.snap
@@ -9,38 +9,46 @@ exports[`Frontend.Project.Thumbnail component renders correctly 1`] = `
     className="figure-wrapper"
   >
     <figure>
-      <div
-        className="follow-button-wrapper follow"
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        role="button"
-        tabIndex="0"
-      >
+      <div>
+        <button
+          className="screen-reader-text"
+          onClick={[Function]}
+        >
+          Unfollow Rowan Test
+        </button>
         <div
-          className="following-button"
+          aria-hidden="true"
+          className="follow-button-wrapper follow"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          role="presentation"
         >
           <div
             aria-hidden="true"
-            className="icons"
+            className="following-button"
           >
-            <i
-              className="manicon manicon-minus-bold"
-            />
-            <i
-              className="manicon manicon-check-bold"
-            />
-            <i
-              className="manicon manicon-plus-bold"
-            />
-          </div>
-          <span>
-            <span
-              className="follow-text"
+            <div
+              className="icons"
             >
-              Follow
+              <i
+                className="manicon manicon-minus-bold"
+              />
+              <i
+                className="manicon manicon-check-bold"
+              />
+              <i
+                className="manicon manicon-plus-bold"
+              />
+            </div>
+            <span>
+              <span
+                className="follow-text"
+              >
+                Follow
+              </span>
             </span>
-          </span>
+          </div>
         </div>
       </div>
     </figure>

--- a/client/src/components/frontend/ProjectList/__tests__/__snapshots__/CoversGrid-test.js.snap
+++ b/client/src/components/frontend/ProjectList/__tests__/__snapshots__/CoversGrid-test.js.snap
@@ -14,38 +14,46 @@ exports[`Frontend.ProjectList.CoversGrid component renders correctly 1`] = `
           className="figure-wrapper"
         >
           <figure>
-            <div
-              className="follow-button-wrapper follow"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="button"
-              tabIndex="0"
-            >
+            <div>
+              <button
+                className="screen-reader-text"
+                onClick={[Function]}
+              >
+                Unfollow Rowan Test
+              </button>
               <div
-                className="following-button"
+                aria-hidden="true"
+                className="follow-button-wrapper follow"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="presentation"
               >
                 <div
                   aria-hidden="true"
-                  className="icons"
+                  className="following-button"
                 >
-                  <i
-                    className="manicon manicon-minus-bold"
-                  />
-                  <i
-                    className="manicon manicon-check-bold"
-                  />
-                  <i
-                    className="manicon manicon-plus-bold"
-                  />
-                </div>
-                <span>
-                  <span
-                    className="follow-text"
+                  <div
+                    className="icons"
                   >
-                    Follow
+                    <i
+                      className="manicon manicon-minus-bold"
+                    />
+                    <i
+                      className="manicon manicon-check-bold"
+                    />
+                    <i
+                      className="manicon manicon-plus-bold"
+                    />
+                  </div>
+                  <span>
+                    <span
+                      className="follow-text"
+                    >
+                      Follow
+                    </span>
                   </span>
-                </span>
+                </div>
               </div>
             </div>
           </figure>
@@ -61,38 +69,46 @@ exports[`Frontend.ProjectList.CoversGrid component renders correctly 1`] = `
           className="figure-wrapper"
         >
           <figure>
-            <div
-              className="follow-button-wrapper follow"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="button"
-              tabIndex="0"
-            >
+            <div>
+              <button
+                className="screen-reader-text"
+                onClick={[Function]}
+              >
+                Unfollow Rowan Test
+              </button>
               <div
-                className="following-button"
+                aria-hidden="true"
+                className="follow-button-wrapper follow"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="presentation"
               >
                 <div
                   aria-hidden="true"
-                  className="icons"
+                  className="following-button"
                 >
-                  <i
-                    className="manicon manicon-minus-bold"
-                  />
-                  <i
-                    className="manicon manicon-check-bold"
-                  />
-                  <i
-                    className="manicon manicon-plus-bold"
-                  />
-                </div>
-                <span>
-                  <span
-                    className="follow-text"
+                  <div
+                    className="icons"
                   >
-                    Follow
+                    <i
+                      className="manicon manicon-minus-bold"
+                    />
+                    <i
+                      className="manicon manicon-check-bold"
+                    />
+                    <i
+                      className="manicon manicon-plus-bold"
+                    />
+                  </div>
+                  <span>
+                    <span
+                      className="follow-text"
+                    >
+                      Follow
+                    </span>
                   </span>
-                </span>
+                </div>
               </div>
             </div>
           </figure>

--- a/client/src/components/frontend/ProjectList/__tests__/__snapshots__/Grid-test.js.snap
+++ b/client/src/components/frontend/ProjectList/__tests__/__snapshots__/Grid-test.js.snap
@@ -14,38 +14,46 @@ exports[`Frontend.ProjectList.Grid component renders correctly 1`] = `
           className="figure-wrapper"
         >
           <figure>
-            <div
-              className="follow-button-wrapper follow"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="button"
-              tabIndex="0"
-            >
+            <div>
+              <button
+                className="screen-reader-text"
+                onClick={[Function]}
+              >
+                Unfollow Rowan Test
+              </button>
               <div
-                className="following-button"
+                aria-hidden="true"
+                className="follow-button-wrapper follow"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="presentation"
               >
                 <div
                   aria-hidden="true"
-                  className="icons"
+                  className="following-button"
                 >
-                  <i
-                    className="manicon manicon-minus-bold"
-                  />
-                  <i
-                    className="manicon manicon-check-bold"
-                  />
-                  <i
-                    className="manicon manicon-plus-bold"
-                  />
-                </div>
-                <span>
-                  <span
-                    className="follow-text"
+                  <div
+                    className="icons"
                   >
-                    Follow
+                    <i
+                      className="manicon manicon-minus-bold"
+                    />
+                    <i
+                      className="manicon manicon-check-bold"
+                    />
+                    <i
+                      className="manicon manicon-plus-bold"
+                    />
+                  </div>
+                  <span>
+                    <span
+                      className="follow-text"
+                    >
+                      Follow
+                    </span>
                   </span>
-                </span>
+                </div>
               </div>
             </div>
           </figure>

--- a/client/src/components/frontend/ProjectList/__tests__/__snapshots__/SummaryGrid-test.js.snap
+++ b/client/src/components/frontend/ProjectList/__tests__/__snapshots__/SummaryGrid-test.js.snap
@@ -14,38 +14,46 @@ exports[`Frontend.ProjectList.SummaryGrid component renders correctly 1`] = `
           className="figure-wrapper"
         >
           <figure>
-            <div
-              className="follow-button-wrapper follow"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="button"
-              tabIndex="0"
-            >
+            <div>
+              <button
+                className="screen-reader-text"
+                onClick={[Function]}
+              >
+                Unfollow Rowan Test
+              </button>
               <div
-                className="following-button"
+                aria-hidden="true"
+                className="follow-button-wrapper follow"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="presentation"
               >
                 <div
                   aria-hidden="true"
-                  className="icons"
+                  className="following-button"
                 >
-                  <i
-                    className="manicon manicon-minus-bold"
-                  />
-                  <i
-                    className="manicon manicon-check-bold"
-                  />
-                  <i
-                    className="manicon manicon-plus-bold"
-                  />
-                </div>
-                <span>
-                  <span
-                    className="follow-text"
+                  <div
+                    className="icons"
                   >
-                    Follow
+                    <i
+                      className="manicon manicon-minus-bold"
+                    />
+                    <i
+                      className="manicon manicon-check-bold"
+                    />
+                    <i
+                      className="manicon manicon-plus-bold"
+                    />
+                  </div>
+                  <span>
+                    <span
+                      className="follow-text"
+                    >
+                      Follow
+                    </span>
                   </span>
-                </span>
+                </div>
               </div>
             </div>
           </figure>
@@ -75,38 +83,46 @@ exports[`Frontend.ProjectList.SummaryGrid component renders correctly 1`] = `
           className="figure-wrapper"
         >
           <figure>
-            <div
-              className="follow-button-wrapper follow"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="button"
-              tabIndex="0"
-            >
+            <div>
+              <button
+                className="screen-reader-text"
+                onClick={[Function]}
+              >
+                Unfollow Rowan Test
+              </button>
               <div
-                className="following-button"
+                aria-hidden="true"
+                className="follow-button-wrapper follow"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="presentation"
               >
                 <div
                   aria-hidden="true"
-                  className="icons"
+                  className="following-button"
                 >
-                  <i
-                    className="manicon manicon-minus-bold"
-                  />
-                  <i
-                    className="manicon manicon-check-bold"
-                  />
-                  <i
-                    className="manicon manicon-plus-bold"
-                  />
-                </div>
-                <span>
-                  <span
-                    className="follow-text"
+                  <div
+                    className="icons"
                   >
-                    Follow
+                    <i
+                      className="manicon manicon-minus-bold"
+                    />
+                    <i
+                      className="manicon manicon-check-bold"
+                    />
+                    <i
+                      className="manicon manicon-plus-bold"
+                    />
+                  </div>
+                  <span>
+                    <span
+                      className="follow-text"
+                    >
+                      Follow
+                    </span>
                   </span>
-                </span>
+                </div>
               </div>
             </div>
           </figure>

--- a/client/src/containers/frontend/__tests__/__snapshots__/Featured-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/Featured-test.js.snap
@@ -51,38 +51,46 @@ exports[`Frontend Featured Container renders correctly 1`] = `
                 className="figure-wrapper"
               >
                 <figure>
-                  <div
-                    className="follow-button-wrapper follow"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex="0"
-                  >
+                  <div>
+                    <button
+                      className="screen-reader-text"
+                      onClick={[Function]}
+                    >
+                      Unfollow Rowan Test
+                    </button>
                     <div
-                      className="following-button"
+                      aria-hidden="true"
+                      className="follow-button-wrapper follow"
+                      onClick={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="presentation"
                     >
                       <div
                         aria-hidden="true"
-                        className="icons"
+                        className="following-button"
                       >
-                        <i
-                          className="manicon manicon-minus-bold"
-                        />
-                        <i
-                          className="manicon manicon-check-bold"
-                        />
-                        <i
-                          className="manicon manicon-plus-bold"
-                        />
-                      </div>
-                      <span>
-                        <span
-                          className="follow-text"
+                        <div
+                          className="icons"
                         >
-                          Follow
+                          <i
+                            className="manicon manicon-minus-bold"
+                          />
+                          <i
+                            className="manicon manicon-check-bold"
+                          />
+                          <i
+                            className="manicon manicon-plus-bold"
+                          />
+                        </div>
+                        <span>
+                          <span
+                            className="follow-text"
+                          >
+                            Follow
+                          </span>
                         </span>
-                      </span>
+                      </div>
                     </div>
                   </div>
                 </figure>
@@ -107,38 +115,46 @@ exports[`Frontend Featured Container renders correctly 1`] = `
                 className="figure-wrapper"
               >
                 <figure>
-                  <div
-                    className="follow-button-wrapper follow"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex="0"
-                  >
+                  <div>
+                    <button
+                      className="screen-reader-text"
+                      onClick={[Function]}
+                    >
+                      Unfollow Rowan Test
+                    </button>
                     <div
-                      className="following-button"
+                      aria-hidden="true"
+                      className="follow-button-wrapper follow"
+                      onClick={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="presentation"
                     >
                       <div
                         aria-hidden="true"
-                        className="icons"
+                        className="following-button"
                       >
-                        <i
-                          className="manicon manicon-minus-bold"
-                        />
-                        <i
-                          className="manicon manicon-check-bold"
-                        />
-                        <i
-                          className="manicon manicon-plus-bold"
-                        />
-                      </div>
-                      <span>
-                        <span
-                          className="follow-text"
+                        <div
+                          className="icons"
                         >
-                          Follow
+                          <i
+                            className="manicon manicon-minus-bold"
+                          />
+                          <i
+                            className="manicon manicon-check-bold"
+                          />
+                          <i
+                            className="manicon manicon-plus-bold"
+                          />
+                        </div>
+                        <span>
+                          <span
+                            className="follow-text"
+                          >
+                            Follow
+                          </span>
                         </span>
-                      </span>
+                      </div>
                     </div>
                   </div>
                 </figure>

--- a/client/src/containers/frontend/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/Following-test.js.snap
@@ -51,38 +51,46 @@ exports[`Frontend Following Container renders correctly 1`] = `
                 className="figure-wrapper"
               >
                 <figure>
-                  <div
-                    className="follow-button-wrapper follow"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex="0"
-                  >
+                  <div>
+                    <button
+                      className="screen-reader-text"
+                      onClick={[Function]}
+                    >
+                      Unfollow Rowan Test
+                    </button>
                     <div
-                      className="following-button"
+                      aria-hidden="true"
+                      className="follow-button-wrapper follow"
+                      onClick={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="presentation"
                     >
                       <div
                         aria-hidden="true"
-                        className="icons"
+                        className="following-button"
                       >
-                        <i
-                          className="manicon manicon-minus-bold"
-                        />
-                        <i
-                          className="manicon manicon-check-bold"
-                        />
-                        <i
-                          className="manicon manicon-plus-bold"
-                        />
-                      </div>
-                      <span>
-                        <span
-                          className="follow-text"
+                        <div
+                          className="icons"
                         >
-                          Follow
+                          <i
+                            className="manicon manicon-minus-bold"
+                          />
+                          <i
+                            className="manicon manicon-check-bold"
+                          />
+                          <i
+                            className="manicon manicon-plus-bold"
+                          />
+                        </div>
+                        <span>
+                          <span
+                            className="follow-text"
+                          >
+                            Follow
+                          </span>
                         </span>
-                      </span>
+                      </div>
                     </div>
                   </div>
                 </figure>
@@ -107,38 +115,46 @@ exports[`Frontend Following Container renders correctly 1`] = `
                 className="figure-wrapper"
               >
                 <figure>
-                  <div
-                    className="follow-button-wrapper follow"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex="0"
-                  >
+                  <div>
+                    <button
+                      className="screen-reader-text"
+                      onClick={[Function]}
+                    >
+                      Unfollow Rowan Test
+                    </button>
                     <div
-                      className="following-button"
+                      aria-hidden="true"
+                      className="follow-button-wrapper follow"
+                      onClick={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="presentation"
                     >
                       <div
                         aria-hidden="true"
-                        className="icons"
+                        className="following-button"
                       >
-                        <i
-                          className="manicon manicon-minus-bold"
-                        />
-                        <i
-                          className="manicon manicon-check-bold"
-                        />
-                        <i
-                          className="manicon manicon-plus-bold"
-                        />
-                      </div>
-                      <span>
-                        <span
-                          className="follow-text"
+                        <div
+                          className="icons"
                         >
-                          Follow
+                          <i
+                            className="manicon manicon-minus-bold"
+                          />
+                          <i
+                            className="manicon manicon-check-bold"
+                          />
+                          <i
+                            className="manicon manicon-plus-bold"
+                          />
+                        </div>
+                        <span>
+                          <span
+                            className="follow-text"
+                          >
+                            Follow
+                          </span>
                         </span>
-                      </span>
+                      </div>
                     </div>
                   </div>
                 </figure>

--- a/client/src/containers/frontend/__tests__/__snapshots__/Home-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/Home-test.js.snap
@@ -46,38 +46,46 @@ exports[`Frontend Home Container renders correctly 1`] = `
                 className="figure-wrapper"
               >
                 <figure>
-                  <div
-                    className="follow-button-wrapper follow"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex="0"
-                  >
+                  <div>
+                    <button
+                      className="screen-reader-text"
+                      onClick={[Function]}
+                    >
+                      Unfollow Rowan Test
+                    </button>
                     <div
-                      className="following-button"
+                      aria-hidden="true"
+                      className="follow-button-wrapper follow"
+                      onClick={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="presentation"
                     >
                       <div
                         aria-hidden="true"
-                        className="icons"
+                        className="following-button"
                       >
-                        <i
-                          className="manicon manicon-minus-bold"
-                        />
-                        <i
-                          className="manicon manicon-check-bold"
-                        />
-                        <i
-                          className="manicon manicon-plus-bold"
-                        />
-                      </div>
-                      <span>
-                        <span
-                          className="follow-text"
+                        <div
+                          className="icons"
                         >
-                          Follow
+                          <i
+                            className="manicon manicon-minus-bold"
+                          />
+                          <i
+                            className="manicon manicon-check-bold"
+                          />
+                          <i
+                            className="manicon manicon-plus-bold"
+                          />
+                        </div>
+                        <span>
+                          <span
+                            className="follow-text"
+                          >
+                            Follow
+                          </span>
                         </span>
-                      </span>
+                      </div>
                     </div>
                   </div>
                 </figure>
@@ -102,38 +110,46 @@ exports[`Frontend Home Container renders correctly 1`] = `
                 className="figure-wrapper"
               >
                 <figure>
-                  <div
-                    className="follow-button-wrapper follow"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="button"
-                    tabIndex="0"
-                  >
+                  <div>
+                    <button
+                      className="screen-reader-text"
+                      onClick={[Function]}
+                    >
+                      Unfollow Rowan Test
+                    </button>
                     <div
-                      className="following-button"
+                      aria-hidden="true"
+                      className="follow-button-wrapper follow"
+                      onClick={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      role="presentation"
                     >
                       <div
                         aria-hidden="true"
-                        className="icons"
+                        className="following-button"
                       >
-                        <i
-                          className="manicon manicon-minus-bold"
-                        />
-                        <i
-                          className="manicon manicon-check-bold"
-                        />
-                        <i
-                          className="manicon manicon-plus-bold"
-                        />
-                      </div>
-                      <span>
-                        <span
-                          className="follow-text"
+                        <div
+                          className="icons"
                         >
-                          Follow
+                          <i
+                            className="manicon manicon-minus-bold"
+                          />
+                          <i
+                            className="manicon manicon-check-bold"
+                          />
+                          <i
+                            className="manicon manicon-plus-bold"
+                          />
+                        </div>
+                        <span>
+                          <span
+                            className="follow-text"
+                          >
+                            Follow
+                          </span>
                         </span>
-                      </span>
+                      </div>
                     </div>
                   </div>
                 </figure>


### PR DESCRIPTION
Resolves #1042 

The follow/unfollow "button" both utilized mouse events to control its state and required a two-phase process for unfollowing which made navigation by only keyboard confusing.  This PR adds a screen reader only button that allows the user to immediately follow/unfollow using only the keyboard (i.e. giving the button focus and then simulating a click using the enter key).