### PR TITLE
[B] Normalize appearance of search inputs

### DIFF
--- a/client/src/theme/Components/global/forms/_shared.scss
+++ b/client/src/theme/Components/global/forms/_shared.scss
@@ -23,6 +23,8 @@
     padding-left: 40px;
     color: $neutral50;
     border-color: $neutral50;
+    border-radius: 0;
+    appearance: none;
     transition: color $duration $timing, border-color $duration $timing;
 
     &::placeholder {

--- a/client/src/theme/STACSS/_appearance.scss
+++ b/client/src/theme/STACSS/_appearance.scss
@@ -336,6 +336,8 @@
   color: $neutral40;
   background: transparent;
   border: 1px solid $neutral80;
+  border-radius: 0;
+  appearance: none;
   outline: none;
   transition: border-color $duration $timing;
 


### PR DESCRIPTION
Fixes an issue with some search inputs having default user agent appearance in iOS Safari.

Resolves #1505 
