### PR TITLE
[F] Expose concept of “slots” in child routes

### DIFF
--- a/client/src/containers/backend/Project/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/containers/backend/Project/__tests__/__snapshots__/General-test.js.snap
@@ -263,13 +263,13 @@ exports[`Backend Project General Container renders correctly 1`] = `
           >
             <label
               className="has-instructions"
-              htmlFor="attributes[tagList]-text-input-15"
+              htmlFor="attributes[tagList]-text-input-1"
             >
               Tags
             </label>
             <input
-              aria-describedby="attributes[tagList]-text-input-15"
-              id="attributes[tagList]-text-input-15"
+              aria-describedby="attributes[tagList]-text-input-1"
+              id="attributes[tagList]-text-input-1"
               onChange={[Function]}
               placeholder="Enter Tags"
               type="text"

--- a/client/src/helpers/router/childRoutes.js
+++ b/client/src/helpers/router/childRoutes.js
@@ -6,6 +6,7 @@ import { CSSTransitionGroup as ReactCSSTransitionGroup } from "react-transition-
 
 const renderChildRoutes = (route, renderOptions) => {
   const defaultOptions = {
+    slot: null,
     switch: true,
     childProps: {},
     drawer: false,
@@ -56,7 +57,11 @@ const renderChildRoutes = (route, renderOptions) => {
   // We can use the array index as the key here, because the order of the routes will
   // never change after the initial mount.
   if (childRoutes) {
-    mapped = childRoutes.map((childRoute, i) => {
+    const filteredChildRoutes = childRoutes.filter(childRoute => {
+      if (!options.slot && !childRoute.slot) return true;
+      return options.slot === childRoute.slot;
+    });
+    mapped = filteredChildRoutes.map((childRoute, i) => {
       const { component, ...props } = childRoute;
       return <Route key={i} {...props} render={render(childRoute)} />;
     });


### PR DESCRIPTION
This revision add the concept of "slots" to child routes, which is
useful in cases where a component wants to render some child routes
in one spot, and others in another spot. By default, a childRoutes()
call will render all child routes, as in the past. If a route has a
"slot" property, that route will only render if the childRoute options
hash has a "slot" property with a matching value. For example

```
<div>
  {childRoutes(this.props.route, { slot: "drawer", drawer: true })}
  {childRoutes(this.props.route)}
</div>
```
The first childRoutes call will render any child routes with a slot
property of "drawer". The second call will render any child routes
with a null or undefined slot property.