### PR TITLE
[C] Only wrap project import in transaction

### DIFF
--- a/api/app/services/demonstration/data_loader.rb
+++ b/api/app/services/demonstration/data_loader.rb
@@ -13,16 +13,14 @@ module Demonstration
     end
 
     def load
-      ApplicationRecord.transaction do
-        clear_db
-        seed_db
-        create_admin_user
-        # create_fake_users
-        create_pages
-        import_projects
-        create_featured_projects_collection
-        reindex_records
-      end
+      clear_db
+      seed_db
+      create_admin_user
+      # create_fake_users
+      create_pages
+      create_featured_projects_collection
+      import_projects
+      reindex_records
     end
 
     def cli_user

--- a/api/app/services/importer/project.rb
+++ b/api/app/services/importer/project.rb
@@ -15,7 +15,7 @@ module Importer
     end
 
     def import(include_texts = true)
-      upsert_project(include_texts) if @project_json
+      ApplicationRecord.transaction { upsert_project(include_texts) } if @project_json
     rescue StandardError => error
       @logger.error "Unable to import project at #{@path}"
       @logger.error(error)


### PR DESCRIPTION
With the latest changes to the dev loader, if something fails
at any point in the `#load` process the whole thing is rolled
back.  The rest of the seed data, besides projects, seems safe to
commit immediately.  This also enables being able to work with the
app while project data is loading.