### PR TITLE
[B] Fix form select visibility bug in Firefox

### DIFF
--- a/client/src/theme/Components/global/forms/_form-inputs-secondary.scss
+++ b/client/src/theme/Components/global/forms/_form-inputs-secondary.scss
@@ -259,6 +259,7 @@
       text-transform: none; // OD
 
       &:focus {
+        color: $neutral40;
         border-color: $accentPrimaryLight;
       }
     }


### PR DESCRIPTION
Setting the `color` property explicitly for `:focus` state solves this
issue.

Resolves #1346