### PR TITLE
[C] Refactor HasMany to set relationships on model

### DIFF
--- a/client/src/components/backend/Project/Form/Subjects.js
+++ b/client/src/components/backend/Project/Form/Subjects.js
@@ -84,7 +84,7 @@ export class ProjectSubjects extends PureComponent {
         label="Subjects"
         placeholder="Add a Subject"
         onNew={this.maybeHandleNew()}
-        onChange={subjects => {
+        changeHandler={subjects => {
           this.updateSubjects(subjects);
         }}
         optionsFetch={subjectsAPI.index}

--- a/client/src/containers/backend/Form/Collaborators.js
+++ b/client/src/containers/backend/Form/Collaborators.js
@@ -89,7 +89,7 @@ export class FormCollaborators extends Component {
             onNew={value => {
               return this.newMaker(value, "creator");
             }}
-            onChange={(makers, changeType) => {
+            changeHandler={(makers, changeType) => {
               this.updateMakers(makers, changeType, "creators");
             }}
             optionsFetch={makersAPI.index}
@@ -107,7 +107,7 @@ export class FormCollaborators extends Component {
             onNew={value => {
               return this.newMaker(value, "contributor");
             }}
-            onChange={(makers, changeType) => {
+            changeHandler={(makers, changeType) => {
               this.updateMakers(makers, changeType, "contributors");
             }}
             optionsFetch={makersAPI.index}


### PR DESCRIPTION
This commit adjusts Form.HasMany to be wrapped with setter.
Along with this, HasMany will now set records to the relationships
object on a model if `name` prop is passed and `changeHandler` is
not passed.  If `changeHandler` is passed, HasMany will run the
callback function on select.

This allows the HasMany component to be used on a new
record as well as existing ones.