### PR TITLE
[B] Fix position of icon in text reingest button

### DIFF
--- a/client/src/containers/backend/Ingestion/Ingest.js
+++ b/client/src/containers/backend/Ingestion/Ingest.js
@@ -288,8 +288,8 @@ export class IngestionIngest extends Component {
               onClick={this.reset}
               disabled={this.state.loading || !this.canReset}
             >
-              Restart Ingestion
               <i className="manicon manicon-x-bold" aria-hidden="true" />
+              Restart Ingestion
             </button>
           </div>
         </div>

--- a/client/src/containers/backend/Ingestion/__tests__/__snapshots__/Ingest-test.js.snap
+++ b/client/src/containers/backend/Ingestion/__tests__/__snapshots__/Ingest-test.js.snap
@@ -91,11 +91,11 @@ exports[`Backend Ingest Container when the ingestion state is finished renders c
         disabled={true}
         onClick={[Function]}
       >
-        Restart Ingestion
         <i
           aria-hidden="true"
           className="manicon manicon-x-bold"
         />
+        Restart Ingestion
       </button>
     </div>
   </div>
@@ -212,11 +212,11 @@ exports[`Backend Ingest Container when the ingestion state is sleeping renders c
         disabled={true}
         onClick={[Function]}
       >
-        Restart Ingestion
         <i
           aria-hidden="true"
           className="manicon manicon-x-bold"
         />
+        Restart Ingestion
       </button>
     </div>
   </div>


### PR DESCRIPTION
Flips order of icon and text in "Restart ingestion" button for
consistency with v2.0 backend UI updates.

Resolves #1329