### PR TITLE
[F] Implement Form.Header component

### DIFF
--- a/client/src/components/backend/Form/Header.js
+++ b/client/src/components/backend/Form/Header.js
@@ -1,0 +1,18 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+export default class FormHeader extends Component {
+  static displayName = "Form.Header";
+
+  static propTypes = {
+    label: PropTypes.string.isRequired
+  };
+
+  render() {
+    return (
+      <header className="form-header">
+        <h2>{this.props.label}</h2>
+      </header>
+    );
+  }
+}

--- a/client/src/components/backend/Form/index.js
+++ b/client/src/components/backend/Form/index.js
@@ -4,6 +4,7 @@ import AttributeMap from "./AttributeMap";
 import Date from "./Date";
 import FieldGroup from "./FieldGroup";
 import GeneratedPasswordInput from "./GeneratedPasswordInput";
+import Header from "./Header";
 import HasMany from "./HasMany";
 import Hidden from "./Hidden";
 import HigherOrder from "./HigherOrder";
@@ -29,6 +30,7 @@ export default {
   FieldGroup,
   GeneratedPasswordInput,
   HasMany,
+  Header,
   Hidden,
   HigherOrder,
   Instructions,

--- a/client/src/components/backend/Ingestion/Form/Upload.js
+++ b/client/src/components/backend/Ingestion/Form/Upload.js
@@ -11,7 +11,8 @@ class IngestionFormUpload extends PureComponent {
     location: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
     cancelUrl: PropTypes.string,
-    setOther: PropTypes.func
+    setOther: PropTypes.func,
+    header: PropTypes.string
   };
 
   onSourceChange = source => {
@@ -47,6 +48,8 @@ class IngestionFormUpload extends PureComponent {
   };
 
   render() {
+    const formHeader = this.props.header || "Upload";
+
     const fileInstructions = (
       <span className="instructions">
         Manifold can ingest texts from single files or a .zip collection.
@@ -66,6 +69,7 @@ class IngestionFormUpload extends PureComponent {
     /* eslint-disable max-len */
     return (
       <div>
+        <Form.Header label={formHeader} />
         <Form.TusUpload
           inlineStyle={{ width: "100%" }}
           layout="landscape"

--- a/client/src/components/backend/Ingestion/Form/Wrapper.js
+++ b/client/src/components/backend/Ingestion/Form/Wrapper.js
@@ -17,7 +17,8 @@ export default class IngestionFormWrapper extends PureComponent {
     ingestion: PropTypes.object.isRequired,
     onSuccess: PropTypes.func,
     triggerClose: PropTypes.func,
-    cancelUrl: PropTypes.string
+    cancelUrl: PropTypes.string,
+    header: PropTypes.string
   };
 
   static defaultProps = {
@@ -61,6 +62,7 @@ export default class IngestionFormWrapper extends PureComponent {
         onSuccess={this.props.onSuccess}
       >
         <Upload
+          header={this.props.header}
           cancelUrl={this.props.cancelUrl}
           history={this.props.history}
           location={this.props.location}

--- a/client/src/components/backend/Ingestion/Form/__tests__/__snapshots__/Upload-test.js.snap
+++ b/client/src/components/backend/Ingestion/Form/__tests__/__snapshots__/Upload-test.js.snap
@@ -2,6 +2,13 @@
 
 exports[`Backend.Ingestion.Form.Upload component renders correctly 1`] = `
 <div>
+  <header
+    className="form-header"
+  >
+    <h2>
+      Upload
+    </h2>
+  </header>
   <div
     className="form-input"
   >

--- a/client/src/components/backend/Ingestion/Form/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/components/backend/Ingestion/Form/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -8,6 +8,13 @@ exports[`Backend.Ingestion.Form.Wrapper component renders correctly 1`] = `
     onSubmit={[Function]}
   >
     <div>
+      <header
+        className="form-header"
+      >
+        <h2>
+          Upload
+        </h2>
+      </header>
       <div
         className="form-input"
       >

--- a/client/src/containers/backend/Project/ProjectPage.js
+++ b/client/src/containers/backend/Project/ProjectPage.js
@@ -39,6 +39,7 @@ export default class ProjectProjectPageContainer extends PureComponent {
             create={projectsAPI.create}
             className="form-secondary"
           >
+            <Form.Header label="Appearance" />
             <Form.TextArea
               label="Description"
               name="attributes[description]"

--- a/client/src/containers/backend/Project/Text/Ingestion/New.js
+++ b/client/src/containers/backend/Project/Text/Ingestion/New.js
@@ -52,6 +52,7 @@ export class IngestionNewContainer extends PureComponent {
           name={requests.beIngestionCreate}
           project={this.props.project}
           triggerClose={this.props.triggerClose}
+          header={"Add a new text"}
         />
       </div>
     );

--- a/client/src/containers/backend/Project/Text/Ingestion/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Project/Text/Ingestion/__tests__/__snapshots__/New-test.js.snap
@@ -9,6 +9,13 @@ exports[`Project Text Ingestion New Container renders correctly 1`] = `
       onSubmit={[Function]}
     >
       <div>
+        <header
+          className="form-header"
+        >
+          <h2>
+            Add a new text
+          </h2>
+        </header>
         <div
           className="form-input"
         >

--- a/client/src/containers/backend/Project/__tests__/__snapshots__/ProjectPage-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/ProjectPage-test.js.snap
@@ -8,6 +8,13 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
       data-id="submit"
       onSubmit={[Function]}
     >
+      <header
+        className="form-header"
+      >
+        <h2>
+          Appearance
+        </h2>
+      </header>
       <div
         className="form-input"
       >

--- a/client/src/containers/backend/Text/General.js
+++ b/client/src/containers/backend/Text/General.js
@@ -21,6 +21,7 @@ export default class TextGeneralContainer extends PureComponent {
           create={textsAPI.create}
           className="form-secondary"
         >
+          <Form.Header label="General" />
           <Form.TextInput
             label="Title"
             name="attributes[title]"

--- a/client/src/containers/backend/Text/Ingestion/New.js
+++ b/client/src/containers/backend/Text/Ingestion/New.js
@@ -52,6 +52,7 @@ export class IngestionNewContainer extends PureComponent {
           name={requests.beIngestionCreate}
           project={this.props.text.relationships.project}
           text={this.props.text}
+          header={"Reingest"}
         />
       </div>
     );

--- a/client/src/containers/backend/Text/Ingestion/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/containers/backend/Text/Ingestion/__tests__/__snapshots__/New-test.js.snap
@@ -9,6 +9,13 @@ exports[`Backend Text Ingestion New Container renders correctly 1`] = `
       onSubmit={[Function]}
     >
       <div>
+        <header
+          className="form-header"
+        >
+          <h2>
+            Reingest
+          </h2>
+        </header>
         <div
           className="form-input"
         >

--- a/client/src/containers/backend/Text/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Text/__tests__/__snapshots__/General-test.js.snap
@@ -8,6 +8,13 @@ exports[`Backend Text General Container renders correctly 1`] = `
       data-id="submit"
       onSubmit={[Function]}
     >
+      <header
+        className="form-header"
+      >
+        <h2>
+          General
+        </h2>
+      </header>
       <div
         className="form-input"
         style={Object {}}

--- a/client/src/theme/Components/global/forms/_form-inputs-secondary.scss
+++ b/client/src/theme/Components/global/forms/_form-inputs-secondary.scss
@@ -54,14 +54,12 @@
     }
   }
 
-  .form-input + .form-header,
-  .form-section + .form-header {
-    margin-top: 60px;
-  }
+  .form-header {
+    @include roundedFormHeader;
 
-  .form-header + .form-input,
-  .form-header + .form-section {
-    margin-top: 10px;
+    @include respond($break90) {
+      margin-bottom: 38px;
+    }
   }
 
   .instructions {

--- a/client/src/theme/Components/global/forms/_section.scss
+++ b/client/src/theme/Components/global/forms/_section.scss
@@ -8,17 +8,7 @@
   }
 
   .form-section-label {
-    @include roundedHeader;
-
-    span {
-      @include utilityPrimary;
-      display: table-cell;
-      width: 100%;
-      font-size: 14px;
-      font-weight: $semibold;
-      color: $accentPrimary;
-      letter-spacing: 0.1em;
-    }
+    @include roundedFormHeader;
   }
 
   .form-input-group {

--- a/client/src/theme/STACSS/_appearance.scss
+++ b/client/src/theme/STACSS/_appearance.scss
@@ -369,3 +369,17 @@
     }
   }
 }
+
+@mixin roundedFormHeader {
+  @include roundedHeader;
+
+  h2, span {
+    @include utilityPrimary;
+    display: table-cell;
+    width: 100%;
+    font-size: 14px;
+    font-weight: $semibold;
+    color: $accentPrimary;
+    letter-spacing: 0.1em;
+  }
+}


### PR DESCRIPTION
This commit adds a new header component for backend forms that currently
lack a clear heading. This better orients the user to the form they are
viewing and improves design coherence across the backend.

Resolves #1331