### PR TITLE
[B] Improve ogg file acceptance

### DIFF
--- a/api/config/manifold.yml
+++ b/api/config/manifold.yml
@@ -188,6 +188,7 @@ common: &1
       :audio:
         :allowed_mime:
           - !ruby/regexp '/audio\/.*/'
+          - !ruby/regexp '/video\/ogg/'
         :allowed_ext:
           - !ruby/regexp '/flac\Z/i'
           - !ruby/regexp '/mp3\Z/i'
@@ -195,6 +196,7 @@ common: &1
           - !ruby/regexp '/wav\Z/i'
           - !ruby/regexp '/mid\Z/i'
           - !ruby/regexp '/ogg\Z/i'
+          - !ruby/regexp '/oga\Z/i'
       :spreadsheet:
         :allowed_mime:
           - "application/vnd.ms-excel"
@@ -330,6 +332,7 @@ common: &1
           - !ruby/regexp '/wav\Z/i'
           - !ruby/regexp '/mid\Z/i'
           - !ruby/regexp '/ogg\Z/i'
+          - !ruby/regexp '/oga\Z/i'
           # Spreadsheet
           - !ruby/regexp '/xls\Z/i'
           - !ruby/regexp '/xlt\Z/i'

--- a/client/src/components/backend/Form/Upload.js
+++ b/client/src/components/backend/Form/Upload.js
@@ -47,7 +47,7 @@ export class FormUpload extends Component {
     },
     audio: {
       accepts: "audio/*",
-      extensions: "mp3, flac, wma, wav, mid, ogg"
+      extensions: "mp3, flac, wma, wav, mid, ogg, oga"
     },
     video: {
       accepts: "video/*",

--- a/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Audio-test.js.snap
+++ b/client/src/components/backend/Resource/Form/Kind/__tests__/__snapshots__/Audio-test.js.snap
@@ -52,7 +52,7 @@ exports[`Backend.Resource.Form.Audio component renders correctly 1`] = `
             <p
               className="secondary"
             >
-              mp3, flac, wma, wav, mid, ogg
+              mp3, flac, wma, wav, mid, ogg, oga
             </p>
           </div>
         </div>


### PR DESCRIPTION
Currently .ogg files are being rejected because their mimetype is being reported as `video/ogg`.  I was unable to find any .ogg files that came back as `audio/ogg`.  Since we don't accept .ogg as video files, I think it makes sense to allow `video/ogg` for audio files.

Additionally, I added acceptance of .oga audio extensions.  Incidentally, these were also reporting `video/ogg` despite explicitly being an audio format.

Fixes #1131