### PR TITLE
[B] Ingestion uploader should validate file ext instead of mime type

### DIFF
--- a/api/app/uploaders/ingestion_uploader.rb
+++ b/api/app/uploaders/ingestion_uploader.rb
@@ -12,7 +12,7 @@ class IngestionUploader < TusUploader
   Attacher.validate do
     validations = Rails.configuration.manifold.attachments.validations
 
-    validate_mime_type_inclusion validations.ingestion.allowed_mime
+    validate_extension_inclusion validations.ingestion.allowed_ext
   end
 
   # rubocop:disable Layout/IndentHeredoc

--- a/api/config/manifold.yml
+++ b/api/config/manifold.yml
@@ -174,15 +174,16 @@ common: &1
           - "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
           - "application/vnd.openxmlformats-officedocument.wordprocessingml.template"
         :allowed_ext:
-          - !ruby/regexp '/\*/i'
-          - !ruby/regexp '/md\Z/i'
-          - !ruby/regexp '/zip\Z/i'
-          - !ruby/regexp '/epub\Z/i'
-          - !ruby/regexp '/html?\Z/i'
-          - !ruby/regexp '/ya?ml\Z/i'
-          - !ruby/regexp '/docx\Z/i'
-          - !ruby/regexp '/tex\Z/i'
-          - !ruby/regexp '/latex\Z/i'
+          - md
+          - zip
+          - epub
+          - htm
+          - html
+          - docx
+          - yaml
+          - yml
+          - tex
+          - latex
       :image:
         :allowed_mime:
           - !ruby/regexp '/image\/.*/'


### PR DESCRIPTION
This is a regression introduced with the change to Shrine.  

Also includes a change to the manifold config file.  Passing regex matchers are deprecated and will be removed in Shrine 3.