### PR TITLE
[B] Don't rescue StandardError during ingestion

### DIFF
--- a/api/app/services/ingestions.rb
+++ b/api/app/services/ingestions.rb
@@ -1,4 +1,6 @@
 module Ingestions
+  class IngestionError < StandardError; end
+
   mattr_accessor :configuration do
     Ingestions::Configuration::GlobalConfigurator.new
   end

--- a/api/app/services/ingestions/concerns/catches_exceptions.rb
+++ b/api/app/services/ingestions/concerns/catches_exceptions.rb
@@ -21,9 +21,10 @@ module Ingestions
       # rubocop:disable Metrics/AbcSize
       def watch_for_uncaught_exceptions!
         yield if block_given?
-      rescue StandardError => e
+      rescue ::Ingestions::IngestionError => e
         @uncaught_exception = e
         error = e.message
+        error += "\n\n#{e.cause.message}" if e.cause.present?
         if Rails.env.development?
           Rails.backtrace_cleaner.clean(e.backtrace).each do |line|
             error += "\n#{line}"

--- a/api/app/services/ingestions/concerns/file_operations.rb
+++ b/api/app/services/ingestions/concerns/file_operations.rb
@@ -142,13 +142,15 @@ module Ingestions
         validate_path(path)
         args.unshift(path)
         File.send(msg, *args)
+      rescue Errno::ENOENT
+        file_not_found
       end
 
       # rubocop:disable Metrics/LineLength
       def validate_path(abs_path)
         path = Pathname.new(abs_path)
-        raise "Ingestion path must be absolute: #{path}" unless path.absolute?
-        raise "Ingestion path not inside of root: #{path}" unless path.to_s.start_with? root_path
+        raise IngestionError, "Ingestion path must be absolute: #{path}" unless path.absolute?
+        raise IngestionError, "Ingestion path not inside of root: #{path}" unless path.to_s.start_with? root_path
       end
       # rubocop:enable Metrics/LineLength
 
@@ -223,6 +225,12 @@ module Ingestions
         else
           FileUtils.cp_r Pathname.glob(File.join(path, "*")), dest_path
         end
+      end
+
+      def file_not_found
+        raise IngestionError, "Manifold could not locate one of the source files
+            specified.  Make sure all assets referred to are included with the
+            source file."
       end
     end
   end

--- a/api/app/services/ingestions/context.rb
+++ b/api/app/services/ingestions/context.rb
@@ -27,7 +27,7 @@ module Ingestions
     end
 
     def source=(fetched)
-      raise "Already provided source" if source_provided?
+      raise IngestionError, "Already provided source" if source_provided?
 
       source, title = if fetched.present?
                         [fetched[:file].path, fetched[:title]]

--- a/api/app/services/ingestions/fetchers.rb
+++ b/api/app/services/ingestions/fetchers.rb
@@ -1,6 +1,6 @@
 module Ingestions
   module Fetchers
-    class NotFetchable < StandardError; end
-    class FetchFailed < StandardError; end
+    class NotFetchable < IngestionError; end
+    class FetchFailed < IngestionError; end
   end
 end

--- a/api/app/services/ingestions/fetchers/google_doc.rb
+++ b/api/app/services/ingestions/fetchers/google_doc.rb
@@ -40,11 +40,21 @@ module Ingestions
           "text/html",
           download_dest: temp_file.path
         )
+      rescue OpenSSL::PKey::RSAError
+        drive_session_error
+      rescue Signet::AuthorizationError
+        authorization_error
       end
 
       def drive_session_error
         raise Fetchers::FetchFailed, "Unable to start google drive session.  Double check
-            that google integration has been configured and the drive API enabled.
+            that google integration has been configured correctly and the drive API
+            enabled. See more at https://manifoldapp.org/docs/customizing/settings/external_services/google/index.html."
+      end
+
+      def authorization_error
+        raise Fetchers::FetchFailed, "Unable to start google drive session. Double check
+            this installation's google integration credentials.
             See more at https://manifoldapp.org/docs/customizing/settings/external_services/google/index.html."
       end
 

--- a/api/app/services/ingestions/pickers/abstract_picker.rb
+++ b/api/app/services/ingestions/pickers/abstract_picker.rb
@@ -14,7 +14,8 @@ module Ingestions
       private
 
       def none_found_error
-        raise "No #{self.class.klass_name} found for #{interaction_source_path}"
+        raise IngestionError,
+              "No #{self.class.klass_name} found for #{interaction_source_path}"
       end
 
       def interaction_source_path

--- a/api/app/services/ingestions/post_processors/text_section_body.rb
+++ b/api/app/services/ingestions/post_processors/text_section_body.rb
@@ -72,7 +72,7 @@ module Ingestions
           if json.blank?
             error_string(body)
 
-            raise "Body contains no nodes"
+            raise IngestionError, "Body contains no nodes"
           end
         end
       end

--- a/api/app/services/ingestions/pre_processors/extract_stylesheets.rb
+++ b/api/app/services/ingestions/pre_processors/extract_stylesheets.rb
@@ -118,7 +118,7 @@ module Ingestions
       def external?(node)
         return true if node.name == "link"
         return false if node.name == "style"
-        raise "Invalid style chunk"
+        raise IngestionError, "Invalid style chunk"
       end
 
       def stylesheet_exists?(hashed_content)

--- a/api/spec/services/ingestions/compiler_spec.rb
+++ b/api/spec/services/ingestions/compiler_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Ingestions::Compiler do
 
     describe "a compilation with failures" do
       it "does not persist updates" do
-        allow_any_instance_of(Ingestions::Compilers::TextSection).to receive(:text_section).and_raise(ActiveRecord::RecordNotFound)
+        allow_any_instance_of(Ingestions::Compilers::TextSection).to receive(:text_section).and_raise(::Ingestions::IngestionError)
         manifest[:relationships][:text_titles] = [{ kind: ::TextTitle::KIND_MAIN, value: "Changed" }]
 
         expect do


### PR DESCRIPTION
This commit adds a new IngestionError class and raises
it in places where ingestions tend to fail.  We now rescue
this error instead of StandardError in the CatchesException
concern.

Fixes #1355
Fixes #1430