### PR TITLE
[B] Improve appearance of project cover button

### DIFF
--- a/client/src/components/backend/ProjectCollection/__tests__/__snapshots__/AddButton-test.js.snap
+++ b/client/src/components/backend/ProjectCollection/__tests__/__snapshots__/AddButton-test.js.snap
@@ -23,15 +23,60 @@ exports[`Backend.ProjectCollection.AddButton component renders correctly 1`] = `
       <div
         className="icons"
       >
-        <i
-          className="manicon manicon-minus-bold"
-        />
-        <i
-          className="manicon manicon-check-bold"
-        />
-        <i
-          className="manicon manicon-plus-bold"
-        />
+        <svg
+          aria-hidden="true"
+          className="manicon-svg minus"
+          fill="currentColor"
+          height={28}
+          stroke={undefined}
+          viewBox="0 0 32 32"
+          width={28}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            height="2"
+            width="14"
+            x="9"
+            y="15"
+          />
+        </svg>
+        <svg
+          aria-hidden="true"
+          className="manicon-svg check"
+          fill="currentColor"
+          height={28}
+          stroke={undefined}
+          viewBox="0 0 32 32"
+          width={28}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polygon
+            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+          />
+        </svg>
+        <svg
+          aria-hidden="true"
+          className="manicon-svg plus"
+          fill="currentColor"
+          height={28}
+          stroke={undefined}
+          viewBox="0 0 32 32"
+          width={28}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            height="2"
+            width="14"
+            x="9"
+            y="15"
+          />
+          <rect
+            height="14"
+            width="2"
+            x="15"
+            y="9"
+          />
+        </svg>
       </div>
       <span>
         <span

--- a/client/src/components/backend/ProjectCollection/__tests__/__snapshots__/ProjectCover-test.js.snap
+++ b/client/src/components/backend/ProjectCollection/__tests__/__snapshots__/ProjectCover-test.js.snap
@@ -29,15 +29,60 @@ exports[`Backend.ProjectCollection.ProjectCover component renders correctly 1`] 
           <div
             className="icons"
           >
-            <i
-              className="manicon manicon-minus-bold"
-            />
-            <i
-              className="manicon manicon-check-bold"
-            />
-            <i
-              className="manicon manicon-plus-bold"
-            />
+            <svg
+              aria-hidden="true"
+              className="manicon-svg minus"
+              fill="currentColor"
+              height={28}
+              stroke={undefined}
+              viewBox="0 0 32 32"
+              width={28}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect
+                height="2"
+                width="14"
+                x="9"
+                y="15"
+              />
+            </svg>
+            <svg
+              aria-hidden="true"
+              className="manicon-svg check"
+              fill="currentColor"
+              height={28}
+              stroke={undefined}
+              viewBox="0 0 32 32"
+              width={28}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+              />
+            </svg>
+            <svg
+              aria-hidden="true"
+              className="manicon-svg plus"
+              fill="currentColor"
+              height={28}
+              stroke={undefined}
+              viewBox="0 0 32 32"
+              width={28}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect
+                height="2"
+                width="14"
+                x="9"
+                y="15"
+              />
+              <rect
+                height="14"
+                width="2"
+                x="15"
+                y="9"
+              />
+            </svg>
           </div>
           <span>
             <span

--- a/client/src/components/frontend/Project/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/components/frontend/Project/__tests__/__snapshots__/Following-test.js.snap
@@ -23,15 +23,60 @@ exports[`Frontend.Project.Follow component renders correctly 1`] = `
       <div
         className="icons"
       >
-        <i
-          className="manicon manicon-minus-bold"
-        />
-        <i
-          className="manicon manicon-check-bold"
-        />
-        <i
-          className="manicon manicon-plus-bold"
-        />
+        <svg
+          aria-hidden="true"
+          className="manicon-svg minus"
+          fill="currentColor"
+          height={28}
+          stroke={undefined}
+          viewBox="0 0 32 32"
+          width={28}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            height="2"
+            width="14"
+            x="9"
+            y="15"
+          />
+        </svg>
+        <svg
+          aria-hidden="true"
+          className="manicon-svg check"
+          fill="currentColor"
+          height={28}
+          stroke={undefined}
+          viewBox="0 0 32 32"
+          width={28}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polygon
+            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+          />
+        </svg>
+        <svg
+          aria-hidden="true"
+          className="manicon-svg plus"
+          fill="currentColor"
+          height={28}
+          stroke={undefined}
+          viewBox="0 0 32 32"
+          width={28}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            height="2"
+            width="14"
+            x="9"
+            y="15"
+          />
+          <rect
+            height="14"
+            width="2"
+            x="15"
+            y="9"
+          />
+        </svg>
       </div>
       <span>
         <span

--- a/client/src/components/frontend/Project/__tests__/__snapshots__/Thumbnail-test.js.snap
+++ b/client/src/components/frontend/Project/__tests__/__snapshots__/Thumbnail-test.js.snap
@@ -30,15 +30,60 @@ exports[`Frontend.Project.Thumbnail component renders correctly 1`] = `
           <div
             className="icons"
           >
-            <i
-              className="manicon manicon-minus-bold"
-            />
-            <i
-              className="manicon manicon-check-bold"
-            />
-            <i
-              className="manicon manicon-plus-bold"
-            />
+            <svg
+              aria-hidden="true"
+              className="manicon-svg minus"
+              fill="currentColor"
+              height={28}
+              stroke={undefined}
+              viewBox="0 0 32 32"
+              width={28}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect
+                height="2"
+                width="14"
+                x="9"
+                y="15"
+              />
+            </svg>
+            <svg
+              aria-hidden="true"
+              className="manicon-svg check"
+              fill="currentColor"
+              height={28}
+              stroke={undefined}
+              viewBox="0 0 32 32"
+              width={28}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+              />
+            </svg>
+            <svg
+              aria-hidden="true"
+              className="manicon-svg plus"
+              fill="currentColor"
+              height={28}
+              stroke={undefined}
+              viewBox="0 0 32 32"
+              width={28}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect
+                height="2"
+                width="14"
+                x="9"
+                y="15"
+              />
+              <rect
+                height="14"
+                width="2"
+                x="15"
+                y="9"
+              />
+            </svg>
           </div>
           <span>
             <span

--- a/client/src/components/frontend/ProjectList/__tests__/__snapshots__/Grid-test.js.snap
+++ b/client/src/components/frontend/ProjectList/__tests__/__snapshots__/Grid-test.js.snap
@@ -35,15 +35,60 @@ exports[`Frontend.ProjectList.Grid component renders correctly 1`] = `
                 <div
                   className="icons"
                 >
-                  <i
-                    className="manicon manicon-minus-bold"
-                  />
-                  <i
-                    className="manicon manicon-check-bold"
-                  />
-                  <i
-                    className="manicon manicon-plus-bold"
-                  />
+                  <svg
+                    aria-hidden="true"
+                    className="manicon-svg minus"
+                    fill="currentColor"
+                    height={28}
+                    stroke={undefined}
+                    viewBox="0 0 32 32"
+                    width={28}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect
+                      height="2"
+                      width="14"
+                      x="9"
+                      y="15"
+                    />
+                  </svg>
+                  <svg
+                    aria-hidden="true"
+                    className="manicon-svg check"
+                    fill="currentColor"
+                    height={28}
+                    stroke={undefined}
+                    viewBox="0 0 32 32"
+                    width={28}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <polygon
+                      points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                    />
+                  </svg>
+                  <svg
+                    aria-hidden="true"
+                    className="manicon-svg plus"
+                    fill="currentColor"
+                    height={28}
+                    stroke={undefined}
+                    viewBox="0 0 32 32"
+                    width={28}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect
+                      height="2"
+                      width="14"
+                      x="9"
+                      y="15"
+                    />
+                    <rect
+                      height="14"
+                      width="2"
+                      x="15"
+                      y="9"
+                    />
+                  </svg>
                 </div>
                 <span>
                   <span

--- a/client/src/components/global/Project/CoverButton.js
+++ b/client/src/components/global/Project/CoverButton.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import startsWith from "lodash/startsWith";
 import classNames from "classnames";
 import { CSSTransitionGroup as ReactCSSTransitionGroup } from "react-transition-group";
+import { Icon } from "components/global/SVG";
 
 export default class CoverButton extends Component {
   static displayName = "Project.CoverButton";
@@ -166,11 +167,10 @@ export default class CoverButton extends Component {
         >
           <div className="project-cover-button" aria-hidden="true">
             <div className="icons">
-              <i key="minus" className="manicon manicon-minus-bold" />
-              <i key="check" className="manicon manicon-check-bold" />
-              <i key="plus" className="manicon manicon-plus-bold" />
+              <Icon.Minus size={28} iconClass="minus" />
+              <Icon.Check size={28} iconClass="check" />
+              <Icon.Plus size={28} iconClass="plus" />
             </div>
-
             <ReactCSSTransitionGroup
               transitionName="button"
               transitionEnterTimeout={300}

--- a/client/src/components/global/SVG/Icon/Check.js
+++ b/client/src/components/global/SVG/Icon/Check.js
@@ -1,0 +1,39 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import classnames from "classnames";
+
+export default class IconCheck extends Component {
+  static displayName = "Icon.Check";
+
+  static propTypes = {
+    iconClass: PropTypes.string,
+    size: PropTypes.number,
+    fill: PropTypes.string,
+    stroke: PropTypes.string
+  };
+
+  static defaultProps = {
+    size: 32,
+    fill: "currentColor"
+  };
+
+  render() {
+    const { iconClass, size, fill, stroke } = this.props;
+    const classes = classnames("manicon-svg", iconClass);
+
+    return (
+      <svg
+        className={classes}
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        fill={fill}
+        stroke={stroke}
+        viewBox="0 0 32 32"
+        aria-hidden="true"
+      >
+        <polygon points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462" />
+      </svg>
+    );
+  }
+}

--- a/client/src/components/global/SVG/Icon/Minus.js
+++ b/client/src/components/global/SVG/Icon/Minus.js
@@ -1,0 +1,39 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import classnames from "classnames";
+
+export default class IconMinus extends Component {
+  static displayName = "Icon.Minus";
+
+  static propTypes = {
+    iconClass: PropTypes.string,
+    size: PropTypes.number,
+    fill: PropTypes.string,
+    stroke: PropTypes.string
+  };
+
+  static defaultProps = {
+    size: 32,
+    fill: "currentColor"
+  };
+
+  render() {
+    const { iconClass, size, fill, stroke } = this.props;
+    const classes = classnames("manicon-svg", iconClass);
+
+    return (
+      <svg
+        className={classes}
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        fill={fill}
+        stroke={stroke}
+        viewBox="0 0 32 32"
+        aria-hidden="true"
+      >
+        <rect x="9" y="15" width="14" height="2" />
+      </svg>
+    );
+  }
+}

--- a/client/src/components/global/SVG/Icon/Plus.js
+++ b/client/src/components/global/SVG/Icon/Plus.js
@@ -1,0 +1,40 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import classnames from "classnames";
+
+export default class IconPlus extends Component {
+  static displayName = "Icon.Plus";
+
+  static propTypes = {
+    iconClass: PropTypes.string,
+    size: PropTypes.number,
+    fill: PropTypes.string,
+    stroke: PropTypes.string
+  };
+
+  static defaultProps = {
+    size: 32,
+    fill: "currentColor"
+  };
+
+  render() {
+    const { iconClass, size, fill, stroke } = this.props;
+    const classes = classnames("manicon-svg", iconClass);
+
+    return (
+      <svg
+        className={classes}
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        fill={fill}
+        stroke={stroke}
+        viewBox="0 0 32 32"
+        aria-hidden="true"
+      >
+        <rect x="9" y="15" width="14" height="2" />
+        <rect x="15" y="9" width="2" height="14" />
+      </svg>
+    );
+  }
+}

--- a/client/src/components/global/SVG/Icon/index.js
+++ b/client/src/components/global/SVG/Icon/index.js
@@ -3,12 +3,15 @@ import BooksOnShelf from "./BooksOnShelf";
 import BooksOnShelfStroke from "./BooksOnShelfStroke";
 import BookStackVertical from "./BookStackVertical";
 import BooksWithGlasses from "./BooksWithGlasses";
+import Check from "./Check";
 import EyeClosed from "./EyeClosed";
 import EyeOpen from "./EyeOpen";
 import Globe from "./Globe";
 import Lamp from "./Lamp";
+import Minus from "./Minus";
 import Mug from "./Mug";
 import NewRound from "./NewRound";
+import Plus from "./Plus";
 import ResourceAudio from "./ResourceAudio";
 import ResourceCollection from "./ResourceCollection";
 import ResourceDocument from "./ResourceDocument";
@@ -28,12 +31,15 @@ export default {
   BooksOnShelfStroke,
   BookStackVertical,
   BooksWithGlasses,
+  Check,
   EyeClosed,
   EyeOpen,
   Globe,
   Lamp,
+  Minus,
   Mug,
   NewRound,
+  Plus,
   ResourceAudio,
   ResourceCollection,
   ResourceDocument,

--- a/client/src/containers/backend/ProjectCollection/__tests__/__snapshots__/ManageProjects-test.js.snap
+++ b/client/src/containers/backend/ProjectCollection/__tests__/__snapshots__/ManageProjects-test.js.snap
@@ -114,15 +114,60 @@ Array [
                         <div
                           className="icons"
                         >
-                          <i
-                            className="manicon manicon-minus-bold"
-                          />
-                          <i
-                            className="manicon manicon-check-bold"
-                          />
-                          <i
-                            className="manicon manicon-plus-bold"
-                          />
+                          <svg
+                            aria-hidden="true"
+                            className="manicon-svg minus"
+                            fill="currentColor"
+                            height={28}
+                            stroke={undefined}
+                            viewBox="0 0 32 32"
+                            width={28}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="14"
+                              x="9"
+                              y="15"
+                            />
+                          </svg>
+                          <svg
+                            aria-hidden="true"
+                            className="manicon-svg check"
+                            fill="currentColor"
+                            height={28}
+                            stroke={undefined}
+                            viewBox="0 0 32 32"
+                            width={28}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <polygon
+                              points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                            />
+                          </svg>
+                          <svg
+                            aria-hidden="true"
+                            className="manicon-svg plus"
+                            fill="currentColor"
+                            height={28}
+                            stroke={undefined}
+                            viewBox="0 0 32 32"
+                            width={28}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="14"
+                              x="9"
+                              y="15"
+                            />
+                            <rect
+                              height="14"
+                              width="2"
+                              x="15"
+                              y="9"
+                            />
+                          </svg>
                         </div>
                         <span>
                           <span
@@ -179,15 +224,60 @@ Array [
                         <div
                           className="icons"
                         >
-                          <i
-                            className="manicon manicon-minus-bold"
-                          />
-                          <i
-                            className="manicon manicon-check-bold"
-                          />
-                          <i
-                            className="manicon manicon-plus-bold"
-                          />
+                          <svg
+                            aria-hidden="true"
+                            className="manicon-svg minus"
+                            fill="currentColor"
+                            height={28}
+                            stroke={undefined}
+                            viewBox="0 0 32 32"
+                            width={28}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="14"
+                              x="9"
+                              y="15"
+                            />
+                          </svg>
+                          <svg
+                            aria-hidden="true"
+                            className="manicon-svg check"
+                            fill="currentColor"
+                            height={28}
+                            stroke={undefined}
+                            viewBox="0 0 32 32"
+                            width={28}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <polygon
+                              points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                            />
+                          </svg>
+                          <svg
+                            aria-hidden="true"
+                            className="manicon-svg plus"
+                            fill="currentColor"
+                            height={28}
+                            stroke={undefined}
+                            viewBox="0 0 32 32"
+                            width={28}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="14"
+                              x="9"
+                              y="15"
+                            />
+                            <rect
+                              height="14"
+                              width="2"
+                              x="15"
+                              y="9"
+                            />
+                          </svg>
                         </div>
                         <span>
                           <span

--- a/client/src/containers/frontend/__tests__/__snapshots__/Featured-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/Featured-test.js.snap
@@ -147,15 +147,60 @@ exports[`Frontend Featured Container renders correctly 1`] = `
                       <div
                         className="icons"
                       >
-                        <i
-                          className="manicon manicon-minus-bold"
-                        />
-                        <i
-                          className="manicon manicon-check-bold"
-                        />
-                        <i
-                          className="manicon manicon-plus-bold"
-                        />
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg minus"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            height="2"
+                            width="14"
+                            x="9"
+                            y="15"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg check"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg plus"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            height="2"
+                            width="14"
+                            x="9"
+                            y="15"
+                          />
+                          <rect
+                            height="14"
+                            width="2"
+                            x="15"
+                            y="9"
+                          />
+                        </svg>
                       </div>
                       <span>
                         <span
@@ -213,15 +258,60 @@ exports[`Frontend Featured Container renders correctly 1`] = `
                       <div
                         className="icons"
                       >
-                        <i
-                          className="manicon manicon-minus-bold"
-                        />
-                        <i
-                          className="manicon manicon-check-bold"
-                        />
-                        <i
-                          className="manicon manicon-plus-bold"
-                        />
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg minus"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            height="2"
+                            width="14"
+                            x="9"
+                            y="15"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg check"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg plus"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            height="2"
+                            width="14"
+                            x="9"
+                            y="15"
+                          />
+                          <rect
+                            height="14"
+                            width="2"
+                            x="15"
+                            y="9"
+                          />
+                        </svg>
                       </div>
                       <span>
                         <span

--- a/client/src/containers/frontend/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/containers/frontend/__tests__/__snapshots__/Following-test.js.snap
@@ -175,15 +175,60 @@ exports[`Frontend Following Container renders correctly 1`] = `
                       <div
                         className="icons"
                       >
-                        <i
-                          className="manicon manicon-minus-bold"
-                        />
-                        <i
-                          className="manicon manicon-check-bold"
-                        />
-                        <i
-                          className="manicon manicon-plus-bold"
-                        />
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg minus"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            height="2"
+                            width="14"
+                            x="9"
+                            y="15"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg check"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg plus"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            height="2"
+                            width="14"
+                            x="9"
+                            y="15"
+                          />
+                          <rect
+                            height="14"
+                            width="2"
+                            x="15"
+                            y="9"
+                          />
+                        </svg>
                       </div>
                       <span>
                         <span
@@ -241,15 +286,60 @@ exports[`Frontend Following Container renders correctly 1`] = `
                       <div
                         className="icons"
                       >
-                        <i
-                          className="manicon manicon-minus-bold"
-                        />
-                        <i
-                          className="manicon manicon-check-bold"
-                        />
-                        <i
-                          className="manicon manicon-plus-bold"
-                        />
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg minus"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            height="2"
+                            width="14"
+                            x="9"
+                            y="15"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg check"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg plus"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            height="2"
+                            width="14"
+                            x="9"
+                            y="15"
+                          />
+                          <rect
+                            height="14"
+                            width="2"
+                            x="15"
+                            y="9"
+                          />
+                        </svg>
                       </div>
                       <span>
                         <span
@@ -355,15 +445,60 @@ exports[`Frontend Following Container renders correctly 1`] = `
                       <div
                         className="icons"
                       >
-                        <i
-                          className="manicon manicon-minus-bold"
-                        />
-                        <i
-                          className="manicon manicon-check-bold"
-                        />
-                        <i
-                          className="manicon manicon-plus-bold"
-                        />
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg minus"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            height="2"
+                            width="14"
+                            x="9"
+                            y="15"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg check"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg plus"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            height="2"
+                            width="14"
+                            x="9"
+                            y="15"
+                          />
+                          <rect
+                            height="14"
+                            width="2"
+                            x="15"
+                            y="9"
+                          />
+                        </svg>
                       </div>
                       <span>
                         <span
@@ -421,15 +556,60 @@ exports[`Frontend Following Container renders correctly 1`] = `
                       <div
                         className="icons"
                       >
-                        <i
-                          className="manicon manicon-minus-bold"
-                        />
-                        <i
-                          className="manicon manicon-check-bold"
-                        />
-                        <i
-                          className="manicon manicon-plus-bold"
-                        />
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg minus"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            height="2"
+                            width="14"
+                            x="9"
+                            y="15"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg check"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          className="manicon-svg plus"
+                          fill="currentColor"
+                          height={28}
+                          stroke={undefined}
+                          viewBox="0 0 32 32"
+                          width={28}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            height="2"
+                            width="14"
+                            x="9"
+                            y="15"
+                          />
+                          <rect
+                            height="14"
+                            width="2"
+                            x="15"
+                            y="9"
+                          />
+                        </svg>
                       </div>
                       <span>
                         <span

--- a/client/src/theme/Components/backend/_project-list.scss
+++ b/client/src/theme/Components/backend/_project-list.scss
@@ -53,7 +53,7 @@
             height: 120px;
 
             // stylelint-disable max-nesting-depth
-            svg {
+            > svg {
               max-width: 100px;
               max-height: 110px;
             }

--- a/client/src/theme/Components/browse/project-list/_project-grid.scss
+++ b/client/src/theme/Components/browse/project-list/_project-grid.scss
@@ -51,7 +51,15 @@
 
     // Frontend grid-style list
     &.grid {
+      li {
+        padding-left: 14px;
+      }
+
       @include respond($break75) {
+        li {
+          padding-left: 0;
+        }
+
         a:hover, a:focus {
           background-color: $neutral05;
           box-shadow: 0 31px 44px 2px rgba($neutralBlack, 0.13);
@@ -64,7 +72,7 @@
         .cover {
           height: 160px;
 
-          svg {
+          > svg {
             max-width: 130px;
             max-height: 130px;
           }

--- a/client/src/theme/Components/global/_buttons.scss
+++ b/client/src/theme/Components/global/_buttons.scss
@@ -755,8 +755,13 @@
   position: absolute;
   top: 10.526%;
   left: -15px;
-  width: 40px;
-  height: 35px;
+  width: 28px;
+  height: 28px;
+
+  @include respond($break75) {
+    width: 30px;
+    height: 30px;
+  }
 
   &.active {
     width: 100%;
@@ -768,11 +773,10 @@
   position: absolute;
   left: 0;
   display: block;
-  max-width: 30px;
-  height: 30px;
-  padding: 5px 13px 0 8px;
+  max-width: 100%;
+  height: 100%;
   overflow: hidden;
-  font-size: 18px;
+  font-size: 16px;
   color: $neutralWhite;
   text-align: left;
   white-space: nowrap;
@@ -783,12 +787,24 @@
   transition: max-width $duration $timing,
     background-color $duration $timing;
 
+  @include respond($break75) {
+    font-size: 18px;
+  }
+
   .remove & {
     background-color: $sp20Primary;
   }
 
   .action-text {
-    padding-left: 32px;
+    display: block;
+    padding-right: 14px;
+    padding-left: 30px;
+    line-height: 1.65;
+
+    @include respond($break75) {
+      padding-left: 32px;
+      line-height: 1.5;
+    }
   }
 
   .button-enter, .button-leave.action-text-hide-immediately {
@@ -813,55 +829,45 @@
   }
 
   .icons {
-    position: relative;
-    width: 25px;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    transition: transform $duration $timing;
 
     .add & {
-      top: -25px;
-      transition: top $duration $timing;
+      transform: translateY(-100%);
     }
 
     .add-active & {
-      top: -25px;
-    }
-
-    .remove & {
-      top: 0;
-      transition: top $duration $timing;
+      transform: translateY(-100%);
     }
 
     .remove-active & {
-      top: 25px;
-      transition: top $duration $timing;
+      transform: translateY(100%);
     }
 
-    .manicon {
+    .manicon-svg {
       position: absolute;
       top: 0;
-      left: -1px;
-      margin-right: 13px;
-      font-size: 14px;
-      text-align: center;
-    }
-
-    .manicon-minus-bold {
-      top: -22px;
       left: 0;
-    }
-
-    .manicon-check-bold {
-      top: 3px;
-    }
-
-    .manicon-plus-bold {
-      top: 28px;
-      left: 1px;
       transition: transform $duration $timing;
 
-      .follow-active & {
-        transform: rotate(-90deg);
+      @include respond($break75) {
+        width: 30px;
+        height: 30px;
       }
 
+      &.minus {
+        top: -100%;
+      }
+
+      &.plus {
+        top: 100%;
+
+        .follow-active & {
+          transform: rotate(-90deg);
+        }
+      }
     }
   }
 }

--- a/client/src/theme/Components/global/_project-list.scss
+++ b/client/src/theme/Components/global/_project-list.scss
@@ -21,7 +21,7 @@
       &:hover, &:focus {
         outline: 0;
 
-        figure img {
+        figure > img {
           border-color: $accentPrimary;
         }
 
@@ -58,6 +58,7 @@
       li {
         flex: 1 1 25%;
         max-width: 25%;
+        padding-left: 0;
         margin-bottom: 18px;
         border-bottom: none;
       }
@@ -66,7 +67,7 @@
         &:hover, &:focus {
           @include panelRounded;
 
-          figure img {
+          figure > img {
             border-color: transparent;
           }
 

--- a/client/src/theme/STACSS/_appearance.scss
+++ b/client/src/theme/STACSS/_appearance.scss
@@ -413,17 +413,17 @@
       padding-left: 15px;
     }
 
-    img, svg {
+    > img, > svg {
       width: 50px;
       height: auto;
     }
 
-    img {
+    > img {
       border: 1px solid transparent;
       transition: border $duration $timing;
     }
 
-    svg {
+    > svg {
       max-height: 50px;
       transition: fill $duration $timing;
     }
@@ -510,7 +510,7 @@
         padding-left: 0;
       }
 
-      img, svg {
+      > img, > svg {
         width: auto;
         height: 100%;
       }


### PR DESCRIPTION
Replaces font-based icons with SVGs to simplify positioning, shrinks button size and adds padding on mobile, and improves CSS transitions.

Resolves #1512