### PR TITLE
[B] Overlay de-focus should not trigger close

### DIFF
--- a/client/src/components/global/Overlay.js
+++ b/client/src/components/global/Overlay.js
@@ -25,10 +25,18 @@ export default class Overlay extends Component {
     };
   }
 
+  componentDidMount() {
+    window.addEventListener("keyup", this.handleEscape);
+  }
+
   componentDidUpdate(prevProps) {
     if (prevProps.triggerScrollToTop !== this.props.triggerScrollToTop) {
-      this.scrollableEl.scrollTo(0, 0);
+      this.scrollableEl.scrollTop = 0;
     }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("keyup", this.handleEscape);
   }
 
   handleCloseEvent = event => {
@@ -39,6 +47,12 @@ export default class Overlay extends Component {
       setTimeout(() => {
         this.props.history.push(this.props.closeUrl);
       }, 200);
+    }
+  };
+
+  handleEscape = event => {
+    if (event.keyCode === 27) {
+      this.handleCloseEvent(event);
     }
   };
 

--- a/client/src/components/global/Overlay.js
+++ b/client/src/components/global/Overlay.js
@@ -92,7 +92,11 @@ export default class Overlay extends Component {
             this.scrollableEl = el;
           }}
         >
-          <FocusTrap>
+          <FocusTrap
+            focusTrapOptions={{
+              escapeDeactivates: false
+            }}
+          >
             {this.renderHeader(this.props)}
             {!this.props.title ? (
               <button

--- a/client/src/components/global/__tests__/__snapshots__/Overlay-test.js.snap
+++ b/client/src/components/global/__tests__/__snapshots__/Overlay-test.js.snap
@@ -4,13 +4,7 @@ exports[`Global.Overlay component renders correctly 1`] = `
 <div
   className="overlay-full"
 >
-  <focus-trap-react
-    focusTrapOptions={
-      Object {
-        "onDeactivate": [Function],
-      }
-    }
-  >
+  <focus-trap-react>
     <button
       className="overlay-close"
       data-id="overlay-close"

--- a/client/src/components/global/__tests__/__snapshots__/Overlay-test.js.snap
+++ b/client/src/components/global/__tests__/__snapshots__/Overlay-test.js.snap
@@ -4,7 +4,13 @@ exports[`Global.Overlay component renders correctly 1`] = `
 <div
   className="overlay-full"
 >
-  <focus-trap-react>
+  <focus-trap-react
+    focusTrapOptions={
+      Object {
+        "escapeDeactivates": false,
+      }
+    }
+  >
     <button
       className="overlay-close"
       data-id="overlay-close"

--- a/client/src/containers/reader/Notation/Collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/containers/reader/Notation/Collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -4,7 +4,13 @@ exports[`Reader Notation Collection Detail Container renders correctly 1`] = `
 <div
   className="overlay-full bg-neutral90"
 >
-  <focus-trap-react>
+  <focus-trap-react
+    focusTrapOptions={
+      Object {
+        "escapeDeactivates": false,
+      }
+    }
+  >
     <button
       className="overlay-close"
       data-id="overlay-close"

--- a/client/src/containers/reader/Notation/Collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/containers/reader/Notation/Collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -4,13 +4,7 @@ exports[`Reader Notation Collection Detail Container renders correctly 1`] = `
 <div
   className="overlay-full bg-neutral90"
 >
-  <focus-trap-react
-    focusTrapOptions={
-      Object {
-        "onDeactivate": [Function],
-      }
-    }
-  >
+  <focus-trap-react>
     <button
       className="overlay-close"
       data-id="overlay-close"

--- a/client/src/containers/reader/Notation/Resource/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/containers/reader/Notation/Resource/__tests__/__snapshots__/Detail-test.js.snap
@@ -4,13 +4,7 @@ exports[`Reader Notation Resource Detail Container renders correctly 1`] = `
 <div
   className="overlay-full bg-neutral90"
 >
-  <focus-trap-react
-    focusTrapOptions={
-      Object {
-        "onDeactivate": [Function],
-      }
-    }
-  >
+  <focus-trap-react>
     <button
       className="overlay-close"
       data-id="overlay-close"

--- a/client/src/containers/reader/Notation/Resource/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/containers/reader/Notation/Resource/__tests__/__snapshots__/Detail-test.js.snap
@@ -4,7 +4,13 @@ exports[`Reader Notation Resource Detail Container renders correctly 1`] = `
 <div
   className="overlay-full bg-neutral90"
 >
-  <focus-trap-react>
+  <focus-trap-react
+    focusTrapOptions={
+      Object {
+        "escapeDeactivates": false,
+      }
+    }
+  >
     <button
       className="overlay-close"
       data-id="overlay-close"


### PR DESCRIPTION
We recently wrapped our overlays in the FocusTrap component as part of
our accessibility efforts. As part of that implementation, we adjusted
the overlay so that it automatically triggers its close handler when
it loses focus. This is a problem because the close handler generally
will trigger a "back" action in history, or will redirect the user to
the URL from which the overlay was opened. The unintended side effect of
this is that if there is a link in the overlay (as in the case of the
resource notation overlay in the reader), clicking that link will
trigger the close behavior rather than going to the intended link
target.

Fixes #1183