### PR TITLE
[B] Broaden acceptable extensions for resource attachments

### DIFF
--- a/api/app/models/project.rb
+++ b/api/app/models/project.rb
@@ -134,7 +134,7 @@ class Project < ApplicationRecord
   manifold_has_attached_file :hero, :image
   manifold_has_attached_file :avatar, :image
   manifold_has_attached_file :published_text_attachment,
-                             :project_text,
+                             :resource,
                              validate_content_type: false
 
   # Scopes

--- a/api/config/manifold.yml
+++ b/api/config/manifold.yml
@@ -184,14 +184,6 @@ common: &1
           - yml
           - tex
           - latex
-      :project_text:
-        :allowed_ext:
-        - !ruby/regexp '/md\Z/i'
-        - !ruby/regexp '/epub\Z/i'
-        - !ruby/regexp '/html?\Z/i'
-        - !ruby/regexp '/docx?\Z/i'
-        - !ruby/regexp '/tex\Z/i'
-        - !ruby/regexp '/latex\Z/i'
       :image:
         :allowed_mime:
           - !ruby/regexp '/image\/.*/'
@@ -404,6 +396,8 @@ common: &1
           # PDF
           - !ruby/regexp '/pdf\Z/'
           # Misc
+          - !ruby/regexp '/tex\Z/i'
+          - !ruby/regexp '/latex\Z/i'
           - !ruby/regexp '/js\Z/i'
           - !ruby/regexp '/x?html?\Z/i'
           - !ruby/regexp '/ttf\Z/i'


### PR DESCRIPTION
Also uses the resource attachment kind to validate project published
text uploads.
Fixes #1373