### PR TITLE
[F] Add skip links to admin pages with sidebar nav

### DIFF
--- a/client/src/containers/backend/Collection/Wrapper.js
+++ b/client/src/containers/backend/Collection/Wrapper.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import connectAndFetch from "utils/connectAndFetch";
 import { Navigation, Dialog } from "components/backend";
 import { HigherOrder } from "containers/global";
+import { Utility } from "components/global";
 import { entityStoreActions, notificationActions } from "actions";
 import { select } from "utils/entityUtils";
 import { collectionsAPI, requests } from "api";
@@ -161,6 +162,7 @@ export class CollectionWrapperContainer extends PureComponent {
     const { collection, match } = this.props;
     /* eslint-enable no-unused-vars */
     if (!collection) return null;
+    const skipId = "skip-to-collection-panel";
 
     return (
       <HigherOrder.Authorize
@@ -196,6 +198,7 @@ export class CollectionWrapperContainer extends PureComponent {
         <section className="backend-panel">
           <aside className="scrollable">
             <div className="wrapper">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary
                 links={this.secondaryNavigationLinks(collection)}
               />
@@ -203,11 +206,14 @@ export class CollectionWrapperContainer extends PureComponent {
           </aside>
           <div className="container">
             <aside className="aside">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary
                 links={this.secondaryNavigationLinks(collection)}
               />
             </aside>
-            <div className="panel">{this.renderRoutes()}</div>
+            <div id={skipId} className="panel">
+              {this.renderRoutes()}
+            </div>
           </div>
         </section>
       </HigherOrder.Authorize>

--- a/client/src/containers/backend/Collection/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/Collection/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -110,6 +110,13 @@ Array [
       <div
         className="wrapper"
       >
+        <a
+          className="screen-reader-text"
+          href="#skip-to-collection-panel"
+          onClick={[Function]}
+        >
+          Skip to main content
+        </a>
         <nav
           className="panel-nav"
         >
@@ -146,6 +153,13 @@ Array [
       <aside
         className="aside"
       >
+        <a
+          className="screen-reader-text"
+          href="#skip-to-collection-panel"
+          onClick={[Function]}
+        >
+          Skip to main content
+        </a>
         <nav
           className="panel-nav"
         >
@@ -177,6 +191,7 @@ Array [
       </aside>
       <div
         className="panel"
+        id="skip-to-collection-panel"
       />
     </div>
   </section>,

--- a/client/src/containers/backend/Content/Pages/Detail.js
+++ b/client/src/containers/backend/Content/Pages/Detail.js
@@ -7,6 +7,7 @@ import { entityStoreActions, notificationActions } from "actions";
 import lh from "helpers/linkHandler";
 import { childRoutes, RedirectToFirstMatch } from "helpers/router";
 import { HigherOrder } from "containers/global";
+import { Utility } from "components/global";
 import { Dialog, Navigation } from "components/backend";
 
 const { select } = entityUtils;
@@ -215,6 +216,7 @@ class PageDetailContainer extends PureComponent {
 
   renderExisting(page) {
     if (!page) return null;
+    const skipId = "skip-to-pages-body-panel";
 
     return (
       <div>
@@ -229,6 +231,7 @@ class PageDetailContainer extends PureComponent {
         <section className="backend-panel">
           <aside className="scrollable">
             <div className="wrapper">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary
                 links={this.secondaryNavigationLinks(this.props)}
               />
@@ -236,11 +239,12 @@ class PageDetailContainer extends PureComponent {
           </aside>
           <div className="container">
             <aside className="aside">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary
                 links={this.secondaryNavigationLinks(this.props)}
               />
             </aside>
-            <div className="panel">
+            <div id={skipId} className="panel">
               <section>{this.renderRoutes()}</section>
             </div>
           </div>

--- a/client/src/containers/backend/Content/Wrapper.js
+++ b/client/src/containers/backend/Content/Wrapper.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { Navigation } from "components/backend";
 import { HigherOrder } from "containers/global";
+import { Utility } from "components/global";
 import { connect } from "react-redux";
 import lh from "helpers/linkHandler";
 import { childRoutes, RedirectToFirstMatch } from "helpers/router";
@@ -37,6 +38,8 @@ export class PagesWrapperContainer extends PureComponent {
   }
 
   render() {
+    const skipId = "skip-to-content-panel";
+
     return (
       <HigherOrder.Authorize
         entity={["page", "feature"]}
@@ -48,14 +51,18 @@ export class PagesWrapperContainer extends PureComponent {
         <section className="backend-panel">
           <aside className="scrollable">
             <div className="wrapper">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary links={this.secondaryNavigationLinks()} />
             </div>
           </aside>
           <div className="container">
             <aside className="aside">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary links={this.secondaryNavigationLinks()} />
             </aside>
-            <div className="panel">{childRoutes(this.props.route)}</div>
+            <div id={skipId} className="panel">
+              {childRoutes(this.props.route)}
+            </div>
           </div>
         </section>
       </HigherOrder.Authorize>

--- a/client/src/containers/backend/People/Wrapper.js
+++ b/client/src/containers/backend/People/Wrapper.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { Navigation } from "components/backend";
 import { HigherOrder } from "containers/global";
+import { Utility } from "components/global";
 import { connect } from "react-redux";
 import lh from "helpers/linkHandler";
 import { childRoutes, RedirectToFirstMatch } from "helpers/router";
@@ -37,6 +38,8 @@ export class UsersWrapperContainer extends PureComponent {
   }
 
   render() {
+    const skipId = "skip-to-people-panel";
+
     return (
       <HigherOrder.Authorize
         ability="update"
@@ -50,14 +53,18 @@ export class UsersWrapperContainer extends PureComponent {
         <section className="backend-panel">
           <aside className="scrollable">
             <div className="wrapper">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary links={this.secondaryNavigationLinks()} />
             </div>
           </aside>
           <div className="container">
             <aside className="aside">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary links={this.secondaryNavigationLinks()} />
             </aside>
-            <div className="panel">{childRoutes(this.props.route)}</div>
+            <div id={skipId} className="panel">
+              {childRoutes(this.props.route)}
+            </div>
           </div>
         </section>
       </HigherOrder.Authorize>

--- a/client/src/containers/backend/People/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/People/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -10,6 +10,13 @@ exports[`Backend People Wrapper Container renders correctly 1`] = `
     <div
       className="wrapper"
     >
+      <a
+        className="screen-reader-text"
+        href="#skip-to-people-panel"
+        onClick={[Function]}
+      >
+        Skip to main content
+      </a>
       <nav
         className="panel-nav"
       >
@@ -35,6 +42,13 @@ exports[`Backend People Wrapper Container renders correctly 1`] = `
     <aside
       className="aside"
     >
+      <a
+        className="screen-reader-text"
+        href="#skip-to-people-panel"
+        onClick={[Function]}
+      >
+        Skip to main content
+      </a>
       <nav
         className="panel-nav"
       >
@@ -55,6 +69,7 @@ exports[`Backend People Wrapper Container renders correctly 1`] = `
     </aside>
     <div
       className="panel"
+      id="skip-to-people-panel"
     />
   </div>
 </section>

--- a/client/src/containers/backend/Project/Wrapper.js
+++ b/client/src/containers/backend/Project/Wrapper.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import connectAndFetch from "utils/connectAndFetch";
 import { Dialog, Navigation } from "components/backend";
 import { HigherOrder } from "containers/global";
+import { Utility } from "components/global";
 import { entityStoreActions } from "actions";
 import { select } from "utils/entityUtils";
 import { projectsAPI, requests } from "api";
@@ -204,6 +205,7 @@ export class ProjectWrapperContainer extends PureComponent {
   render() {
     if (!this.props.project) return null;
     const { project } = this.props;
+    const skipId = "skip-to-project-panel";
 
     return (
       <HigherOrder.Authorize
@@ -231,6 +233,7 @@ export class ProjectWrapperContainer extends PureComponent {
         <section className="backend-panel">
           <aside className="scrollable">
             <div className="wrapper">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary
                 links={this.secondaryNavigationLinks(project)}
               />
@@ -238,11 +241,14 @@ export class ProjectWrapperContainer extends PureComponent {
           </aside>
           <div className="container">
             <aside className="aside">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary
                 links={this.secondaryNavigationLinks(project)}
               />
             </aside>
-            <div className="panel">{this.renderRoutes()}</div>
+            <div id={skipId} className="panel">
+              {this.renderRoutes()}
+            </div>
           </div>
         </section>
       </HigherOrder.Authorize>

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -97,6 +97,13 @@ Array [
       <div
         className="wrapper"
       >
+        <a
+          className="screen-reader-text"
+          href="#skip-to-project-panel"
+          onClick={[Function]}
+        >
+          Skip to main content
+        </a>
         <nav
           className="panel-nav"
         >
@@ -232,6 +239,13 @@ Array [
       <aside
         className="aside"
       >
+        <a
+          className="screen-reader-text"
+          href="#skip-to-project-panel"
+          onClick={[Function]}
+        >
+          Skip to main content
+        </a>
         <nav
           className="panel-nav"
         >
@@ -362,6 +376,7 @@ Array [
       </aside>
       <div
         className="panel"
+        id="skip-to-project-panel"
       />
     </div>
   </section>,

--- a/client/src/containers/backend/Resource/Wrapper.js
+++ b/client/src/containers/backend/Resource/Wrapper.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import connectAndFetch from "utils/connectAndFetch";
 import { Navigation, Dialog } from "components/backend";
 import { HigherOrder } from "containers/global";
+import { Utility } from "components/global";
 import { entityStoreActions, notificationActions } from "actions";
 import { select } from "utils/entityUtils";
 import { resourcesAPI, requests } from "api";
@@ -177,6 +178,7 @@ export class ResourceWrapperContainer extends PureComponent {
     const { resource, match } = this.props;
     /* eslint-enable no-unused-vars */
     if (!resource) return null;
+    const skipId = "skip-to-resource-panel";
 
     return (
       <HigherOrder.Authorize
@@ -216,6 +218,7 @@ export class ResourceWrapperContainer extends PureComponent {
         <section className="backend-panel">
           <aside className="scrollable">
             <div className="wrapper">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary
                 links={this.secondaryNavigationLinks(
                   resource,
@@ -226,6 +229,7 @@ export class ResourceWrapperContainer extends PureComponent {
           </aside>
           <div className="container">
             <aside className="aside">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary
                 links={this.secondaryNavigationLinks(
                   resource,
@@ -233,7 +237,9 @@ export class ResourceWrapperContainer extends PureComponent {
                 )}
               />
             </aside>
-            <div className="panel">{this.renderRoutes()}</div>
+            <div id={skipId} className="panel">
+              {this.renderRoutes()}
+            </div>
           </div>
         </section>
       </HigherOrder.Authorize>

--- a/client/src/containers/backend/Resource/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/Resource/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -110,6 +110,13 @@ Array [
       <div
         className="wrapper"
       >
+        <a
+          className="screen-reader-text"
+          href="#skip-to-resource-panel"
+          onClick={[Function]}
+        >
+          Skip to main content
+        </a>
         <nav
           className="panel-nav"
         >
@@ -157,6 +164,13 @@ Array [
       <aside
         className="aside"
       >
+        <a
+          className="screen-reader-text"
+          href="#skip-to-resource-panel"
+          onClick={[Function]}
+        >
+          Skip to main content
+        </a>
         <nav
           className="panel-nav"
         >
@@ -199,6 +213,7 @@ Array [
       </aside>
       <div
         className="panel"
+        id="skip-to-resource-panel"
       />
     </div>
   </section>,

--- a/client/src/containers/backend/Settings/Wrapper.js
+++ b/client/src/containers/backend/Settings/Wrapper.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Navigation } from "components/backend";
 import { HigherOrder } from "containers/global";
+import { Utility } from "components/global";
 import lh from "helpers/linkHandler";
 import { childRoutes, RedirectToFirstMatch } from "helpers/router";
 
@@ -52,6 +53,8 @@ export class SettingsWrapperContainer extends PureComponent {
   }
 
   render() {
+    const skipId = "skip-to-settings-panel";
+
     return (
       <HigherOrder.Authorize
         entity="settings"
@@ -65,14 +68,18 @@ export class SettingsWrapperContainer extends PureComponent {
         <section className="backend-panel">
           <aside className="scrollable">
             <div className="wrapper">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary links={this.secondaryNavigationLinks()} />
             </div>
           </aside>
           <div className="container">
             <aside className="aside">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary links={this.secondaryNavigationLinks()} />
             </aside>
-            <div className="panel">{childRoutes(this.props.route)}</div>
+            <div id={skipId} className="panel">
+              {childRoutes(this.props.route)}
+            </div>
           </div>
         </section>
       </HigherOrder.Authorize>

--- a/client/src/containers/backend/Settings/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/Settings/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -10,6 +10,13 @@ exports[`Backend Settings Wrapper Container renders correctly 1`] = `
     <div
       className="wrapper"
     >
+      <a
+        className="screen-reader-text"
+        href="#skip-to-settings-panel"
+        onClick={[Function]}
+      >
+        Skip to main content
+      </a>
       <nav
         className="panel-nav"
       >
@@ -79,6 +86,13 @@ exports[`Backend Settings Wrapper Container renders correctly 1`] = `
     <aside
       className="aside"
     >
+      <a
+        className="screen-reader-text"
+        href="#skip-to-settings-panel"
+        onClick={[Function]}
+      >
+        Skip to main content
+      </a>
       <nav
         className="panel-nav"
       >
@@ -143,6 +157,7 @@ exports[`Backend Settings Wrapper Container renders correctly 1`] = `
     </aside>
     <div
       className="panel"
+      id="skip-to-settings-panel"
     />
   </div>
 </section>

--- a/client/src/containers/backend/Text/Wrapper.js
+++ b/client/src/containers/backend/Text/Wrapper.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import connectAndFetch from "utils/connectAndFetch";
 import { Dialog, Navigation } from "components/backend";
 import { HigherOrder } from "containers/global";
+import { Utility } from "components/global";
 import { entityStoreActions, notificationActions } from "actions";
 import { select } from "utils/entityUtils";
 import { textsAPI, requests } from "api";
@@ -177,6 +178,8 @@ export class TextWrapperContainer extends PureComponent {
   render() {
     const { text } = this.props;
     if (!text) return null;
+    const skipId = "skip-to-text-panel";
+
     return (
       <HigherOrder.Authorize
         entity={text}
@@ -211,6 +214,7 @@ export class TextWrapperContainer extends PureComponent {
         <section className="backend-panel">
           <aside className="scrollable">
             <div className="wrapper">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary
                 links={this.secondaryNavigationLinks(text)}
               />
@@ -218,11 +222,14 @@ export class TextWrapperContainer extends PureComponent {
           </aside>
           <div className="container">
             <aside className="aside">
+              <Utility.SkipLink skipId={skipId} />
               <Navigation.Secondary
                 links={this.secondaryNavigationLinks(text)}
               />
             </aside>
-            <div className="panel">{this.renderRoutes()}</div>
+            <div id={skipId} className="panel">
+              {this.renderRoutes()}
+            </div>
           </div>
         </section>
       </HigherOrder.Authorize>

--- a/client/src/containers/backend/Text/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/Text/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -104,6 +104,13 @@ Array [
       <div
         className="wrapper"
       >
+        <a
+          className="screen-reader-text"
+          href="#skip-to-text-panel"
+          onClick={[Function]}
+        >
+          Skip to main content
+        </a>
         <nav
           className="panel-nav"
         >
@@ -173,6 +180,13 @@ Array [
       <aside
         className="aside"
       >
+        <a
+          className="screen-reader-text"
+          href="#skip-to-text-panel"
+          onClick={[Function]}
+        >
+          Skip to main content
+        </a>
         <nav
           className="panel-nav"
         >
@@ -237,6 +251,7 @@ Array [
       </aside>
       <div
         className="panel"
+        id="skip-to-text-panel"
       />
     </div>
   </section>,


### PR DESCRIPTION
Resolves #1201

Adds anchor links, that are only visible to screen readers, above the sidebar nav of each admin backend page that link to the main panel content.