### PR TITLE
[B] Fix layout of backend text category headers

### DIFF
--- a/client/src/theme/Components/backend/text/_list.scss
+++ b/client/src/theme/Components/backend/text/_list.scss
@@ -48,6 +48,7 @@
     .text-category-list-utility {
       display: table-cell;
       text-align: right;
+      line-height: 1;
       white-space: nowrap;
     }
   }


### PR DESCRIPTION
Inconsistent line-height of children was causing category headers to be too tall.

Resolves #1321