### PR TITLE
[B] TextNode annotation queries substring

### DIFF
--- a/client/src/components/reader/Section/BodyNodes/TextNode.js
+++ b/client/src/components/reader/Section/BodyNodes/TextNode.js
@@ -40,7 +40,7 @@ export default class TextNode extends Component {
   doScroll(withTimeout = false) {
     const { scrollAnnotation } = this.props;
     const target = scrollAnnotation
-      ? document.querySelector(`[data-annotation-ids="${scrollAnnotation}"]`)
+      ? document.querySelector(`[data-annotation-ids*="${scrollAnnotation}"]`)
       : this.el;
     const annotation = scrollAnnotation
       ? this.getAnnotation(scrollAnnotation)

--- a/client/src/utils/smoothScroll.js
+++ b/client/src/utils/smoothScroll.js
@@ -21,6 +21,7 @@ export default function smoothScroll(
   callback,
   context
 ) {
+  if (!el) return null;
   const adjustedDuration = duration || 500;
   const adjustedContext = context || window;
   const start = window.pageYOffset;


### PR DESCRIPTION
Currently this looks for an exact `annotation-ids` match to
the id in the url hash.  This is an issue when a single TextNode
has multiple annotation ids on it.  Ultimately this results in a
null element being passed to `smoothScroll`, which has no protection
against a null element.
This commit adjusts the TextNode `doScroll` function to
query elements by `data-annotation-ids` substring presence and also
adds a guard to `smoothScroll` in any case where a null element is
passed to it

Fixes #1571