### PR TITLE
[B] Fix resource cards not using full space on project detail

### DIFF
--- a/api/app/serializers/project_serializer.rb
+++ b/api/app/serializers/project_serializer.rb
@@ -32,7 +32,7 @@ class ProjectSerializer < ProjectPartialSerializer
   end
 
   def uncollected_resources
-    object.uncollected_resources.limit(12)
+    object.uncollected_resources.limit(15)
   end
 
   def events

--- a/client/src/theme/Components/browse/project/_resource-thumbnail-list.scss
+++ b/client/src/theme/Components/browse/project/_resource-thumbnail-list.scss
@@ -12,6 +12,10 @@
     padding-left: 20px;
     margin-bottom: 20px;
 
+    &:nth-last-of-type(-n + 3) {
+      display: none;
+    }
+
     @include respond($break60) {
       width: 33.333%;
     };
@@ -22,6 +26,10 @@
 
     @include respond($break90) {
       width: 20%;
+
+      &:nth-last-of-type(-n + 3) {
+        display: flex;
+      }
     }
   }
 


### PR DESCRIPTION
The issue here is that we only fetch 12 resources.  This is fine in all cases except for full-width (> 960px), when the row items are 1/5 width.  

The fix I went with fetches 15 resources and hides the last 3 on screen sizes below 960px.  

The other approach would be to keep it at 12 resources and never have resource cards go smaller than 1/4 wide.

![screen shot 2018-06-25 at 12 18 18 pm](https://user-images.githubusercontent.com/8389445/41870837-0a90faf4-7872-11e8-9e11-f6368ed3338b.png)
![screen shot 2018-06-25 at 12 18 40 pm](https://user-images.githubusercontent.com/8389445/41870838-0aa6974c-7872-11e8-9ca7-c396d1c20e14.png)

Fixes #1132 
