### PR TITLE
[B] Fix search menu slide off transition

### DIFF
--- a/client/src/theme/Components/reader/_header-reader.scss
+++ b/client/src/theme/Components/reader/_header-reader.scss
@@ -249,7 +249,7 @@
       transition: right $duration $timing;
 
       @include respond($break70) {
-        right: -610px;
+        right: -687px;
       }
     }
 


### PR DESCRIPTION
Resolves #1202

This menu slides out of sight by its width.  This menu must have changed size (is now wider) since this css transition was introduced and so was not sliding off all of the way.  This updates that amount by which it slides (the menu's new width).