### PR TITLE
[B] API sets client URL from CLIENT_URL or DOMAIN

### DIFF
--- a/api/config/initializers/20_configuration.rb
+++ b/api/config/initializers/20_configuration.rb
@@ -3,7 +3,12 @@ m = Hashie::Mash.new(Rails.application.config_for(:manifold))
 # Load environment variables into configuration so we have a unified interface
 # for accessing configuration that can be spread across a few locations.
 
-m.url ||= "#{ENV['USE_SSL'].to_s == '1' ? 'https' : 'http'}://#{ENV['DOMAIN']}"
+m.url ||= if ENV["CLIENT_URL"]
+            (ENV["CLIENT_URL"]).to_s
+          else
+            "#{ENV['USE_SSL'].to_s == '1' ? 'https' : 'http'}://#{ENV['DOMAIN']}"
+          end
+
 m.api_url ||= ENV["API_URL"]
 m.elastic_search!.url ||= ENV["ELASTICSEARCH_URL"]
 


### PR DESCRIPTION
There’s a little ENV cleanup that needs to happen at some point. Our
Omnibus packages don't ask the user to set the domain, instead asking
for the URL of the site in /etc/manifold/manifold.rb. That setting
flows into the API environment as CLIENT_URL. In our local dev
environments and installations installed by puppet, we're setting the
DOMAIN environment variable, and building the client URL in an
initializer based on that domain and whether or not Manifodl is
configured to use SSL. This change allows the interal client URL in the
API to be set from either CLIENT_URL or DOMAIN, in the interest of
backwards compatibility. This needs to be set correctly for the
email notifications to have correct image pages.

Fixes #1381