### PR TITLE
[B] Add styles to text cover attachments

### DIFF
--- a/api/app/models/text.rb
+++ b/api/app/models/text.rb
@@ -94,7 +94,7 @@ class Text < ApplicationRecord
   scope :published, ->(published) { where(published: published) if published.present? }
 
   # Attachments
-  manifold_has_attached_file :cover, :image, no_styles: true
+  manifold_has_attached_file :cover, :image
 
   # Callbacks
   after_commit :trigger_text_added_event, on: [:create, :update]

--- a/api/app/services/system_upgrades/upgrades/manifold030000.rb
+++ b/api/app/services/system_upgrades/upgrades/manifold030000.rb
@@ -1,0 +1,32 @@
+module SystemUpgrades
+  module Upgrades
+    class Manifold030000 < SystemUpgrades::AbstractVersion
+      # rubocop:disable Metrics/AbcSize
+
+      def perform!
+        reprocess_text_covers!
+      end
+
+      private
+
+      def reprocess_text_covers!
+        logger.info("===================================================================")
+        logger.info("Reprocessing Text Cover Attachments                                ")
+        logger.info("===================================================================")
+        logger.info("Prior to version 3.0.0, Manifold did not have multiple versions of ")
+        logger.info("a text's cover attachment.  Future text covers will generate styles")
+        logger.info("for attachments automatically, but styles need to be generated for ")
+        logger.info("existing text covers.                                              ")
+        logger.info("===================================================================")
+
+        Text.find_each do |text|
+          next unless text.cover_attacher.stored?
+          logger.info("Generating cover styles for Text #{text.id}")
+          text.update cover: text.cover[:original]
+        end
+      end
+
+      # rubocop:enable Metrics/AbcSize
+    end
+  end
+end

--- a/client/src/frontend/components/TextList/ListItem/Content.js
+++ b/client/src/frontend/components/TextList/ListItem/Content.js
@@ -14,6 +14,7 @@ export default class TextListListItemContent extends Component {
     showAuthors: PropTypes.bool,
     showDescriptions: PropTypes.bool,
     showSubtitles: PropTypes.bool,
+    showCovers: PropTypes.bool,
     datesVisible: PropTypes.bool,
     datePrefix: PropTypes.string,
     publishedVisible: PropTypes.bool
@@ -51,7 +52,11 @@ export default class TextListListItemContent extends Component {
     return (
       <Link to={lh.link("reader", slug)} className={`${baseClass}__link`}>
         <div className={`${baseClass}__inner`}>
-          <Cover text={text} baseClass={baseClass} />
+          <Cover
+            text={text}
+            baseClass={baseClass}
+            iconOnly={!this.props.showCovers}
+          />
           <div className={`${this.props.baseClass}__content`}>
             <Bibliographic
               baseClass={baseClass}

--- a/client/src/frontend/components/TextList/ListItem/__tests__/__snapshots__/Content-test.js.snap
+++ b/client/src/frontend/components/TextList/ListItem/__tests__/__snapshots__/Content-test.js.snap
@@ -14,7 +14,7 @@ exports[`Frontend.TextList.ListItem.Content component renders correctly 1`] = `
     >
       <svg
         aria-hidden="true"
-        className="manicon-svg text-block"
+        className="manicon-svg text-block__cover-svg"
         fill="currentColor"
         height={78}
         viewBox="0 0 64 64"

--- a/client/src/frontend/components/TextList/ListItem/index.js
+++ b/client/src/frontend/components/TextList/ListItem/index.js
@@ -60,6 +60,7 @@ export default class TextListListItem extends Component {
           showAuthors={this.props.showAuthors}
           showSubtitles={this.props.showSubtitles}
           showDescriptions={this.props.showDescriptions}
+          showCovers={this.props.showCovers}
           datesVisible={this.utilityInContent && this.props.showDates}
           datePrefix={this.datePrefix}
           publishedVisible={this.utilityInContent && this.isPublished}

--- a/client/src/frontend/components/TextList/__tests__/__snapshots__/TextList-test.js.snap
+++ b/client/src/frontend/components/TextList/__tests__/__snapshots__/TextList-test.js.snap
@@ -31,7 +31,7 @@ exports[`Frontend.TextList component renders correctly 1`] = `
             >
               <svg
                 aria-hidden="true"
-                className="manicon-svg text-block"
+                className="manicon-svg text-block__cover-svg"
                 fill="currentColor"
                 height={78}
                 viewBox="0 0 64 64"
@@ -166,7 +166,7 @@ exports[`Frontend.TextList component renders correctly 1`] = `
             >
               <svg
                 aria-hidden="true"
-                className="manicon-svg text-block"
+                className="manicon-svg text-block__cover-svg"
                 fill="currentColor"
                 height={78}
                 viewBox="0 0 64 64"

--- a/client/src/frontend/components/text/Cover.js
+++ b/client/src/frontend/components/text/Cover.js
@@ -9,11 +9,12 @@ export default class TextCover extends PureComponent {
 
   static propTypes = {
     text: PropTypes.object.isRequired,
+    iconOnly: PropTypes.bool,
     baseClass: PropTypes.string
   };
 
   static defaultProps = {
-    new: false,
+    iconOnly: true,
     baseClass: "text-cover"
   };
 
@@ -22,7 +23,8 @@ export default class TextCover extends PureComponent {
   }
 
   get hasCover() {
-    return get(this.text.attributes, "coverStyles.small");
+    if (this.props.iconOnly) return false;
+    return get(this.text.attributes, "coverStyles.smallPortrait");
   }
 
   render() {
@@ -33,7 +35,7 @@ export default class TextCover extends PureComponent {
       <figure className={`${elemClass} ${elemClass}--${modifier}`}>
         {this.hasCover ? (
           <img
-            src={this.text.attributes.coverStyles.small}
+            src={this.text.attributes.coverStyles.smallPortrait}
             alt={"Thumbnail image for " + this.text.attributes.titlePlaintext}
             className={classNames(this.props.baseClass)}
           />

--- a/client/src/frontend/components/text/Cover.js
+++ b/client/src/frontend/components/text/Cover.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import get from "lodash/get";
-import classNames from "classnames";
 import { Icon } from "global/components/svg";
 
 export default class TextCover extends PureComponent {
@@ -37,12 +36,12 @@ export default class TextCover extends PureComponent {
           <img
             src={this.text.attributes.coverStyles.smallPortrait}
             alt={"Thumbnail image for " + this.text.attributes.titlePlaintext}
-            className={classNames(this.props.baseClass)}
+            className={`${this.props.baseClass}__cover-image`}
           />
         ) : (
           <Icon.LoosePages
             size={78}
-            iconClass={classNames(this.props.baseClass)}
+            iconClass={`${this.props.baseClass}__cover-svg`}
           />
         )}
       </figure>


### PR DESCRIPTION
Removes the `no_styles` option from Text cover attachments.  This commit
includes a SystemUpgrade file for V3.0.0 to generate styles for all
existing Text cover attachments.

Closes #1848