### PR TITLE
[B] Errorable always looks at attributes

### DIFF
--- a/client/src/global/components/form/Errorable.js
+++ b/client/src/global/components/form/Errorable.js
@@ -50,8 +50,8 @@ export default class Errorable extends PureComponent {
 
   pointerFor(name) {
     const dotNotation = brackets2dots(name);
-    const jsonPointer = dotNotation.replace(".", "/");
-    return `/data/${jsonPointer}`;
+    const jsonPointer = dotNotation.replace(/^attributes\.|^relationships\./, "").replace(".", "/");
+    return `/data/attributes/${jsonPointer}`;
   }
 
   render() {


### PR DESCRIPTION
The serializer returns all errors under an `attributes` pointer.  This
causes issues in the client with form components that are setting
relationships.  This commit changes the errorable component to always
look at the `attributes` pointer regardless of whether the wrapping component
is looking at a relationship or attribute.