### PR TITLE
[B] Fix footer padding on mobile

### DIFF
--- a/client/src/theme/Components/browse/layout/_footer-browse.scss
+++ b/client/src/theme/Components/browse/layout/_footer-browse.scss
@@ -10,6 +10,14 @@
     padding-top: 67px;
   }
 
+  .browse & {
+    padding-bottom: 35px;
+
+    @include respond($break50) {
+      padding-bottom: 0;
+    }
+  }
+
   .footer-primary {
     @include clearfix;
     @include respond($break65) {


### PR DESCRIPTION
Resolves #1218

Adds padding to the bottom of the browse layout's footer so that the following and projects buttons don't overlap with any footer content.