### PR TITLE
[F] Adds "skip to main content" links for Reader, Admin Backend, and Frontend page templates

### DIFF
--- a/client/src/components/global/Utility/SkipLink.js
+++ b/client/src/components/global/Utility/SkipLink.js
@@ -1,0 +1,44 @@
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
+
+export default class SkipLink extends PureComponent {
+  static propTypes = {
+    skipId: PropTypes.string,
+    skipLinkText: PropTypes.string,
+    skipMessage: PropTypes.string
+  };
+
+  static defaultProps = {
+    skipId: "skip-to-main",
+    skipLinkText: "Skip to main content",
+    skipMessage: "Skipped to Main Content"
+  };
+
+  constructor() {
+    super();
+    this.state = { skipped: false };
+  }
+
+  activateSkipMessage = () => {
+    this.setState({ skipped: true });
+  };
+
+  render() {
+    return (
+      <React.Fragment>
+        <a
+          className="screen-reader-text"
+          href={`#${this.props.skipId}`}
+          onClick={this.activateSkipMessage}
+        >
+          {this.props.skipLinkText}
+        </a>
+        {this.state.skipped ? (
+          <span className="screen-reader-text" role="alert">
+            {this.props.skipMessage}
+          </span>
+        ) : null}
+      </React.Fragment>
+    );
+  }
+}

--- a/client/src/components/global/Utility/index.js
+++ b/client/src/components/global/Utility/index.js
@@ -3,11 +3,13 @@ import EdgeLockScroll from "./EdgeLockScroll";
 import EntityCount from "./EntityCount";
 import LockBodyScroll from "./LockBodyScroll";
 import ScrollToTop from "./ScrollToTop";
+import SkipLink from "./SkipLink";
 
 export default {
   Pagination,
   EdgeLockScroll,
   EntityCount,
   LockBodyScroll,
-  ScrollToTop
+  ScrollToTop,
+  SkipLink
 };

--- a/client/src/containers/backend/Backend.js
+++ b/client/src/containers/backend/Backend.js
@@ -138,10 +138,12 @@ export class BackendContainer extends PureComponent {
   render() {
     if (this.hasFatalError()) return this.renderFatalError();
     if (this.hasAuthenticationError()) return this.renderAuthenticationError();
+    const skipId = "skip-to-main";
 
     return (
       <HigherOrder.BodyClass className={"backend bg-neutral90"}>
         <div>
+          <Utility.SkipLink skipId={skipId} />
           <Utility.ScrollToTop />
           <HigherOrder.ScrollAware>
             <LayoutBackend.Header
@@ -157,6 +159,7 @@ export class BackendContainer extends PureComponent {
             ref={mainContainer => {
               this.mainContainer = mainContainer;
             }}
+            id={skipId}
           >
             {childRoutes(this.props.route, { childProps: this.childProps() })}
           </main>

--- a/client/src/containers/backend/__tests__/__snapshots__/Backend-test.js.snap
+++ b/client/src/containers/backend/__tests__/__snapshots__/Backend-test.js.snap
@@ -8,6 +8,11 @@ exports[`Backend Backend Container renders correctly 1`] = `
         <SideEffect(BodyClass) className=\\"backend bg-neutral90\\">
           <BodyClass className=\\"backend bg-neutral90\\">
             <div>
+              <SkipLink skipId=\\"skip-to-main\\" skipLinkText=\\"Skip to main content\\" skipMessage=\\"Skipped to Main Content\\">
+                <a className=\\"screen-reader-text\\" href=\\"#skip-to-main\\" onClick={[Function]}>
+                  Skip to main content
+                </a>
+              </SkipLink>
               <withRouter(ScrollToTop)>
                 <Route render={[Function: render]}>
                   <ScrollToTop match={{...}} location={{...}} history={{...}} staticContext={[undefined]} />
@@ -131,7 +136,7 @@ exports[`Backend Backend Container renders correctly 1`] = `
                   </Layout.Header>
                 </div>
               </ScrollAware>
-              <main>
+              <main id=\\"skip-to-main\\">
                 <Switch />
               </main>
               <withRouter(Layout.Footer) pages={[undefined]} authentication={{...}} commonActions={{...}} settings={{...}}>

--- a/client/src/containers/frontend/Frontend.js
+++ b/client/src/containers/frontend/Frontend.js
@@ -72,9 +72,12 @@ export class FrontendContainer extends Component {
 
   render() {
     const fatalError = this.props.notifications.fatalError;
+    const skipId = "skip-to-main";
+
     return (
       <HigherOrder.BodyClass className={"browse"}>
         <div>
+          <Utility.SkipLink skipId={skipId} />
           <Utility.ScrollToTop />
           <HigherOrder.ScrollAware>
             <Layout.Header
@@ -94,6 +97,7 @@ export class FrontendContainer extends Component {
             ref={mainContainer => {
               this.mainContainer = mainContainer;
             }}
+            id={skipId}
           >
             {fatalError ? (
               <div className="global-container">

--- a/client/src/containers/frontend/__tests__/__snapshots__/Frontend-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/Frontend-test.js.snap
@@ -2,6 +2,13 @@
 
 exports[`Frontend Frontend Container renders correctly 1`] = `
 <div>
+  <a
+    className="screen-reader-text"
+    href="#skip-to-main"
+    onClick={[Function]}
+  >
+    Skip to main content
+  </a>
   <div
     className="scroll-aware top pinned"
   >
@@ -162,7 +169,9 @@ exports[`Frontend Frontend Container renders correctly 1`] = `
       </section>
     </header>
   </div>
-  <main>
+  <main
+    id="skip-to-main"
+  >
     <div />
   </main>
   <footer

--- a/client/src/containers/reader/Reader.js
+++ b/client/src/containers/reader/Reader.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import connectAndFetch from "utils/connectAndFetch";
 import { bindActionCreators } from "redux";
-import { HigherOrder, Overlay } from "components/global";
+import { HigherOrder, Overlay, Utility } from "components/global";
 import {
   Header,
   Footer,
@@ -239,11 +239,13 @@ export class ReaderContainer extends Component {
     if (!this.props.text) return null;
     if (this.shouldRedirect(this.props)) return this.renderRedirect(this.props);
     if (!this.props.text) return null;
+    const skipId = "skip-to-main";
 
     return (
       <HigherOrder.BodyClass className="reader">
         <div>
           {this.renderStyles()}
+          <Utility.SkipLink skipId={skipId} />
           <HigherOrder.ScrollAware>
             {/* Header inside scroll-aware HOC */}
             <Header
@@ -267,7 +269,7 @@ export class ReaderContainer extends Component {
             hideTocDrawer={this.hideTocDrawer}
             showMeta={this.toggleMeta}
           />
-          <main>
+          <main id={skipId}>
             <ReactCSSTransitionGroup
               transitionName="overlay-full"
               transitionEnterTimeout={200}

--- a/client/src/containers/reader/__tests__/__snapshots__/Reader-test.js.snap
+++ b/client/src/containers/reader/__tests__/__snapshots__/Reader-test.js.snap
@@ -2,6 +2,13 @@
 
 exports[`Reader Reader Container renders correctly 1`] = `
 <div>
+  <a
+    className="screen-reader-text"
+    href="#skip-to-main"
+    onClick={[Function]}
+  >
+    Skip to main content
+  </a>
   <div
     className="scroll-aware top pinned"
   >
@@ -452,7 +459,9 @@ exports[`Reader Reader Container renders correctly 1`] = `
     </header>
   </div>
   <span />
-  <main>
+  <main
+    id="skip-to-main"
+  >
     <span />
     <span />
   </main>


### PR DESCRIPTION
Resolves #1146 

These skip links are only visible to screen readers and provide the user with the means to skip over the main navigation on page load (as the screen reader always starts reading from the top).