### PR TITLE
[B] Prevent wrapping in activity statistics

### DIFF
--- a/client/src/backend/components/dashboard/Activity.js
+++ b/client/src/backend/components/dashboard/Activity.js
@@ -23,8 +23,8 @@ export default class Activity extends Component {
     const increase = stats.readerIncrease;
 
     if (increase === null) return "";
-    if (increase > 0) return "+ " + increase.toString() + "%";
-    if (increase < 0) return "- " + Math.abs(increase).toString() + "%";
+    if (increase > 0) return "+" + increase.toString() + "%";
+    if (increase < 0) return "-" + Math.abs(increase).toString() + "%";
     return "0%";
   }
 

--- a/client/src/backend/components/dashboard/__tests__/__snapshots__/Activity-test.js.snap
+++ b/client/src/backend/components/dashboard/__tests__/__snapshots__/Activity-test.js.snap
@@ -26,7 +26,7 @@ exports[`Backend.Dashboard.Activity component renders correctly 1`] = `
         Change from last week
       </td>
       <td>
-        + 50%
+        +50%
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
* Removes space between +/- and number to prevent stat from breaking between lines.

Resolves #1770