### PR TITLE
[B] HasMany should not require entities prop

### DIFF
--- a/client/src/components/backend/Form/HasMany.js
+++ b/client/src/components/backend/Form/HasMany.js
@@ -21,7 +21,7 @@ export class FormHasMany extends PureComponent {
     editClickHandler: PropTypes.func,
     fetch: PropTypes.func.isRequired,
     fetchOptions: PropTypes.object,
-    entities: PropTypes.array.isRequired,
+    entities: PropTypes.array,
     entityLabelAttribute: PropTypes.string.isRequired,
     entityAvatarAttribute: PropTypes.string,
     placeholder: PropTypes.string,


### PR DESCRIPTION
Since the entities for a HasMany list can now come from a
form model's attributes in addition to a model record, this
prop is empty when the value is set by setter.  As a result,
we should no longer require the entities prop to be present.