### PR TITLE
[B] Fix purchase price being reset on project update

### DIFF
--- a/api/app/lib/updaters/project.rb
+++ b/api/app/lib/updaters/project.rb
@@ -27,9 +27,9 @@ module Updaters
     end
 
     def purchase_price!(attributes)
-      raw = attributes[:purchase_price_money]
-      attributes.delete(:purchase_price_money)
-      price_in_cents = raw.blank? ? 0 : (raw.gsub(/[^0-9\.]/, "").to_d * 100).to_i
+      raw = attributes.delete(:purchase_price_money)
+      return if raw.nil?
+      price_in_cents = raw.blank? ? 0 : (raw.gsub(/[^0-9.]/, "").to_d * 100).to_i
       attributes[:purchase_price_in_cents] = price_in_cents
     end
   end

--- a/api/spec/requests/projects_spec.rb
+++ b/api/spec/requests/projects_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Projects API", type: :request do
   include_context("authenticated request")
   include_context("param helpers")
 
-  let(:project) { FactoryBot.create(:project, draft: false) }
+  let(:project) { FactoryBot.create(:project, draft: false, purchase_price: "10.00") }
 
   describe "responds with a list of projects" do
     before(:each) { get api_v1_projects_path, headers: reader_headers }
@@ -137,6 +137,10 @@ RSpec.describe "Projects API", type: :request do
           context "contains the updated purchase price" do
             it("when the currency sign is not present") { expect_updated_param("purchasePriceMoney", "2.50", "$2.50") }
             it("when the currency sign is present") { expect_updated_param("purchasePriceMoney", "$2.50", "$2.50") }
+            it("when the purchase price is empty") { expect_updated_param("purchasePriceMoney", "", 0.0, "purchasePrice") }
+          end
+          context "does not update the purchase price" do
+            it("when the price is not included in params") { expect_updated_param("purchasePriceMoney", nil, 10.0, "purchasePrice") }
           end
         end
 


### PR DESCRIPTION
If `attributes[:purchase_price_money]` is `nil`, it wasn't included in params and we don't want to touch the field.  If it's `""` or true for any other `blank?` check, we should reset it.

Fixes #1424