### PR TITLE
[B] Fix document ingestion TOC nesting

### DIFF
--- a/api/app/services/ingestions/strategy/document/toc.rb
+++ b/api/app/services/ingestions/strategy/document/toc.rb
@@ -31,10 +31,16 @@ module Ingestions
           memo = []
           entries = []
           current_depth = 0
+          last_entry_depth = nil
+          last_unadjusted_entry_depth = nil
           headers.each do |header|
             entry_depth = header_tag_depth(header.name)
+            unadjusted_entry_depth = entry_depth
             entry = entry_for_header(header)
             entry_depth = (current_depth + 1) if entry_depth > current_depth
+            entry_depth = current_depth if
+              unadjusted_entry_depth == last_unadjusted_entry_depth
+            entry_depth = 0 if last_entry_depth.nil?
             parent_depth = entry_depth - 1
             collection = if parent_depth != -1 && memo[parent_depth]
                            memo[parent_depth][:children]
@@ -44,6 +50,8 @@ module Ingestions
             collection << entry
             memo[entry_depth] = entry
             current_depth = entry_depth
+            last_entry_depth = entry_depth
+            last_unadjusted_entry_depth = unadjusted_entry_depth
           end
           entries
         end

--- a/api/spec/services/ingestions/strategy/document/toc_spec.rb
+++ b/api/spec/services/ingestions/strategy/document/toc_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe Ingestions::Strategy::Document::TOC do
+  context "when headers are sequentially ordered" do
+    let(:toc) do
+      <<~HEREDOC
+        <html>
+          <body>
+            <h1>A</h1>
+            <h2>A/1</h2>
+            <h3>A/1/a</h3>
+            <h4>A/1/a/i</h4>
+            <h2>A/2</h2>
+            <h3>A/2/a</h3>
+          </body>
+        </html>
+      HEREDOC
+    end
+
+    let(:inspector) do
+      mock_inspector = double(context: {}, index_parsed_uncached: Nokogiri::HTML(toc), index_source_path: nil)
+      described_class.new mock_inspector
+    end
+
+    it "correctly generates a toc structure" do
+      expected =  [{:label=>"A", :anchor=>nil, :source_path=>nil, :children=>[
+                      {:label=>"A/1", :anchor=>nil, :source_path=>nil, :children=>[
+                        {:label=>"A/1/a",:anchor=>nil,:source_path=>nil, :children=>[
+                          {:label=>"A/1/a/i",:anchor=>nil,:source_path=>nil, :children=>[]}
+                        ]}
+                      ]},
+                      {:label=>"A/2",:anchor=>nil,:source_path=>nil, :children=>[
+                        {:label=>"A/2/a", :anchor=>nil, :source_path=>nil, :children=>[]}
+                      ]}
+                    ]}
+                   ]
+      expect(inspector.toc).to eq expected
+    end
+  end
+
+  context "when headers are not sequentially ordered" do
+    let(:toc) do
+      <<~HEREDOC
+        <html>
+          <body>
+            <h2>A</h2>
+            <h1>B</h1>
+            <h3>B/1</h3>
+            <h4>B/1/a</h4>
+            <h4>B/1/b</h4>
+            <h3>B/1/c</h3>
+            <h1>C</h1>
+            <h2>C/1</h2>
+            <h3>C/1/a</h3>
+          </body>
+        </html>
+      HEREDOC
+    end
+
+    let(:inspector) do
+      mock_inspector = double(context: {}, index_parsed_uncached: Nokogiri::HTML(toc), index_source_path: nil)
+      described_class.new mock_inspector
+    end
+
+    it "correctly generates a toc structure" do
+      expected = [{:label=>"A", :anchor=>nil, :source_path=>nil, :children=>[]},
+                  {:label=>"B", :anchor=>nil, :source_path=>nil, :children=>[
+                    {:label=>"B/1", :anchor=>nil, :source_path=>nil, :children=>[
+                      {:label=>"B/1/a",:anchor=>nil,:source_path=>nil, :children=>[]},
+                      {:label=>"B/1/b", :anchor=>nil, :source_path=>nil, :children=>[]},
+                      {:label=>"B/1/c",:anchor=>nil,:source_path=>nil, :children=>[]}
+
+                    ]},
+                  ]},
+                  {:label=>"C", :anchor=>nil, :source_path=>nil, :children=>[
+                    {:label=>"C/1",:anchor=>nil,:source_path=>nil, :children=>[
+                      :label=>"C/1/a",:anchor=>nil,:source_path=>nil, :children=>[]
+                    ]}
+                  ]}]
+      actual = inspector.toc
+      expect(actual).to eq expected
+    end
+  end
+end


### PR DESCRIPTION
Improves TOC structure to support cases where headers aren't
consecutive. This commit gets us a little closer to handling
improperly nested headers, although the best way to ensure
good TOC rendering is to keep all headers properly nested.

Fixes #1471