### PR TITLE
[B] Improve unauthenticated authorization

### DIFF
--- a/api/app/authorizers/annotation_authorizer.rb
+++ b/api/app/authorizers/annotation_authorizer.rb
@@ -6,7 +6,7 @@ class AnnotationAuthorizer < ApplicationAuthorizer
   end
 
   def creatable_by?(user, _options = {})
-    return true unless Annotation::NOTATION_TYPES.include?(resource.format)
+    return known_user?(user) unless Annotation::NOTATION_TYPES.include?(resource.format)
     resource&.text&.notatable_by? user || false
   end
 

--- a/api/app/authorizers/application_authorizer.rb
+++ b/api/app/authorizers/application_authorizer.rb
@@ -66,6 +66,10 @@ class ApplicationAuthorizer < Authority::Authorizer
 
   protected
 
+  def known_user?(user)
+    user.role.present?
+  end
+
   def resource_belongs_to_updatable_project?(user, resource)
     resource.projects.any? do |project|
       user.can_update? project

--- a/api/app/controllers/api/v1/me/relationships/annotations_controller.rb
+++ b/api/app/controllers/api/v1/me/relationships/annotations_controller.rb
@@ -5,6 +5,8 @@ module Api
         # Annotations controller
         class AnnotationsController < ApplicationController
 
+          before_action :authenticate_request!
+
           resourceful! Annotation do
             scope = Annotation.created_by(current_user)
             Annotation.filter(annotation_filter_params, scope: scope)

--- a/api/app/controllers/api/v1/me/relationships/favorite_projects_controller.rb
+++ b/api/app/controllers/api/v1/me/relationships/favorite_projects_controller.rb
@@ -5,10 +5,12 @@ module Api
         # Favorite Projects controller
         class FavoriteProjectsController < ApplicationController
 
+          before_action :authenticate_request!
+
           resourceful! Project do
             Project.filter(
               with_pagination!(project_filter_params),
-              scope: @current_user.favorite_projects.includes(:creators, :collaborators)
+              scope: current_user.favorite_projects.includes(:creators, :collaborators)
             )
           end
 

--- a/api/app/controllers/api/v1/me/relationships/favorites_controller.rb
+++ b/api/app/controllers/api/v1/me/relationships/favorites_controller.rb
@@ -5,11 +5,13 @@ module Api
         # Favorites Controller
         class FavoritesController < ApplicationController
 
+          before_action :authenticate_request!
+
           INCLUDES = %w(favorites).freeze
           LOCATION = [:api, :v1, :me].freeze
 
           resourceful! Favorite do
-            @current_user.favorites
+            current_user.favorites
           end
 
           def index
@@ -23,10 +25,10 @@ module Api
 
           def create
             updater = ::Updaters::Default.new(favorite_params)
-            @favorite = updater.update(@current_user.favorites.build)
+            @favorite = updater.update(current_user.favorites.build)
             if @favorite.valid?
               render_single_resource(
-                @current_user,
+                current_user,
                 include: INCLUDES,
                 location: LOCATION,
                 serializer: CurrentUserSerializer

--- a/api/app/controllers/api/v1/me_controller.rb
+++ b/api/app/controllers/api/v1/me_controller.rb
@@ -8,8 +8,8 @@ module Api
       INCLUDES = %w(favorites makers).freeze
 
       def show
-        if @current_user
-          render json: @current_user,
+        if current_user
+          render json: current_user,
                  include: INCLUDES,
                  serializer: CurrentUserSerializer
         else
@@ -18,13 +18,13 @@ module Api
       end
 
       def update
-        ::Updaters::User.new(user_params).update(@current_user)
-        if @current_user.valid?
-          render json: @current_user,
+        ::Updaters::User.new(user_params).update(current_user)
+        if current_user.valid?
+          render json: current_user,
                  include: INCLUDES,
                  serializer: CurrentUserSerializer
         else
-          render json: @current_user,
+          render json: current_user,
                  serializer: ActiveModel::Serializer::ErrorSerializer,
                  status: :unprocessable_entity
         end

--- a/api/app/controllers/api/v1/projects_controller.rb
+++ b/api/app/controllers/api/v1/projects_controller.rb
@@ -31,6 +31,7 @@ module Api
 
       def show
         @project = scope_for_projects.find(params[:id])
+        authorize_action_for @project
         render_single_resource @project,
                                serializer: ProjectFullSerializer,
                                include: INCLUDES

--- a/api/app/controllers/api/v1/texts_controller.rb
+++ b/api/app/controllers/api/v1/texts_controller.rb
@@ -20,6 +20,7 @@ module Api
         @text = scope_for_texts.includes(:project, :text_sections, :stylesheets)
                                .find(params[:id])
         includes = INCLUDES + %w(category creators contributors stylesheets)
+        authorize_action_for @text
         render_single_resource @text,
                                serializer: TextFullSerializer,
                                include: includes

--- a/api/app/services/ingestions/post_processors/text_section_body.rb
+++ b/api/app/services/ingestions/post_processors/text_section_body.rb
@@ -1,4 +1,3 @@
-require "naught"
 require "pathname"
 require "uri"
 require "cgi"

--- a/api/app/services/ingestions/strategy/epub/toc.rb
+++ b/api/app/services/ingestions/strategy/epub/toc.rb
@@ -1,5 +1,4 @@
 require "memoist"
-require "naught"
 
 module Ingestions
   module Strategy

--- a/api/config/initializers/authority.rb
+++ b/api/config/initializers/authority.rb
@@ -8,7 +8,7 @@ Authority.configure do |config|
   #
   # Default is:
   #
-  # config.user_method = :current_user
+  config.user_method = :authority_user
 
   # CONTROLLER_ACTION_MAP
   # =====================

--- a/api/spec/authorizers/annotation_authorizer_spec.rb
+++ b/api/spec/authorizers/annotation_authorizer_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe "Annotation Abilities", :authorizer do
   let(:text) { FactoryBot.create(:text, project: project) }
   let(:object) { FactoryBot.create(:annotation, creator: creator, private: false, text: text) }
 
+  context 'when the subject is an anonymous user' do
+    let(:subject) { anonymous_user }
+    abilities = { create: false, read: true, update: false, delete: false}
+    the_subject_behaves_like "instance abilities", Annotation, abilities
+  end
+
   context 'when the subject is an admin' do
     let(:subject) { FactoryBot.create(:user, role: Role::ROLE_ADMIN) }
 

--- a/api/spec/authorizers/project_authorizer_spec.rb
+++ b/api/spec/authorizers/project_authorizer_spec.rb
@@ -50,6 +50,28 @@ shared_examples_for "unauthorized to manage project permissions" do
 end
 
 RSpec.describe "Project Abilities", :authorizer do
+  include TestHelpers::AuthorizationHelpers
+
+  context 'when unauthenticated' do
+    context 'when draft' do
+      let(:subject) { anonymous_user }
+      let(:object) { FactoryBot.create(:project, draft: true) }
+
+      the_subject_behaves_like "instance abilities", Project, none: true
+      the_subject_behaves_like "unauthorized to manage project children"
+      the_subject_behaves_like "unauthorized to manage project permissions"
+    end
+
+    context 'when not draft' do
+      let(:subject) { anonymous_user }
+      let(:object) { FactoryBot.create(:project) }
+
+      the_subject_behaves_like "instance abilities", Project, read_only: true
+      the_subject_behaves_like "unauthorized to manage project children"
+      the_subject_behaves_like "unauthorized to manage project permissions"
+    end
+  end
+
   context 'when the subject is an admin and the project is a draft' do
     let(:subject) { FactoryBot.create(:user, role: Role::ROLE_ADMIN) }
     let(:object) { FactoryBot.create(:project, draft: true) }

--- a/api/spec/authorizers/resource_authorizer_spec.rb
+++ b/api/spec/authorizers/resource_authorizer_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "Resource Abilities", :authorizer do
+  include_examples "unauthenticated user", Resource
+
   context 'when the subject is an admin' do
     let(:subject) { FactoryBot.create(:user, role: Role::ROLE_ADMIN) }
     let(:object) { FactoryBot.create(:resource) }

--- a/api/spec/authorizers/text_authorizer_spec.rb
+++ b/api/spec/authorizers/text_authorizer_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "Text Abilities", :authorizer do
+  include_examples "unauthenticated user", Text
+
   context 'when the subject is an admin' do
     let(:subject) { FactoryBot.create(:user, role: Role::ROLE_ADMIN) }
     let(:object) { FactoryBot.create(:text) }

--- a/api/spec/requests/text_sections/relationships/annotations_spec.rb
+++ b/api/spec/requests/text_sections/relationships/annotations_spec.rb
@@ -86,6 +86,15 @@ RSpec.describe "Text Section Annotations API", type: :request do
       end
     end
 
+    context "when the user is not authenticated" do
+      before(:each) { post path, params: json_payload(annotation_params) }
+      describe "the response" do
+        it "has a 403 status code" do
+          expect(response).to have_http_status(403)
+        end
+      end
+    end
+
     context "when the user is an admin" do
       before(:each) { post path, headers: admin_headers, params: json_payload(annotation_params) }
       describe "the response" do

--- a/api/spec/support/helpers/authorization.rb
+++ b/api/spec/support/helpers/authorization.rb
@@ -1,3 +1,5 @@
+require "naught"
+
 module TestHelpers
   module AuthorizationHelpers
 
@@ -29,4 +31,24 @@ module TestHelpers
       "an "
     end
   end
+
+  def anonymous_user
+    Naught.build do |config|
+      config.impersonate User
+      config.predicates_return false
+
+      def role
+        nil
+      end
+
+      def kind
+        nil
+      end
+
+      def can_read?(resource)
+        resource.readable_by? self
+      end
+    end.new
+  end
+
 end

--- a/api/spec/support/shared_examples/authorization.rb
+++ b/api/spec/support/shared_examples/authorization.rb
@@ -32,3 +32,23 @@ shared_examples_for "class abilities" do |klass, abilities|
   end
 end
 
+shared_examples_for "unauthenticated user" do |klass|
+  class_name = klass.name.underscore
+
+  let(:subject) { anonymous_user }
+
+  context 'when unauthenticated user' do
+    context "when #{class_name}'s project is draft" do
+      let(:project) { FactoryBot.create(:project, draft: true) }
+      let(:object) { FactoryBot.create(class_name.to_sym, project: project) }
+
+      the_subject_behaves_like "instance abilities", klass, none: true
+    end
+
+    context "when #{class_name}'s project is live" do
+      let(:object) { FactoryBot.create(class_name.to_sym) }
+
+      the_subject_behaves_like "instance abilities", klass, read_only: true
+    end
+  end
+end

--- a/client/src/reader/containers/Reader/index.js
+++ b/client/src/reader/containers/Reader/index.js
@@ -217,7 +217,7 @@ export class ReaderContainer extends Component {
   render() {
     if (!this.props.text) return null;
     if (this.shouldRedirect(this.props)) return this.renderRedirect(this.props);
-    if (!this.props.text) return null;
+
     const skipId = "skip-to-main";
 
     return (

--- a/client/src/store/middleware/apiErrorMiddleware.js
+++ b/client/src/store/middleware/apiErrorMiddleware.js
@@ -7,6 +7,10 @@ function isApiError(error) {
   return error.id === "API_ERROR";
 }
 
+function isAuthorizationError(error) {
+  return error.status === 403;
+}
+
 function isFatal(error) {
   return [500, 501, 502, 503, 504, 511, 404].includes(error.status);
 }
@@ -35,10 +39,21 @@ function firstFatalError(action) {
   });
 }
 
+function fatalAuthorizationError(error) {
+  return fatalErrorActions.setFatalError(
+    { heading: error.title, body: error.detail },
+    fatalErrorActions.types.authorization
+  );
+}
+
 function notifyApiErrors(dispatch, action) {
   const errors = apiErrors(action);
   if (errors.length === 0) return;
   errors.forEach(error => {
+    if (isAuthorizationError(error)) {
+      return dispatch(fatalAuthorizationError(error));
+    }
+
     dispatch(
       notificationActions.addNotification({
         id: error.id,


### PR DESCRIPTION
This commit addresses a couple issues:

1. We weren't previously authorizing Project/Text#show, which meant
that direct navigation to draft projects and those projects' texts
always succeeded, even when unauthenticated.

2. We were rescuing Authority::MissingUser errors with a 401 error
requiring login.  This is incorrect when an unauthenticated user is
attempting to view a Project or Text and we authorize the action.
Instead, we now create an `anonymous_user` that has reader privileges
and defers its `can_read?` check to the resource we're verifying.

Fixes #1670