### PR TITLE
[C] Abstract .project-list-container into general section wrapper

### DIFF
--- a/client/src/frontend/components/project-collection/Detail.js
+++ b/client/src/frontend/components/project-collection/Detail.js
@@ -27,6 +27,8 @@ export default class ProjectCollectionDetail extends Component {
     const projectCollection = this.props.projectCollection;
     if (!projectCollection) return null;
 
+    const baseClass = "entity-section-wrapper";
+
     const iconFill =
       projectCollection.attributes.icon === "new-round"
         ? "#52e3ac"
@@ -34,8 +36,8 @@ export default class ProjectCollectionDetail extends Component {
 
     return (
       <section key={projectCollection.id} className="bg-neutral05">
-        <div className="container project-list-container">
-          <div className="section-heading">
+        <div className={`${baseClass} container`}>
+          <div className={`${baseClass}__heading section-heading`}>
             <div className="main">
               <i className={"manicon"} aria-hidden="true">
                 <Utility.IconComposer
@@ -52,8 +54,9 @@ export default class ProjectCollectionDetail extends Component {
           <Filters
             filterChangeHandler={this.props.filterChangeHandler}
             initialState={this.props.initialState}
+            additionalClasses={`${baseClass}__tools`}
           />
-          <div className="details">
+          <div className={`${baseClass}__details`}>
             {this.description && (
               <p
                 className="description"
@@ -76,6 +79,7 @@ export default class ProjectCollectionDetail extends Component {
             dispatch={this.props.dispatch}
             paginationClickHandler={this.props.paginationClickHandler}
             pagination={this.props.pagination}
+            additionalClass={baseClass}
           />
         </div>
       </section>

--- a/client/src/frontend/components/project-collection/Filters.js
+++ b/client/src/frontend/components/project-collection/Filters.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import omitBy from "lodash/omitBy";
 import uniqueId from "lodash/uniqueId";
+import classNames from "classnames";
 
 export default class ProjectCollectionFilters extends Component {
   static displayName = "ProjectCollection.Filters";
@@ -9,7 +10,8 @@ export default class ProjectCollectionFilters extends Component {
   static propTypes = {
     filterChangeHandler: PropTypes.func.isRequired,
     initialFilterState: PropTypes.object,
-    searchId: PropTypes.string
+    searchId: PropTypes.string,
+    additionalClasses: PropTypes.string
   };
 
   static defaultProps = {
@@ -56,7 +58,10 @@ export default class ProjectCollectionFilters extends Component {
 
   render() {
     return (
-      <form className="form-list-filter" onSubmit={this.updateResults}>
+      <form
+        className={classNames("form-list-filter", this.props.additionalClasses)}
+        onSubmit={this.updateResults}
+      >
         <div className="search-input">
           <button className="search-button" type="submit">
             <span className="screen-reader-text">Search…</span>

--- a/client/src/frontend/components/project-collection/Summary.js
+++ b/client/src/frontend/components/project-collection/Summary.js
@@ -48,6 +48,8 @@ export default class ProjectCollectionSummary extends Component {
   render() {
     if (!this.collection) return null;
 
+    const baseClass = "entity-section-wrapper";
+
     const backgroundClasses = classnames({
       "project-collection-summary": true,
       "bg-neutral05": this.props.ordinal % 2 === 0
@@ -59,9 +61,9 @@ export default class ProjectCollectionSummary extends Component {
 
     return (
       <section key={this.collection.id} className={backgroundClasses}>
-        <div className="container project-list-container">
+        <div className={`${baseClass} container`}>
           <Link
-            className="section-heading"
+            className={`${baseClass}__heading section-heading`}
             to={lh.link(
               "frontendProjectCollection",
               this.collection.attributes.slug
@@ -81,7 +83,7 @@ export default class ProjectCollectionSummary extends Component {
             </div>
           </Link>
           {this.description && (
-            <div className="details">
+            <div className={`${baseClass}__details`}>
               <p
                 className="description"
                 dangerouslySetInnerHTML={{
@@ -105,9 +107,10 @@ export default class ProjectCollectionSummary extends Component {
                 this.collection.attributes.slug
               )}
               viewAllLabel={"See the full collection"}
+              additionalClass={baseClass}
             />
           ) : (
-            <div className="project-list empty">
+            <div className={`${baseClass}__body project-list empty`}>
               <p className="message">
                 {"This Project Collection is currently empty."}
               </p>

--- a/client/src/frontend/components/project-collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/project-collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -5,10 +5,10 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
   className="bg-neutral05"
 >
   <div
-    className="container project-list-container"
+    className="entity-section-wrapper container"
   >
     <div
-      className="section-heading"
+      className="entity-section-wrapper__heading section-heading"
     >
       <div
         className="main"
@@ -43,7 +43,7 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
       </div>
     </div>
     <form
-      className="form-list-filter"
+      className="form-list-filter entity-section-wrapper__tools"
       onSubmit={[Function]}
     >
       <div
@@ -117,7 +117,7 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
       </button>
     </form>
     <div
-      className="details"
+      className="entity-section-wrapper__details"
     >
       <p
         className="list-total"
@@ -129,7 +129,7 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
       </p>
     </div>
     <nav
-      className="project-list grid"
+      className="project-list grid entity-section-wrapper__body"
     >
       <ul>
         <li>
@@ -186,102 +186,106 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
         </li>
       </ul>
     </nav>
-    <nav
-      className="list-pagination-primary"
+    <div
+      className="entity-section-wrapper__pagination"
     >
-      <ul
-        className={null}
+      <nav
+        className="list-pagination-primary"
       >
-        <li
-          className="pagination-previous disabled"
+        <ul
+          className={null}
         >
-          <a
-            data-id="page-prev"
-            href="#pagination-target"
-            onClick={[MockFunction]}
+          <li
+            className="pagination-previous disabled"
           >
-            <i
-              aria-hidden="true"
-              className="manicon manicon-arrow-long-left"
-            />
-            <span
-              aria-hidden="true"
+            <a
+              data-id="page-prev"
+              href="#pagination-target"
+              onClick={[MockFunction]}
             >
-              Prev
-            </span>
-            <span
-              className="screen-reader-text"
-            >
-              Previous Page
-            </span>
-          </a>
-        </li>
-        <li
-          className="active ordinal"
-        >
-          <a
-            href="#pagination-target"
-            onClick={[MockFunction]}
+              <i
+                aria-hidden="true"
+                className="manicon manicon-arrow-long-left"
+              />
+              <span
+                aria-hidden="true"
+              >
+                Prev
+              </span>
+              <span
+                className="screen-reader-text"
+              >
+                Previous Page
+              </span>
+            </a>
+          </li>
+          <li
+            className="active ordinal"
           >
-            <span
-              aria-hidden="true"
+            <a
+              href="#pagination-target"
+              onClick={[MockFunction]}
             >
-              1
-            </span>
-            <span
-              className="screen-reader-text"
-            >
-              Go to page: 
-              1
-            </span>
-          </a>
-        </li>
-        <li
-          className="ordinal"
-        >
-          <a
-            href="#pagination-target"
-            onClick={[MockFunction]}
+              <span
+                aria-hidden="true"
+              >
+                1
+              </span>
+              <span
+                className="screen-reader-text"
+              >
+                Go to page: 
+                1
+              </span>
+            </a>
+          </li>
+          <li
+            className="ordinal"
           >
-            <span
-              aria-hidden="true"
+            <a
+              href="#pagination-target"
+              onClick={[MockFunction]}
             >
-              2
-            </span>
-            <span
-              className="screen-reader-text"
-            >
-              Go to page: 
-              2
-            </span>
-          </a>
-        </li>
-        <li
-          className="pagination-next "
-        >
-          <a
-            data-id="page-next"
-            href="#pagination-target"
-            onClick={[MockFunction]}
+              <span
+                aria-hidden="true"
+              >
+                2
+              </span>
+              <span
+                className="screen-reader-text"
+              >
+                Go to page: 
+                2
+              </span>
+            </a>
+          </li>
+          <li
+            className="pagination-next "
           >
-            <span
-              className="screen-reader-text"
+            <a
+              data-id="page-next"
+              href="#pagination-target"
+              onClick={[MockFunction]}
             >
-              Next Page
-            </span>
-            <span
-              aria-hidden="true"
-            >
-              Next
-            </span>
-            <i
-              aria-hidden="true"
-              className="manicon manicon-arrow-long-right"
-            />
-          </a>
-        </li>
-      </ul>
-    </nav>
+              <span
+                className="screen-reader-text"
+              >
+                Next Page
+              </span>
+              <span
+                aria-hidden="true"
+              >
+                Next
+              </span>
+              <i
+                aria-hidden="true"
+                className="manicon manicon-arrow-long-right"
+              />
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
   </div>
 </section>
 `;

--- a/client/src/frontend/components/project-collection/__tests__/__snapshots__/Summary-test.js.snap
+++ b/client/src/frontend/components/project-collection/__tests__/__snapshots__/Summary-test.js.snap
@@ -5,10 +5,10 @@ exports[`Frontend.ProjectCollection.Placeholder component renders correctly 1`] 
   className="project-collection-summary"
 >
   <div
-    className="container project-list-container"
+    className="entity-section-wrapper container"
   >
     <a
-      className="section-heading"
+      className="entity-section-wrapper__heading section-heading"
       href="/projects/project-collection/undefined"
       onClick={[Function]}
     >
@@ -45,7 +45,7 @@ exports[`Frontend.ProjectCollection.Placeholder component renders correctly 1`] 
       </div>
     </a>
     <nav
-      className="project-list grid"
+      className="project-list grid entity-section-wrapper__body"
     >
       <ul>
         <li>
@@ -77,7 +77,7 @@ exports[`Frontend.ProjectCollection.Placeholder component renders correctly 1`] 
       </ul>
     </nav>
     <div
-      className="utility"
+      className="entity-section-wrapper__utility entity-section-wrapper__utility--footer"
     >
       <a
         href="/projects/project-collection/undefined"

--- a/client/src/frontend/components/project-list/Filters.js
+++ b/client/src/frontend/components/project-list/Filters.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import omitBy from "lodash/omitBy";
 import uniqueId from "lodash/uniqueId";
+import classNames from "classnames";
 
 export default class ProjectListFilters extends Component {
   static displayName = "ProjectList.Filters";
@@ -11,7 +12,8 @@ export default class ProjectListFilters extends Component {
     initialFilterState: PropTypes.object,
     subjects: PropTypes.array,
     hideFeatured: PropTypes.bool,
-    searchId: PropTypes.string
+    searchId: PropTypes.string,
+    additionalClasses: PropTypes.string
   };
 
   static defaultProps = {
@@ -144,7 +146,10 @@ export default class ProjectListFilters extends Component {
 
   render() {
     return (
-      <form className="form-list-filter" onSubmit={this.updateResults}>
+      <form
+        className={classNames("form-list-filter", this.props.additionalClasses)}
+        onSubmit={this.updateResults}
+      >
         {this.renderSearch()}
         <div className="select-group inline">
           {this.renderSort()}

--- a/client/src/frontend/components/project-list/Following.js
+++ b/client/src/frontend/components/project-list/Following.js
@@ -37,10 +37,13 @@ export default class ProjectListFollowing extends Component {
     if (!currentUser) return null;
     if (!currentUser.favorites || size(currentUser.favorites) <= 0)
       return <Layout.NoFollow />;
+
+    const baseClass = "entity-section-wrapper";
+
     return (
       <section className="bg-neutral05">
-        <div className="container project-list-container">
-          <header className="section-heading">
+        <div className={`${baseClass} container`}>
+          <header className={`${baseClass}__heading section-heading`}>
             <div className="main">
               <i className="manicon" aria-hidden="true">
                 <Icon.BooksWithGlasses size={54} />
@@ -53,6 +56,7 @@ export default class ProjectListFollowing extends Component {
           <Filters
             filterChangeHandler={this.props.filterChangeHandler}
             subjects={this.mapFavoritesToSubjects()}
+            additionalClasses={`${baseClass}__tools`}
           />
           {this.props.followedProjects ? (
             <Grid
@@ -60,6 +64,7 @@ export default class ProjectListFollowing extends Component {
               favorites={this.props.authentication.currentUser.favorites}
               dispatch={this.props.dispatch}
               projects={this.props.followedProjects}
+              additionalClass={baseClass}
             />
           ) : null}
         </div>

--- a/client/src/frontend/components/project-list/Grid.js
+++ b/client/src/frontend/components/project-list/Grid.js
@@ -5,6 +5,7 @@ import Utility from "global/components/utility";
 import { CSSTransitionGroup as ReactCSSTransitionGroup } from "react-transition-group";
 import difference from "lodash/difference";
 import { Link } from "react-router-dom";
+import classNames from "classnames";
 
 export default class ProjectListGrid extends Component {
   static displayName = "ProjectList.Grid";
@@ -18,7 +19,8 @@ export default class ProjectListGrid extends Component {
     pagination: PropTypes.object,
     paginationClickHandler: PropTypes.func,
     viewAllUrl: PropTypes.string,
-    viewAllLabel: PropTypes.string
+    viewAllLabel: PropTypes.string,
+    additionalClass: PropTypes.string
   };
 
   static defaultProps = {
@@ -62,11 +64,19 @@ export default class ProjectListGrid extends Component {
   }
 
   renderPagination(props) {
+    const additionalClass = this.props.additionalClass;
+
     return (
-      <Utility.Pagination
-        paginationClickHandler={props.paginationClickHandler}
-        pagination={props.pagination}
-      />
+      <div
+        className={classNames({
+          [`${additionalClass}__pagination`]: additionalClass
+        })}
+      >
+        <Utility.Pagination
+          paginationClickHandler={props.paginationClickHandler}
+          pagination={props.pagination}
+        />
+      </div>
     );
   }
 
@@ -75,8 +85,15 @@ export default class ProjectListGrid extends Component {
     if (props.projects.length <= props.limit) return null;
     if (!props.viewAllUrl) return null;
 
+    const additionalClass = this.props.additionalClass;
+
     return (
-      <div className="utility">
+      <div
+        className={classNames({
+          [`${additionalClass}__utility`]: additionalClass,
+          [`${additionalClass}__utility--footer`]: additionalClass
+        })}
+      >
         <Link to={this.props.viewAllUrl}>
           {this.props.viewAllLabel}
           <i className="manicon manicon-arrow-long-right" />
@@ -89,10 +106,15 @@ export default class ProjectListGrid extends Component {
     const projects = this.projectsList();
     if (!projects) return null;
     const hideDesc = true;
+    const additionalClass = this.props.additionalClass;
 
     return (
       <React.Fragment>
-        <nav className="project-list grid">
+        <nav
+          className={classNames("project-list grid", {
+            [`${additionalClass}__body`]: additionalClass
+          })}
+        >
           <ReactCSSTransitionGroup
             transitionName="project-list grid"
             transitionEnter={this.enableAnimation}

--- a/client/src/frontend/components/project-list/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/frontend/components/project-list/__tests__/__snapshots__/Following-test.js.snap
@@ -5,10 +5,10 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
   className="bg-neutral05"
 >
   <div
-    className="container project-list-container"
+    className="entity-section-wrapper container"
   >
     <header
-      className="section-heading"
+      className="entity-section-wrapper__heading section-heading"
     >
       <div
         className="main"
@@ -43,7 +43,7 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
       </div>
     </header>
     <form
-      className="form-list-filter"
+      className="form-list-filter entity-section-wrapper__tools"
       onSubmit={[Function]}
     >
       <div
@@ -140,7 +140,7 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
       </button>
     </form>
     <nav
-      className="project-list grid"
+      className="project-list grid entity-section-wrapper__body"
     >
       <ul>
         <li>

--- a/client/src/frontend/containers/Following/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/frontend/containers/Following/__tests__/__snapshots__/Following-test.js.snap
@@ -6,10 +6,10 @@ exports[`Frontend Following Container renders correctly 1`] = `
     className="bg-neutral05"
   >
     <div
-      className="container project-list-container"
+      className="entity-section-wrapper container"
     >
       <header
-        className="section-heading"
+        className="entity-section-wrapper__heading section-heading"
       >
         <div
           className="main"
@@ -44,7 +44,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
         </div>
       </header>
       <form
-        className="form-list-filter"
+        className="form-list-filter entity-section-wrapper__tools"
         onSubmit={[Function]}
       >
         <div
@@ -141,7 +141,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
         </button>
       </form>
       <nav
-        className="project-list grid"
+        className="project-list grid entity-section-wrapper__body"
       >
         <ul>
           <li>
@@ -372,10 +372,10 @@ exports[`Frontend Following Container renders correctly 1`] = `
   </section>
   <section>
     <div
-      className="container project-list-container"
+      className="entity-section-wrapper container"
     >
       <header
-        className="section-heading"
+        className="entity-section-wrapper__heading section-heading"
       >
         <div
           className="main"
@@ -410,7 +410,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
         </div>
       </header>
       <nav
-        className="project-list grid"
+        className="project-list grid entity-section-wrapper__body"
       >
         <ul>
           <li>

--- a/client/src/frontend/containers/Following/index.js
+++ b/client/src/frontend/containers/Following/index.js
@@ -121,10 +121,13 @@ export class FollowingContainer extends Component {
   renderFeaturedProjects() {
     if (!this.props.featuredProjects || !this.props.featuredProjects.length > 0)
       return null;
+
+    const baseClass = "entity-section-wrapper";
+
     return (
       <section>
-        <div className="container project-list-container">
-          <header className="section-heading">
+        <div className={`${baseClass} container`}>
+          <header className={`${baseClass}__heading section-heading`}>
             <div className="main">
               <i className="manicon" aria-hidden="true">
                 <Icon.Lamp size={54} />
@@ -145,6 +148,7 @@ export class FollowingContainer extends Component {
               dispatch={this.props.dispatch}
               projects={this.props.featuredProjects}
               limit={featuredLimit}
+              additionalClass={baseClass}
             />
           ) : null}
         </div>

--- a/client/src/frontend/containers/ProjectCollectionDetail/__tests__/__snapshots__/ProjectCollectionDetail-test.js.snap
+++ b/client/src/frontend/containers/ProjectCollectionDetail/__tests__/__snapshots__/ProjectCollectionDetail-test.js.snap
@@ -22,10 +22,10 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
     className="bg-neutral05"
   >
     <div
-      className="container project-list-container"
+      className="entity-section-wrapper container"
     >
       <div
-        className="section-heading"
+        className="entity-section-wrapper__heading section-heading"
       >
         <div
           className="main"
@@ -60,7 +60,7 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
         </div>
       </div>
       <form
-        className="form-list-filter"
+        className="form-list-filter entity-section-wrapper__tools"
         onSubmit={[Function]}
       >
         <div
@@ -134,7 +134,7 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
         </button>
       </form>
       <div
-        className="details"
+        className="entity-section-wrapper__details"
       >
         <p
           className="list-total"
@@ -146,7 +146,7 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
         </p>
       </div>
       <nav
-        className="project-list grid"
+        className="project-list grid entity-section-wrapper__body"
       >
         <ul>
           <li>
@@ -203,102 +203,106 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
           </li>
         </ul>
       </nav>
-      <nav
-        className="list-pagination-primary"
+      <div
+        className="entity-section-wrapper__pagination"
       >
-        <ul
-          className={null}
+        <nav
+          className="list-pagination-primary"
         >
-          <li
-            className="pagination-previous disabled"
+          <ul
+            className={null}
           >
-            <a
-              data-id="page-prev"
-              href="#pagination-target"
-              onClick={[Function]}
+            <li
+              className="pagination-previous disabled"
             >
-              <i
-                aria-hidden="true"
-                className="manicon manicon-arrow-long-left"
-              />
-              <span
-                aria-hidden="true"
+              <a
+                data-id="page-prev"
+                href="#pagination-target"
+                onClick={[Function]}
               >
-                Prev
-              </span>
-              <span
-                className="screen-reader-text"
-              >
-                Previous Page
-              </span>
-            </a>
-          </li>
-          <li
-            className="active ordinal"
-          >
-            <a
-              href="#pagination-target"
-              onClick={[Function]}
+                <i
+                  aria-hidden="true"
+                  className="manicon manicon-arrow-long-left"
+                />
+                <span
+                  aria-hidden="true"
+                >
+                  Prev
+                </span>
+                <span
+                  className="screen-reader-text"
+                >
+                  Previous Page
+                </span>
+              </a>
+            </li>
+            <li
+              className="active ordinal"
             >
-              <span
-                aria-hidden="true"
+              <a
+                href="#pagination-target"
+                onClick={[Function]}
               >
-                1
-              </span>
-              <span
-                className="screen-reader-text"
-              >
-                Go to page: 
-                1
-              </span>
-            </a>
-          </li>
-          <li
-            className="ordinal"
-          >
-            <a
-              href="#pagination-target"
-              onClick={[Function]}
+                <span
+                  aria-hidden="true"
+                >
+                  1
+                </span>
+                <span
+                  className="screen-reader-text"
+                >
+                  Go to page: 
+                  1
+                </span>
+              </a>
+            </li>
+            <li
+              className="ordinal"
             >
-              <span
-                aria-hidden="true"
+              <a
+                href="#pagination-target"
+                onClick={[Function]}
               >
-                2
-              </span>
-              <span
-                className="screen-reader-text"
-              >
-                Go to page: 
-                2
-              </span>
-            </a>
-          </li>
-          <li
-            className="pagination-next "
-          >
-            <a
-              data-id="page-next"
-              href="#pagination-target"
-              onClick={[Function]}
+                <span
+                  aria-hidden="true"
+                >
+                  2
+                </span>
+                <span
+                  className="screen-reader-text"
+                >
+                  Go to page: 
+                  2
+                </span>
+              </a>
+            </li>
+            <li
+              className="pagination-next "
             >
-              <span
-                className="screen-reader-text"
+              <a
+                data-id="page-next"
+                href="#pagination-target"
+                onClick={[Function]}
               >
-                Next Page
-              </span>
-              <span
-                aria-hidden="true"
-              >
-                Next
-              </span>
-              <i
-                aria-hidden="true"
-                className="manicon manicon-arrow-long-right"
-              />
-            </a>
-          </li>
-        </ul>
-      </nav>
+                <span
+                  className="screen-reader-text"
+                >
+                  Next Page
+                </span>
+                <span
+                  aria-hidden="true"
+                >
+                  Next
+                </span>
+                <i
+                  aria-hidden="true"
+                  className="manicon manicon-arrow-long-right"
+                />
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
     </div>
   </section>
   <section

--- a/client/src/frontend/containers/ProjectCollections/__tests__/__snapshots__/ProjectCollections-test.js.snap
+++ b/client/src/frontend/containers/ProjectCollections/__tests__/__snapshots__/ProjectCollections-test.js.snap
@@ -28,10 +28,10 @@ exports[`Frontend ProjectCollections Container renders correctly 1`] = `
     className="project-collection-summary bg-neutral05"
   >
     <div
-      className="container project-list-container"
+      className="entity-section-wrapper container"
     >
       <a
-        className="section-heading"
+        className="entity-section-wrapper__heading section-heading"
         href="/projects/project-collection/undefined"
         onClick={[Function]}
       >
@@ -68,7 +68,7 @@ exports[`Frontend ProjectCollections Container renders correctly 1`] = `
         </div>
       </a>
       <div
-        className="project-list empty"
+        className="entity-section-wrapper__body project-list empty"
       >
         <p
           className="message"
@@ -82,10 +82,10 @@ exports[`Frontend ProjectCollections Container renders correctly 1`] = `
     className="project-collection-summary"
   >
     <div
-      className="container project-list-container"
+      className="entity-section-wrapper container"
     >
       <a
-        className="section-heading"
+        className="entity-section-wrapper__heading section-heading"
         href="/projects/project-collection/undefined"
         onClick={[Function]}
       >
@@ -122,7 +122,7 @@ exports[`Frontend ProjectCollections Container renders correctly 1`] = `
         </div>
       </a>
       <div
-        className="project-list empty"
+        className="entity-section-wrapper__body project-list empty"
       >
         <p
           className="message"

--- a/client/src/frontend/containers/Projects/index.js
+++ b/client/src/frontend/containers/Projects/index.js
@@ -135,10 +135,12 @@ export class ProjectsContainer extends Component {
   renderProjectLibrary() {
     if (this.showPlaceholder()) return <ProjectList.Placeholder />;
 
+    const baseClass = "entity-section-wrapper";
+
     return (
       <section className="bg-neutral05">
-        <div className="container project-list-container">
-          <header className="section-heading">
+        <div className={`${baseClass} container`}>
+          <header className={`${baseClass}__heading section-heading`}>
             <div className="main">
               <i className="manicon" aria-hidden="true">
                 <Icon.BooksOnShelf size={54} />
@@ -152,8 +154,9 @@ export class ProjectsContainer extends Component {
             filterChangeHandler={this.filterChangeHandler}
             initialFilterState={this.state.filter}
             subjects={this.props.subjects}
+            additionalClasses={`${baseClass}__tools`}
           />
-          <div className="details">
+          <div className={`${baseClass}__details`}>
             <Utility.EntityCount
               pagination={get(this.props.projectsMeta, "pagination")}
               singularUnit="project"
@@ -169,6 +172,7 @@ export class ProjectsContainer extends Component {
             pagination={get(this.props.projectsMeta, "pagination")}
             paginationClickHandler={this.pageChangeHandlerCreator}
             limit={perPage}
+            additionalClass={baseClass}
           />
         </div>
       </section>

--- a/client/src/theme/Components/browse/layout/_entity-section-wrapper.scss
+++ b/client/src/theme/Components/browse/layout/_entity-section-wrapper.scss
@@ -1,6 +1,6 @@
-// Arranges section-heading, details, and search/filters using flexbox
-// Currently used on Project & Project Collections detail pages
-.project-list-container {
+// Arranges section-heading, any details, search/filters, and body of section using flexbox
+// Used on All Projects, Project Detail, & Project Collections detail pages
+.entity-section-wrapper {
   display: flex;
   flex-direction: column;
   padding-top: 30px;
@@ -11,12 +11,12 @@
     justify-content: space-between;
   }
 
-  .section-heading {
+  &__heading {
     flex-grow: 1;
     order: -1;
     margin-bottom: 20px;
 
-    + .project-list { // if no filters or .details
+    + .entity-section-wrapper__body { // if no .list-tools or .details
       @include respond($break75) {
         margin-top: 34px;
       }
@@ -50,7 +50,7 @@
     }
   }
 
-  .form-list-filter {
+  &__tools {
     position: relative;
     display: flex;
     flex-direction: column;
@@ -59,7 +59,7 @@
     padding-bottom: 0;
     margin-bottom: 36px;
 
-    + .project-list { // if no .details
+    + .entity-section-wrapper__body { // if no .details
       margin-top: 18px;
 
       @include respond($break75) {
@@ -80,43 +80,42 @@
       margin-bottom: 0;
     }
 
-    .search-input {
-      width: auto;
-
-      @include respond($break75) {
-        flex-grow: 1;
-      }
-
-      @include respond($break95) {
-        width: 200px;
-      }
-    }
-
-    .select-group.inline {
-      @include respond($break75) {
+    &.form-list-filter {
+      .search-input {
         width: auto;
-        padding-top: 0;
-        margin-left: 0;
+
+        @include respond($break75) {
+          flex-grow: 1;
+        }
+
+        @include respond($break95) {
+          width: 200px;
+        }
       }
 
-      @include respond($break90) {
+      .select-group.inline {
+        @include respond($break75) {
+          width: auto;
+          padding-top: 0;
+          margin-left: 0;
+        }
+      }
+
+      .reset-button {
+        position: absolute;
+        top: 100%;
+        left: 0;
+
+        @include respond($break95) {
+          right: 0;
+          left: unset;
+          text-align: right;
+        }
       }
     }
   }
 
-  .reset-button {
-    position: absolute;
-    top: 100%;
-    left: 0;
-
-    @include respond($break95) {
-      right: 0;
-      left: unset;
-      text-align: right;
-    }
-  }
-
-  .details {
+  &__details {
     order: -1;
     width: 100%;
     margin-bottom: 20px;
@@ -132,7 +131,7 @@
       margin-right: 50%;
     }
 
-    + .project-list.empty {
+    + .entity-section-wrapper__body.project-list.empty {
       margin-top: 6px;
 
       @include respond($break75) {
@@ -161,14 +160,21 @@
     }
   }
 
-  .utility {
+  &__body:not(.project-list) {
+    width: 100%;
+  }
+
+  &__utility {
     @include utilityPrimary;
-    margin-top: 30px;
     font-size: 14px;
     line-height: 1.57;
 
-    @include respond($break75) {
-      margin-top: 20px;
+    &--footer {
+      margin-top: 30px;
+
+      @include respond($break75) {
+        margin-top: 20px;
+      }
     }
 
     a {
@@ -188,7 +194,7 @@
     }
   }
 
-  .list-pagination-primary {
+  &__pagination {
     width: 100%;
     margin-top: 30px;
   }

--- a/client/src/theme/Components/browse/layout/_index.scss
+++ b/client/src/theme/Components/browse/layout/_index.scss
@@ -1,4 +1,5 @@
 @import './no-follow';
 @import './button-nav';
+@import './entity-section-wrapper';
 @import './footer-browse';
 @import './social-nav';

--- a/client/src/theme/Components/browse/project-list/_index.scss
+++ b/client/src/theme/Components/browse/project-list/_index.scss
@@ -2,5 +2,4 @@
 // -----------------------------------------------------------
 
 @import './project-grid';
-@import './project-list-container';
 @import './project-list-placeholder';


### PR DESCRIPTION
This commit creates .entity-section-wrapper and nested classes to manage a common layout across the frontend of a section title, description, body, pagination, and filters. This change abstracts the existing styles of project list and project collection containers so that these styles may be used generally for any similar high-level layout of page elements.

Components and containers are updated to reflect this change in classNames and also to apply BEM naming conventions (e.g. .entity-section-wrapper__heading), which helps avoid excessive scoping of selectors and leave elements within things like the heading unaffected.