### PR TITLE
[C] Drawers do not trigger page scrolling

### DIFF
--- a/client/src/global/components/drawer/Wrapper.js
+++ b/client/src/global/components/drawer/Wrapper.js
@@ -157,7 +157,7 @@ export default class DrawerWrapper extends PureComponent {
 
     if (this.props.closeUrl) {
       setTimeout(() => {
-        this.props.history.push(this.props.closeUrl);
+        this.props.history.push(this.props.closeUrl, { noScroll: true });
       }, 200);
     }
   };

--- a/client/src/helpers/router/childRoutes.js
+++ b/client/src/helpers/router/childRoutes.js
@@ -25,9 +25,17 @@ const renderChildRoutes = (route, renderOptions) => {
   const childRoutes = route.routes;
 
   const defaultRender = childRoute => props => {
+    const adjustedProps = Object.assign({}, props);
+
+    if (options.drawer) {
+      adjustedProps.location.state = Object.assign({}, props.location.state, {
+        noScroll: true
+      });
+    }
+
     let rendered = (
       <childRoute.component
-        {...props}
+        {...adjustedProps}
         {...options.childProps}
         route={childRoute}
       />


### PR DESCRIPTION
This commit changes drawer route behavior to never trigger parent
route scrolling. Since the drawer routes should be considered as an
interaction similar to an overlay, they should not change anything
about the page that opens them.