### PR TITLE
 [C] Replace velocity-react with react-collapse

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -103,6 +103,7 @@
     "react-ace": "^5.9.0",
     "react-beautiful-dnd": "^4.0.1",
     "react-dom": "^16.4",
+    "react-collapse": "^4.0.3",
     "react-dropzone": "^4.x",
     "react-ga": "^2.x",
     "react-helmet": "^5.1.3",
@@ -110,6 +111,7 @@
     "react-html5video": "^2.x",
     "react-json-tree": "^0.x",
     "react-loadable": "^5.3.1",
+    "react-motion": "^0.5.2",
     "react-redux": "^5.0.5",
     "react-router": "^4.x",
     "react-router-config": "^1.0.0-beta.4",
@@ -133,7 +135,6 @@
     "text-mask-addons": "^3.7.1",
     "urijs": "^1.0",
     "uuid": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-    "velocity-react": "^1.3.3",
     "wavesurfer": "^1.3.4"
   },
   "devDependencies": {

--- a/client/src/components/frontend/ResourceCollection/__tests__/Detail-test.js
+++ b/client/src/components/frontend/ResourceCollection/__tests__/Detail-test.js
@@ -1,3 +1,5 @@
+jest.mock("react-collapse");
+
 import React from "react";
 import renderer from "react-test-renderer";
 import { ResourceCollection } from "components/frontend";

--- a/client/src/components/frontend/ResourceList/Slide/__tests__/Caption-test.js
+++ b/client/src/components/frontend/ResourceList/Slide/__tests__/Caption-test.js
@@ -1,3 +1,5 @@
+jest.mock("react-collapse");
+
 import React from "react";
 import renderer from "react-test-renderer";
 import Caption from "../Caption";

--- a/client/src/components/frontend/ResourceList/__tests__/Slideshow-test.js
+++ b/client/src/components/frontend/ResourceList/__tests__/Slideshow-test.js
@@ -1,3 +1,5 @@
+jest.mock("react-collapse");
+
 import React from "react";
 import renderer from "react-test-renderer";
 import Slideshow from "../Slideshow";

--- a/client/src/components/reader/Notation/Collection/__tests__/Detail-test.js
+++ b/client/src/components/reader/Notation/Collection/__tests__/Detail-test.js
@@ -1,5 +1,6 @@
+jest.mock("react-collapse");
+
 import React from "react";
-import { mount } from "enzyme";
 import Detail from "../Detail";
 import renderer from "react-test-renderer";
 import build from "test/fixtures/build";
@@ -7,7 +8,6 @@ import { wrapWithRouter, renderWithRouter } from "test/helpers/routing";
 
 describe("Reader.Notation.Collection.Detail component", () => {
   const pagination = build.pagination();
-  const store = build.store();
 
   const project = build.entity.project("1");
   const collectionResource = build.entity.collectionResource("4", {});

--- a/client/src/components/reader/Notation/Collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/components/reader/Notation/Collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -94,17 +94,6 @@ exports[`Reader.Notation.Collection.Detail component renders correctly 1`] = `
             </span>
           </header>
           <div
-            className="resource-description"
-          >
-            <div
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": "World's Greatest Dog",
-                }
-              }
-            />
-          </div>
-          <div
             className="resource-utility with-shadow"
           >
             <div

--- a/client/src/components/reader/Notes/Partial/Group.js
+++ b/client/src/components/reader/Notes/Partial/Group.js
@@ -3,15 +3,7 @@ import { Notes } from "components/reader";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import debounce from "lodash/debounce";
-import Loadable from "react-loadable";
-
-const Velocity = Loadable({
-  loader: () =>
-    import(/* webpackChunkName: "velocity-react" */ "velocity-react").then(
-      velocity => velocity.VelocityComponent
-    ),
-  loading: () => null
-});
+import { Collapse } from "react-collapse";
 
 export default class Group extends Component {
   static displayName = "Notes.List.Group";
@@ -26,69 +18,36 @@ export default class Group extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      expanded: false,
-      targetHeight: "5em"
+      expanded: false
     };
   }
   componentDidMount() {
     this.preOpenItem();
   }
 
-  getFullGroupHeight() {
-    if (!this._group) return;
-    this._group.style.height = "auto";
-    const measuredHeight = this._group.offsetHeight;
-    this._group.style.height = "1em";
-    return measuredHeight + "px";
-  }
-
   preOpenItem = debounce(() => {
     const expanded =
       this.props.readerSection.attributes.name === this.props.sectionName;
 
-    return this.setState({
-      expanded,
-      targetHeight: expanded
-        ? this.getFullGroupHeight()
-        : this.state.targetHeight
-    });
+    return this.setState({ expanded });
   }, 200);
 
   handleClick = event => {
     event.stopPropagation();
-    if (!this.state.expanded) {
-      this.setState({
-        targetHeight: this.getFullGroupHeight()
-      });
-    }
     return this.setState({ expanded: !this.state.expanded });
   };
 
   renderGroupItems(annotations) {
-    const animation = {
-      animation: {
-        height: this.state.expanded ? this.state.targetHeight : ""
-      },
-      duration: 250,
-      complete: () => {
-        if (this.state.expanded) {
-          this._group.style.height = "auto";
-        }
-      }
-    };
-
     const classes = classNames({
       open: this.state.expanded
     });
 
     return (
-      <Velocity {...animation}>
-        <ul
-          className={classes}
-          ref={e => {
-            this._group = e;
-          }}
-        >
+      <Collapse
+        isOpened={this.state.expanded}
+        springConfig={{ stiffness: 270 }}
+      >
+        <ul className={classes}>
           {annotations.map(annotation => {
             return (
               <Notes.Partial.GroupItem
@@ -99,7 +58,7 @@ export default class Group extends Component {
             );
           })}
         </ul>
-      </Velocity>
+      </Collapse>
     );
   }
 

--- a/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/Group-test.js.snap
+++ b/client/src/components/reader/Notes/Partial/__tests__/__snapshots__/Group-test.js.snap
@@ -18,39 +18,53 @@ exports[`Reader.Notes.Partial.Group Component renders correctly 1`] = `
       Test
     </h4>
   </div>
-  <ul
-    className=""
+  <div
+    className="ReactCollapse--collapse"
+    style={
+      Object {
+        "height": 0,
+        "overflow": "hidden",
+      }
+    }
   >
-    <li
-      className="item"
-      onClick={[Function]}
+    <div
+      className="ReactCollapse--content"
     >
-      <span
-        className="screen-reader-text"
-      />
-      <i
-        aria-hidden="true"
-        className="manicon manicon-null"
-      />
-      <span>
-        Gods, Earths, and 85ers
-      </span>
-    </li>
-    <li
-      className="item"
-      onClick={[Function]}
-    >
-      <span
-        className="screen-reader-text"
-      />
-      <i
-        aria-hidden="true"
-        className="manicon manicon-null"
-      />
-      <span>
-        Gods, Earths, and 85ers
-      </span>
-    </li>
-  </ul>
+      <ul
+        className=""
+      >
+        <li
+          className="item"
+          onClick={[Function]}
+        >
+          <span
+            className="screen-reader-text"
+          />
+          <i
+            aria-hidden="true"
+            className="manicon manicon-null"
+          />
+          <span>
+            Gods, Earths, and 85ers
+          </span>
+        </li>
+        <li
+          className="item"
+          onClick={[Function]}
+        >
+          <span
+            className="screen-reader-text"
+          />
+          <i
+            aria-hidden="true"
+            className="manicon manicon-null"
+          />
+          <span>
+            Gods, Earths, and 85ers
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
 </li>
 `;

--- a/client/src/components/reader/Notes/__tests__/__snapshots__/FilteredList-test.js.snap
+++ b/client/src/components/reader/Notes/__tests__/__snapshots__/FilteredList-test.js.snap
@@ -95,40 +95,54 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
             Test
           </h4>
         </div>
-        <ul
-          className=""
+        <div
+          className="ReactCollapse--collapse"
+          style={
+            Object {
+              "height": 0,
+              "overflow": "hidden",
+            }
+          }
         >
-          <li
-            className="item"
-            onClick={[Function]}
+          <div
+            className="ReactCollapse--content"
           >
-            <span
-              className="screen-reader-text"
-            />
-            <i
-              aria-hidden="true"
-              className="manicon manicon-null"
-            />
-            <span>
-              Gods, Earths, and 85ers
-            </span>
-          </li>
-          <li
-            className="item"
-            onClick={[Function]}
-          >
-            <span
-              className="screen-reader-text"
-            />
-            <i
-              aria-hidden="true"
-              className="manicon manicon-null"
-            />
-            <span>
-              Gods, Earths, and 85ers
-            </span>
-          </li>
-        </ul>
+            <ul
+              className=""
+            >
+              <li
+                className="item"
+                onClick={[Function]}
+              >
+                <span
+                  className="screen-reader-text"
+                />
+                <i
+                  aria-hidden="true"
+                  className="manicon manicon-null"
+                />
+                <span>
+                  Gods, Earths, and 85ers
+                </span>
+              </li>
+              <li
+                className="item"
+                onClick={[Function]}
+              >
+                <span
+                  className="screen-reader-text"
+                />
+                <i
+                  aria-hidden="true"
+                  className="manicon manicon-null"
+                />
+                <span>
+                  Gods, Earths, and 85ers
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
       </li>
     </ul>
   </nav>

--- a/client/src/containers/frontend/__tests__/CollectionDetail-test.js
+++ b/client/src/containers/frontend/__tests__/CollectionDetail-test.js
@@ -1,3 +1,5 @@
+jest.mock("react-collapse");
+
 import React from "react";
 import renderer from "react-test-renderer";
 import { CollectionDetailContainer } from "../CollectionDetail";

--- a/client/src/containers/frontend/__tests__/__snapshots__/CollectionDetail-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/CollectionDetail-test.js.snap
@@ -161,17 +161,6 @@ exports[`Frontend CollectionDetail Container renders correctly 1`] = `
               </span>
             </header>
             <div
-              className="resource-description"
-            >
-              <div
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "World's Greatest Dog",
-                  }
-                }
-              />
-            </div>
-            <div
               className="resource-utility with-shadow"
             >
               <div

--- a/client/src/containers/reader/Notation/Collection/__tests__/Detail-test.js
+++ b/client/src/containers/reader/Notation/Collection/__tests__/Detail-test.js
@@ -1,3 +1,5 @@
+jest.mock("react-collapse");
+
 import React from "react";
 import renderer from "react-test-renderer";
 import { NotationCollectionDetailContainer } from "../Detail";

--- a/client/src/containers/reader/Notation/Collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/containers/reader/Notation/Collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -126,17 +126,6 @@ exports[`Reader Notation Collection Detail Container renders correctly 1`] = `
                     </span>
                   </header>
                   <div
-                    className="resource-description"
-                  >
-                    <div
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "World's Greatest Dog",
-                        }
-                      }
-                    />
-                  </div>
-                  <div
                     className="resource-utility with-shadow"
                   >
                     <div

--- a/client/src/theme/Components/browse/collection/_resource-slideshow.scss
+++ b/client/src/theme/Components/browse/collection/_resource-slideshow.scss
@@ -55,10 +55,15 @@
   .resource-description {
     @include templateCopy;
     max-width: $slideCopyFocus;
-    height: 5em;
-    overflow: hidden;
+    overflow: visible;
     font-size: 15px;
     color: $neutral40;
+    height: 48px;
+    padding-bottom: 5em;
+
+    @include respond($break40) {
+      padding-bottom: 3.5em;
+    }
 
     p + p {
       margin-top: 1em;
@@ -72,8 +77,12 @@
       }
     }
 
-    &.transition-height {
-      transition: height $duration $timing;
+    &.collapsed {
+      overflow: hidden;
+    }
+
+    &.expanded {
+      height: auto;
     }
   }
 
@@ -196,8 +205,6 @@
 
     &.expandable {
       &.expanded {
-        margin-top: 33px;
-
         .wrapper {
           margin-top: 0;
         }

--- a/client/src/theme/Components/reader/notation/_detail.scss
+++ b/client/src/theme/Components/reader/notation/_detail.scss
@@ -47,14 +47,6 @@
       margin-top: 25px;
     }
 
-    .resource-description {
-      padding-bottom: 5em;
-
-      @include respond($break40) {
-        padding-bottom: 3.5em;
-      }
-    }
-
     .slide-footer {
       padding-right: 0;
       padding-left: 0;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2812,7 +2812,7 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-helpers@^3.2.0, dom-helpers@^3.3.1:
+dom-helpers@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
@@ -7512,8 +7512,8 @@ postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.1
     supports-color "^5.4.0"
 
 postcss@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.0.tgz#163f70d2fe2715c6d4a4b3d300051c1ea9594aa9"
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.1.tgz#db20ca4fc90aa56809674eea75864148c66b67fa"
   dependencies:
     chalk "^2.4.1"
     source-map "^0.6.1"
@@ -7832,6 +7832,12 @@ react-beautiful-dnd@^4.0.1:
     redux-thunk "^2.2.0"
     reselect "^3.0.1"
 
+react-collapse@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/react-collapse/-/react-collapse-4.0.3.tgz#b96de959ed0092a43534630b599a4753dd76d543"
+  dependencies:
+    prop-types "^15.5.8"
+
 react-cookie@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-1.0.5.tgz#234190bd55ddfea361444a89c873077ab6abf651"
@@ -8018,15 +8024,6 @@ react-transition-group@1.x:
     loose-envify "^1.3.1"
     prop-types "^15.5.6"
     warning "^3.0.0"
-
-react-transition-group@^2.0.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.4.0.tgz#1d9391fabfd82e016f26fabd1eec329dbd922b5a"
-  dependencies:
-    dom-helpers "^3.3.1"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
 
 react-typekit@^1.0.8:
   version "1.1.3"
@@ -10104,19 +10101,6 @@ varstream@^0.3.2:
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
-
-velocity-animate@^1.4.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/velocity-animate/-/velocity-animate-1.5.1.tgz#606837047bab8fbfb59a636d1d82ecc3f7bd71a6"
-
-velocity-react@^1.3.3:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/velocity-react/-/velocity-react-1.4.1.tgz#1d0b41859cdf2521c08a8b57f44e93ed2d54b5fc"
-  dependencies:
-    lodash "^4.17.5"
-    prop-types "^15.5.8"
-    react-transition-group "^2.0.0"
-    velocity-animate "^1.4.0"
 
 vendors@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
We're only using `velocity-react` in two places and the same effect can be easily achieved with `react-collapse`.  This PR came as a result of trying to solve #972.  

We rely on the height of the children of `<VelocityComponent>` to determine when a description can be expanded.  Since we accomplish this by using refs on the children, the are undefined until the async component is loaded.  When component loads asynchronously, there is no re-render triggered, so we never get those child refs.

Using `react-collapse` we achieve the same behavior, but with a much smaller package, allowing us to remove the `velocity-react` dependency entirely.  This allow allows us to not have to use code-splitting.

In it's current release, `react-collapse` uses `react-motion` for animation, but this dependency will be removed and be purely CSS based when version 5 is released.