### PR TITLE
[B] Catch and ignore URI.parse errors in reader

### DIFF
--- a/client/src/components/reader/Section/BodyNodes/LinkNode.js
+++ b/client/src/components/reader/Section/BodyNodes/LinkNode.js
@@ -19,7 +19,12 @@ class LinkNode extends Component {
     if (!this.hasUri()) {
       return false;
     }
-    return URI.parse(this.props.attributes.href).protocol;
+
+    try {
+      return URI.parse(this.props.attributes.href).protocol;
+    } catch (e) {
+      return true;
+    }
   }
 
   adjustedAttributes() {


### PR DESCRIPTION
If a URL fails to parse (most common occurrence would be an
outdated DOI link format), we will now just render the url as
an absolute, external URL.
Fixes #1476