### PR TITLE
[B] Fix EPUB v2 TOC tree generation

### DIFF
--- a/api/app/services/ingestions/strategy/epub/toc/v2.rb
+++ b/api/app/services/ingestions/strategy/epub/toc/v2.rb
@@ -49,17 +49,16 @@ module Ingestions
           # rubocop: disable Metrics/MethodLength
           def nodes_to_structure(nodes)
             items = []
-            if nodes.count
+            if nodes.count.positive?
               nodes.each do |node|
                 item = {}
                 if node.at(".//xmlns:content")
                   label = node.at(".//xmlns:navLabel/xmlns:text/text()")&.text
                   href = node.at("content")&.attribute("src")&.value
                   item = make_structure_item(label, href)
-                  if node.at(".//xmlns:navPoint")
-                    children = node.search(".//xmlns:navPoint")
-                    item[:children] = toc_nodes_to_structure(children)
-                  end
+
+                  children = node > "xmlns|navPoint"
+                  item[:children] = toc_nodes_to_structure(children) if children.present?
                 end
                 items.push item unless item.empty?
               end

--- a/api/lib/tasks/project.rake
+++ b/api/lib/tasks/project.rake
@@ -12,7 +12,7 @@ namespace :manifold do
       Manifold::Rake.logger.info "Ingesting #{args[:path]}"
       project = Project.find(args[:project_id])
       ingestion = Ingestions::CreateManually.run(project: project,
-                                                 source: File.open(path),
+                                                 source: File.open(args[:path]),
                                                  creator: User.cli_user).result
       outcome = Ingestions::Ingestor.run ingestion: ingestion,
                                          logger: Logger.new(STDOUT)

--- a/api/spec/services/ingestions/strategy/epub/toc_spec.rb
+++ b/api/spec/services/ingestions/strategy/epub/toc_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe Ingestions::Strategy::Epub::TOC do
+
+  context "when v3" do
+    let(:toc) do
+      <<~HEREDOC
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE html>
+        <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+          <nav epub:type="toc">
+            <h1>Table of Contents</h1>
+            <ol>
+              <li>
+                <span>Section 1</span>
+                <ol>
+                  <li>
+                    <span>Section 2</span>
+                    <ol>
+                      <li>
+                        <span>Section 2.a</span>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li><span>Section 3</span></li>
+            </ol>
+          </nav>
+        </html>
+      HEREDOC
+    end
+
+    let(:inspector) do
+      mock_inspector = double(v2?: false, context: {}, nav_parsed: Nokogiri::XML(toc), nav_path: nil)
+      described_class.new mock_inspector
+    end
+
+    it "correctly generates a toc structure" do
+      expected =  [{:label=>"Section 1", :anchor=>"", :source_path=>"", :type=>nil, :children=>
+                    [{:label=>"Section 2", :anchor=>"", :source_path=>"", :type=>nil, :children=>
+                      [{:label=>"Section 2.a", :anchor=>"", :source_path=>"", :type=>nil}]
+                     }]},
+                   {:label=>"Section 3", :anchor=>"", :source_path=>"", :type=>nil}]
+      expect(inspector.toc_structure).to eq expected
+    end
+  end
+
+  context "when v2" do
+    let(:toc) do
+      <<~HEREDOC
+      <?xml version="1.0" encoding="UTF-8"?>
+      <ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+        <navMap>
+          <navPoint id="navPoint-1">
+            <navLabel>
+              <text>Section 1</text>
+            </navLabel>
+            <content src=nil />
+            <navPoint id="navPoint-2">
+              <navLabel>
+                <text>Section 2</text>
+              </navLabel>
+              <content src=nil />
+              <navPoint id="navPoint-2a">
+                <navLabel>
+                  <text>Section 2.a</text>
+                </navLabel>
+                <content src=nil />
+              </navPoint>
+            </navPoint>
+          </navPoint>
+          <navPoint id="navPoint-3">
+            <navLabel>
+              <text>Section 3</text>
+            </navLabel>
+            <content src=nil />
+          </navPoint>
+        </navMap>
+      </ncx>
+      HEREDOC
+    end
+
+    let(:inspector) do
+      mock_inspector = double(v2?: true, context: {}, nav_parsed: Nokogiri::XML(toc), nav_path: nil)
+      described_class.new mock_inspector
+    end
+
+    it "correctly generates a toc structure" do
+      expected =  [{:label=>"Section 1", :anchor=>"", :source_path=>"", :type=>nil, :children=>
+                    [{:label=>"Section 2", :anchor=>"", :source_path=>"", :type=>nil, :children=>
+                       [{:label=>"Section 2.a", :anchor=>"", :source_path=>"", :type=>nil}]
+                     }]},
+                   {:label=>"Section 3", :anchor=>"", :source_path=>"", :type=>nil}]
+      expect(inspector.toc_structure).to eq expected
+    end
+  end
+
+end


### PR DESCRIPTION
The EPUB v2 node structure was selecting _all_ matching child nodes.  This meant that for every item with children, the entire branch was run through the structure generator.

The fix is to only select the direct descendants of each branch.