### PR TITLE
[B] Self-close void element tags in html validator

### DIFF
--- a/api/app/services/validator/html.rb
+++ b/api/app/services/validator/html.rb
@@ -4,6 +4,10 @@ module Validator
   # frontend. This mainly involves insuring proper nesting, and making sure that the
   # structure will work with ReactDom.
   class Html
+
+    VOID_ELEMENTS = %w(area base br col embed hr img input keygen
+                       link meta param source track wbr).freeze
+
     def validate(html)
       source = html.encoding == ::Encoding::ASCII_8BIT ? html.encode("UTF-8") : html
       fragment = Nokogiri::HTML.fragment(source)
@@ -11,10 +15,20 @@ module Validator
       ensure_valid_parent_nodes(fragment)
       strip_invalid_children(fragment)
       validate_tags(fragment)
-      fragment.to_s
+      close_void_tags(fragment.to_s)
     end
 
     private
+
+    def close_void_tags(html)
+      output = html
+      VOID_ELEMENTS.each do |element|
+        output.gsub!(%r(<#{element}(.+?)?\/?>), "<#{element}\\1 />")
+        output.gsub!(%r(<\/#{element}>), "")
+      end
+
+      output
+    end
 
     def validate_tags(fragment)
       tag_validator = Tag.new

--- a/api/app/services/validator/tag.rb
+++ b/api/app/services/validator/tag.rb
@@ -155,6 +155,12 @@ module Validator
       node.delete(attribute_name(attribute))
     end
 
+    def transform_attribute_value!(node, attribute, transform)
+      value = transform[:to]
+      name = attribute_name(attribute)
+      node[name] = value
+    end
+
     # @param attribute [Array] containing exactly two elements: key and value
     # @return [String]
     def attribute_value(attribute)

--- a/api/config/manifold.yml
+++ b/api/config/manifold.yml
@@ -42,6 +42,10 @@ common: &1
         :tag: "image"
         :type: "attribute_name"
       -
+        :name: "controls"
+        :to: true
+        :type: "attribute_value"
+      -
         :name: "*"
         :type: "namespaced"
     :attribute_exclusions:

--- a/api/spec/services/validator/html_spec.rb
+++ b/api/spec/services/validator/html_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe Validator::Html do
     expect(validator.validate(fragment).delete("\n")).to eq(fragment)
   end
 
+  it "should close void tags" do
+    fragment = '<video><source src="sample.webm" type="video/webm"></video>'
+    valid = '<video><source src="sample.webm" type="video/webm" /></video>'
+    expect(validator.validate(fragment).delete("\n")).to eq(valid)
+  end
+
+  it "should remove closing void tags" do
+    fragment = '<div><input type="text"></input></div>'
+    valid = '<div><input type="text" /></div>'
+    expect(validator.validate(fragment).delete("\n")).to eq(valid)
+  end
+
   describe "excluded attributes" do
     html_config.attribute_exclusions.each do |attr|
       it "are removed: #{attr}" do
@@ -101,43 +113,43 @@ RSpec.describe Validator::Html do
 
   it "should remove max-width style attributes" do
     fragment = "<img style=\"max-width: 650px\">"
-    valid = "<img>"
+    valid = "<img />"
     expect(validator.validate(fragment).delete("\n")).to eq(valid)
   end
 
   it "should rewrite width attribute to width style" do
     fragment = "<img width=\"650px\">"
-    valid = "<img style=\"width: 650px\">"
+    valid = "<img style=\"width: 650px\" />"
     expect(validator.validate(fragment).delete("\n")).to eq(valid)
   end
 
   it "should cap the width" do
     fragment = "<img width=\"700px\">"
-    valid = "<img style=\"width: 650px\">"
+    valid = "<img style=\"width: 650px\" />"
     expect(validator.validate(fragment).delete("\n")).to eq(valid)
   end
 
   it "should maintain units when rewriting measured attribute" do
     fragment = "<img width=\"50%\">"
-    valid = "<img style=\"width: 50%\">"
+    valid = "<img style=\"width: 50%\" />"
     expect(validator.validate(fragment).delete("\n")).to eq(valid)
   end
 
   it "should default to pixels when rewriting measured attributes that have no unit" do
     fragment = "<img width=\"50\">"
-    valid = "<img style=\"width: 50px\">"
+    valid = "<img style=\"width: 50px\" />"
     expect(validator.validate(fragment).delete("\n")).to eq(valid)
   end
 
   it "should rewrite bgcolor attribute to background-color style" do
     fragment = "<img bgcolor=\"red\">"
-    valid = "<img style=\"background-color: red\">"
+    valid = "<img style=\"background-color: red\" />"
     expect(validator.validate(fragment).delete("\n")).to eq(valid)
   end
 
   it "should rewrite align attribute to text-align style" do
     fragment = "<img align=\"left\">"
-    valid = "<img style=\"text-align: left\">"
+    valid = "<img style=\"text-align: left\" />"
     expect(validator.validate(fragment).delete("\n")).to eq(valid)
   end
 


### PR DESCRIPTION
The primary issue here was that the source html had unlcosed `<source>` tags.  While this is valid HTML 5, Nokogiri adds closing `</source>` tags, which is invalid.  Additionally, Nokogiri adds these closing tags in inconsistent places, resulting in some invalid nesting.

This fix adds a step in the HTML validator that will take void elements and ensure they're closed while maintaining their properties.  It will also remove any closing void tags.  It runs as the last step in the validator because we're manipulating the resulting HTML string, not the parsed nodes, and sending the string back through Nokogiri will add back the removed closing tags.