### PR TITLE
[B] Improve CSV parsing during bulk resource import

### DIFF
--- a/api/spec/data/resource_import/utf-8.csv
+++ b/api/spec/data/resource_import/utf-8.csv
@@ -1,0 +1,2 @@
+﻿Header 1,Header 2
+regular value,value ‘with’ curly “quotes”

--- a/api/spec/services/resource_imports/parse_csv_spec.rb
+++ b/api/spec/services/resource_imports/parse_csv_spec.rb
@@ -1,12 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe ResourceImports::ParseCSV do
-  let(:path) { fixture_file_upload(Rails.root.join('spec', 'data','resource_import','invalid_encoding.csv'), 'text/csv') }
-  let(:import) { FactoryBot.create(:resource_import_csv, data: path) }
-
   it "can handle non-valid UTF-8 charsets" do
+    path = fixture_file_upload(Rails.root.join('spec', 'data','resource_import','invalid_encoding.csv'), 'text/csv')
+    import = FactoryBot.create(:resource_import_csv, data: path)
+
     expect do
       ResourceImports::ParseCSV.run resource_import: import
     end.to_not raise_error
+  end
+
+  context "when utf-8 encoded sheet" do
+    let(:path) { fixture_file_upload(Rails.root.join('spec', 'data','resource_import','utf-8.csv'), 'text/csv') }
+    let(:import) { FactoryBot.create(:resource_import_csv, data: path) }
+
+    before(:each) do
+      ResourceImports::ParseCSV.run resource_import: import
+    end
+
+    it "parses and maintains the correct characters" do
+      expected = [["Header 1", "Header 2"], ["regular value",  "value ‘with’ curly “quotes”"]]
+      expect(ResourceImportRow.pluck(:values)).to eq expected
+    end
   end
 end


### PR DESCRIPTION
This issue is sort of a few levels deep.

The solution to the issue that Terence opened is to export the csv as a UTF-8 formatted csv, which preserves the curly quotes.  Whatever encoding Excel exports the regular csv type in (ISO-something) results in those curly characters being misinterpreted by ruby's `File.read`.  As far as I can tell, this is the only way to make sure the curly quotes stay as curly quotes as `File.read` does not intereprete them as something we could reliable catch and switch back.

I then found that the first row, the one with the instructions, in Terence's file was causing an error when exported as UTF-8 csv.  Despite its output looking correct, trying to parse it with `CSV.parse` would throw `CSV::MalformedCSVError: Illegal quoting in line 1.`.  His file parses correctly without that first line though.  

This seems to be an Excel specific issue, as it seems to be adding _something_ to the first character that causes `CSV.parse` to break, though I'm not sure why Terence's file fails to even parse.  A diff comparison of the output from a Excel UTF-8 csv and a Numbers csv shows no difference, but checking with the Differ gem _does_ indicate that while looking the same, the opening `"` mark is different.  I replicated this failure in our existing behavior with a test:

```
expected: [["Header 1", "Header 2"], ["regular value", "Churchwardens’ account of St Edmund’s parish, Salisbury (1491-2)"]]
     got: [["﻿Header 1", "Header 2"], ["regular value", "Churchwardens’ account of St Edmund’s parish, Salisbury (1491-2)"]]
```

I've implemented functionality that fixes the parsing issues and make the `ParseCSV` class a little more resilient.  I'm still not sure what exactly in that first row was causing problems, but when the file is already UTF-8 having `CSV` read the file with the encoding directly, instead of parsing the `File.read` output, works and accepts the file in question without modification.  


Fixes #1438