### PR TITLE
[B] Fix single file manifest ingestions failing to detect source

### DIFF
--- a/api/app/services/ingestions/strategies/manifest.rb
+++ b/api/app/services/ingestions/strategies/manifest.rb
@@ -11,7 +11,7 @@ module Ingestions
       end
 
       def determine_ingestibility
-        context.source_path_for_file("manifest", %w(yml yaml)).present?
+        context.source_path_for_file("*", %w(yml yaml)).present?
       end
 
       private

--- a/api/app/services/ingestions/strategy/manifest/inspector.rb
+++ b/api/app/services/ingestions/strategy/manifest/inspector.rb
@@ -86,7 +86,7 @@ module Ingestions
         end
 
         def manifest_path
-          context.rel_path_for_file "manifest", %w(yml yaml)
+          context.rel_path_for_file "*", %w(yml yaml)
         end
 
         def source_dir_path

--- a/api/spec/services/ingestions/compiler_spec.rb
+++ b/api/spec/services/ingestions/compiler_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Ingestions::Compiler do
                       .and change(TextTitle, :count).by(1)
                              .and change(IngestionSource, :count).by(2)
                                     .and change(Maker, :count).by(0)
-                                           .and change(Stylesheet, :count).by(1)
+                                           .and change(Stylesheet, :count).by(2)
     end
   end
 end


### PR DESCRIPTION
The solution we use in the Document strategy won't actually work here.

If the manifest is a single file and collection of google docs, the sources count is 1 at the start, but > 1 after docs are downloaded.  This presents the same issue we have now because we would try to determine the manifest by name, which is still changed through paperclip.

example: 
- At ingestion start, `sources = ["paperclip-random-name.yml"]`
- After downloading docs, `sources = ["paperclip-random-name.yml", "doc-1.html", "doc-2.html"]`

This essentially leaves us having to make the determination by file extension for now.  I _do_ think this is acceptable right now, as the use-cases for including additional `yml` files are extremely narrow, if existent at all.

Again, this may be worth revisiting when #1264 is merged.