### PR TITLE
[B] Reload text before passing to PostProcessor

### DIFF
--- a/api/app/services/ingestions/compiler.rb
+++ b/api/app/services/ingestions/compiler.rb
@@ -13,7 +13,7 @@ module Ingestions
         create_records :text_sections
       end
 
-      text
+      text.reload
     end
 
     private


### PR DESCRIPTION
Addresses a case where a spine is generated in the post processor
and then lost when the text is reloaded as part of
`#remove_stale_sections`. This commit reloads the text when it is
stable and returned from the Compiler.