### PR TITLE
[B] Address regression when navigating between notes

### DIFF
--- a/client/src/components/reader/Notation/Marker.js
+++ b/client/src/components/reader/Notation/Marker.js
@@ -50,7 +50,7 @@ class NotationMarker extends Component {
         );
       }
       const url = `${base}/${rel}`;
-      this.props.history.push(url);
+      this.props.history.push(url, { noScroll: true });
     } else {
       this.setActiveAnnotation(annotation.id);
     }

--- a/client/src/components/reader/Notation/Viewer/Link.js
+++ b/client/src/components/reader/Notation/Viewer/Link.js
@@ -32,7 +32,10 @@ class NotationViewerLink extends PureComponent {
 
     if (url) {
       return (
-        <Link className={className} to={url}>
+        <Link
+          className={className}
+          to={{ pathname: url, state: { noScroll: true } }}
+        >
           {children}
         </Link>
       );

--- a/client/src/components/reader/Notation/Viewer/__tests__/__snapshots__/Group-test.js.snap
+++ b/client/src/components/reader/Notation/Viewer/__tests__/__snapshots__/Group-test.js.snap
@@ -24,7 +24,7 @@ exports[`Reader.Notation.Viewer.Group component renders correctly 1`] = `
                           </AuthorizeComponent>
                         </Connect(AuthorizeComponent)>
                         <NotationViewerLink notation={{...}} params={{...}} className=\\"notation-single-link\\">
-                          <Link className=\\"notation-single-link\\" to=\\"/read/5/section/6/resource/2\\" replace={false}>
+                          <Link className=\\"notation-single-link\\" to={{...}} replace={false}>
                             <a className=\\"notation-single-link\\" onClick={[Function]} href=\\"/read/5/section/6/resource/2\\">
                               <div style={{...}} onMouseOver={[Function: onMouseOver]} onMouseLeave={[Function: onMouseLeave]}>
                                 <NotationViewer.Notation notation={{...}} additionalClasses=\\"minimal right\\" showTitle={false} neverCrop={false}>
@@ -62,7 +62,7 @@ exports[`Reader.Notation.Viewer.Group component renders correctly 1`] = `
               <div onMouseOver={[Function: onMouseOver]} onMouseLeave={[Function: onMouseLeave]}>
                 <div className=\\"group-thumbnail\\">
                   <NotationViewerLink params={{...}} notation={{...}}>
-                    <Link className={[undefined]} to=\\"/read/5/section/6/resource/2\\" replace={false}>
+                    <Link className={[undefined]} to={{...}} replace={false}>
                       <a className={[undefined]} onClick={[Function]} href=\\"/read/5/section/6/resource/2\\">
                         <NotationViewer.Notation notation={{...}} additionalClasses=\\"minimal preview\\" showTitle={false} neverCrop={true}>
                           <Resourceish.Thumbnail resourceish={{...}} showKind={false} noCrop={false} showTitle={false} variant=\\"smallLandscape\\" additionalClasses=\\"minimal preview\\">
@@ -93,7 +93,7 @@ exports[`Reader.Notation.Viewer.Group component renders correctly 1`] = `
               <div onMouseOver={[Function: onMouseOver]} onMouseLeave={[Function: onMouseLeave]}>
                 <div className=\\"group-thumbnail\\">
                   <NotationViewerLink params={{...}} notation={{...}}>
-                    <Link className={[undefined]} to=\\"/read/5/section/6/resource/4\\" replace={false}>
+                    <Link className={[undefined]} to={{...}} replace={false}>
                       <a className={[undefined]} onClick={[Function]} href=\\"/read/5/section/6/resource/4\\">
                         <NotationViewer.Notation notation={{...}} additionalClasses=\\"minimal preview\\" showTitle={false} neverCrop={true}>
                           <Resourceish.Thumbnail resourceish={{...}} showKind={false} noCrop={false} showTitle={false} variant=\\"smallLandscape\\" additionalClasses=\\"minimal preview\\">
@@ -123,7 +123,7 @@ exports[`Reader.Notation.Viewer.Group component renders correctly 1`] = `
           </ul>
           <h4 onMouseOver={[Function: onMouseOver]} onMouseLeave={[Function: onMouseLeave]} className=\\"group-active-title\\">
             <NotationViewerLink params={{...}} notation={{...}}>
-              <Link className={[undefined]} to=\\"/read/5/section/6/resource/2\\" replace={false}>
+              <Link className={[undefined]} to={{...}} replace={false}>
                 <a className={[undefined]} onClick={[Function]} href=\\"/read/5/section/6/resource/2\\">
                   <span dangerouslySetInnerHTML={{...}} />
                 </a>

--- a/client/src/containers/reader/Notation/Resource/Detail.js
+++ b/client/src/containers/reader/Notation/Resource/Detail.js
@@ -46,7 +46,9 @@ export class NotationResourceDetailContainer extends PureComponent {
   handleClose = event => {
     if (event) event.preventDefault();
     const { textId, sectionId } = this.props.match.params;
-    this.props.history.push(lh.link("readerSection", textId, sectionId));
+    this.props.history.push(lh.link("readerSection", textId, sectionId), {
+      noScroll: true
+    });
   };
 
   render() {


### PR DESCRIPTION
This commit moves annotation filtering into getDerivedStateFromProps
while continuing to check if there's an invalid annotation in the URL
after the component has updated. Prior to this change, the check was
happening before the annotations for a new text section were filtered
and stored in state, which cause the annotation hash to be stripped
every time.

Fixes #823