### PR TITLE
[F] Updates drawers to always include some kind of screen reader accessible close button

### DIFF
--- a/client/src/components/global/Drawer/Wrapper.js
+++ b/client/src/components/global/Drawer/Wrapper.js
@@ -33,7 +33,8 @@ export default class DrawerWrapper extends PureComponent {
     style: PropTypes.string,
     history: PropTypes.object,
     includeDrawerFrontMatter: PropTypes.bool,
-    returnFocusOnDeactivate: PropTypes.bool
+    returnFocusOnDeactivate: PropTypes.bool,
+    focusTrap: PropTypes.bool
   };
 
   static childContextTypes = {
@@ -53,7 +54,8 @@ export default class DrawerWrapper extends PureComponent {
     style: "backend",
     entrySide: "right",
     includeDrawerFrontMatter: true,
-    returnFocusOnDeactivate: true
+    returnFocusOnDeactivate: true,
+    focusTrap: true
   };
 
   constructor(props) {
@@ -155,40 +157,52 @@ export default class DrawerWrapper extends PureComponent {
   };
 
   renderDrawerFrontMatter(props) {
-    if (!props.includeDrawerFrontMatter) return null;
     const hasTitle = props.title || props.icon;
     const hasClose = props.closeCallback || props.closeUrl;
     return (
-      <div className="drawer-bar">
-        {hasTitle ? (
-          <div className="drawer-title">
-            {props.icon ? (
-              <i
-                className={`manicon manicon-${props.icon}`}
-                aria-hidden="true"
-              />
+      <React.Fragment>
+        {props.includeDrawerFrontMatter ? (
+          <div className="drawer-bar">
+            {hasTitle ? (
+              <div className="drawer-title">
+                {props.icon ? (
+                  <i
+                    className={`manicon manicon-${props.icon}`}
+                    aria-hidden="true"
+                  />
+                ) : null}
+                {props.title ? props.title : null}
+              </div>
             ) : null}
-            {props.title ? props.title : null}
+            {hasClose ? (
+              <div
+                onClick={this.handleLeaveEvent}
+                role="button"
+                tabIndex="0"
+                className="close-button-primary"
+              >
+                <span className="close-text">Close</span>
+                <i className="manicon manicon-x" aria-hidden="true" />
+              </div>
+            ) : null}
           </div>
-        ) : null}
-        {hasClose ? (
-          <div
+        ) : (
+          <button
             onClick={this.handleLeaveEvent}
-            role="button"
             tabIndex="0"
-            className="close-button-primary"
+            className="screen-reader-text"
           >
-            <span className="close-text">Close</span>
-            <i className="manicon manicon-x" aria-hidden="true" />
-          </div>
-        ) : null}
-      </div>
+            Close
+          </button>
+        )}
+      </React.Fragment>
     );
   }
 
   renderDrawer() {
     const entrySideClass =
       this.props.entrySide === "left" ? this.props.entrySide : "";
+
     return (
       <div
         key="drawer"
@@ -196,7 +210,7 @@ export default class DrawerWrapper extends PureComponent {
       >
         <FocusTrap
           ref={this.focusTrapNode}
-          active={this.state.focusable}
+          active={this.state.focusable && this.props.focusTrap}
           focusTrapOptions={{
             clickOutsideDeactivates: true,
             escapeDeactivates: false,

--- a/client/src/components/global/Drawer/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/components/global/Drawer/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -3,7 +3,7 @@
 exports[`Backend.Drawer.Wrapper Component renders correctly 1`] = `
 "<MemoryRouter>
   <Router history={{...}}>
-    <Drawer.Wrapper open={true} style=\\"backend\\" title=\\"wrapper\\" closeCallback={[Function: mockConstructor]} connected={false} lockScroll=\\"hover\\" entrySide=\\"right\\" includeDrawerFrontMatter={true} returnFocusOnDeactivate={true}>
+    <Drawer.Wrapper open={true} style=\\"backend\\" title=\\"wrapper\\" closeCallback={[Function: mockConstructor]} connected={false} lockScroll=\\"hover\\" entrySide=\\"right\\" includeDrawerFrontMatter={true} returnFocusOnDeactivate={true} focusTrap={true}>
       <CSSTransitionGroup transitionName=\\"drawer\\" transitionEnterTimeout={500} transitionLeaveTimeout={300} transitionAppear={false} transitionEnter={true} transitionLeave={true}>
         <TransitionGroup transitionName=\\"drawer\\" transitionEnterTimeout={500} transitionLeaveTimeout={300} transitionAppear={false} transitionEnter={true} transitionLeave={true} childFactory={[Function]} component=\\"span\\">
           <span>

--- a/client/src/components/reader/Notes/ReaderDrawer.js
+++ b/client/src/components/reader/Notes/ReaderDrawer.js
@@ -26,7 +26,8 @@ export default class ReaderDrawer extends PureComponent {
       style: "reader",
       identifier: "notes-drawer",
       lockScroll: "always",
-      includeDrawerFrontMatter: false
+      includeDrawerFrontMatter: false,
+      focusTrap: false
     };
 
     return (

--- a/client/src/components/reader/__tests__/__snapshots__/Toc-test.js.snap
+++ b/client/src/components/reader/__tests__/__snapshots__/Toc-test.js.snap
@@ -21,6 +21,13 @@ exports[`Reader.Toc Component renders correctly 1`] = `
             }
           }
         >
+          <button
+            className="screen-reader-text"
+            onClick={[Function]}
+            tabIndex="0"
+          >
+            Close
+          </button>
           <nav
             className="table-of-contents"
           >
@@ -88,6 +95,13 @@ exports[`Reader.Toc Component renders correctly with empty toc 1`] = `
             }
           }
         >
+          <button
+            className="screen-reader-text"
+            onClick={[Function]}
+            tabIndex="0"
+          >
+            Close
+          </button>
           <nav
             className="table-of-contents"
           >

--- a/client/src/containers/backend/Project/Social/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/containers/backend/Project/Social/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -15,7 +15,7 @@ exports[`Backend Project Social Wrapper Container renders correctly 1`] = `
                       <Connect(withRouter(Drawer.Wrapper)) open={false} closeUrl=\\"/backend/project/1/social\\">
                         <withRouter(Drawer.Wrapper) open={false} closeUrl=\\"/backend/project/1/social\\" connected={true} dispatch={[Function]}>
                           <Route>
-                            <Drawer.Wrapper open={false} closeUrl=\\"/backend/project/1/social\\" connected={true} dispatch={[Function]} match={{...}} location={{...}} history={{...}} staticContext={[undefined]} lockScroll=\\"hover\\" style=\\"backend\\" entrySide=\\"right\\" includeDrawerFrontMatter={true} returnFocusOnDeactivate={true}>
+                            <Drawer.Wrapper open={false} closeUrl=\\"/backend/project/1/social\\" connected={true} dispatch={[Function]} match={{...}} location={{...}} history={{...}} staticContext={[undefined]} lockScroll=\\"hover\\" style=\\"backend\\" entrySide=\\"right\\" includeDrawerFrontMatter={true} returnFocusOnDeactivate={true} focusTrap={true}>
                               <CSSTransitionGroup transitionName=\\"drawer\\" transitionEnterTimeout={500} transitionLeaveTimeout={300} transitionAppear={false} transitionEnter={true} transitionLeave={true}>
                                 <TransitionGroup transitionName=\\"drawer\\" transitionEnterTimeout={500} transitionLeaveTimeout={300} transitionAppear={false} transitionEnter={true} transitionLeave={true} childFactory={[Function]} component=\\"span\\">
                                   <span />


### PR DESCRIPTION
Adds a screen reader only close button to the drawer even if there is no visible drawer header or close button.
Includes update to the Drawer component to optionally not initialize focus trap.  This is used on the "notes" ReaderDrawer as that drawer already lives in another focus trap supplied by its parent UIPanel.