### PR TITLE
[B] Misc style fixes to project hero/content blocks

### DIFF
--- a/client/src/theme/Components/backend/_drawer.scss
+++ b/client/src/theme/Components/backend/_drawer.scss
@@ -5,7 +5,7 @@
   bottom: 0;
   width: 100%;
   padding: 20px $containerPaddingResp 33px;
-  overflow: scroll;
+  overflow: auto;
   background-color: $neutral100;
 
   .drawer-enter & {

--- a/client/src/theme/Components/backend/project/_action_callout_slot.scss
+++ b/client/src/theme/Components/backend/project/_action_callout_slot.scss
@@ -38,6 +38,13 @@
       margin-bottom: 4px;
     }
 
+    &--draggable {
+      cursor: move; // fallback for older browsers
+      cursor: grab;
+      user-select: none;
+      -webkit-touch-callout: none;
+    }
+
     &:not(:last-child) {
       svg {
         margin-right: 8px;
@@ -73,29 +80,19 @@
     justify-content: space-between;
     padding: 9px 15px 11px;
     font-size: 12px;
-    line-height: 1;
+    line-height: 1.2;
     color: $neutral50;
     letter-spacing: 0.125em;
     background: $neutral95;
     border-radius: 5px;
+  }
 
-    & + & {
-      //margin-top: 10px;
-    }
+  &__chip-title {
+    flex-grow: 1;
   }
 
   &__chip-utility {
+    display: flex;
     margin-left: 10px;
   }
-
-  &__button {
-    @include buttonUnstyled;
-
-    &--draggable {
-      cursor: move; // fallback for older browsers
-      cursor: grab;
-    }
-  }
-
-
 }

--- a/client/src/theme/Components/backend/project/_content-block.scss
+++ b/client/src/theme/Components/backend/project/_content-block.scss
@@ -126,7 +126,11 @@
     display: flex;
 
     > * + * {
-      margin-left: 14px;
+      margin-left: 2vw;
+
+      @include respond($break60) {
+        margin-left: 14px;
+      }
     }
   }
 
@@ -141,6 +145,8 @@
     &--draggable {
       cursor: move; // fallback for older browsers
       cursor: grab;
+      user-select: none;
+      -webkit-touch-callout: none;
     }
 
     &:not(:disabled):hover,

--- a/client/src/theme/Components/backend/project/_hero-builder-block.scss
+++ b/client/src/theme/Components/backend/project/_hero-builder-block.scss
@@ -49,8 +49,10 @@
       }
 
       .hero-builder-block__button-label {
-        color: $accentPrimary;
-        visibility: visible;
+        @include respond($break40) {
+          color: $accentPrimary;
+          visibility: visible;
+        }
       }
 
     }
@@ -64,7 +66,9 @@
     color: $accentPrimary;
 
     .hero-builder-block__button-label {
-      visibility: visible;
+      @include respond($break40) {
+        visibility: visible;
+      }
     }
   }
 

--- a/client/src/theme/Components/browse/collection/_list.scss
+++ b/client/src/theme/Components/browse/collection/_list.scss
@@ -94,6 +94,10 @@
 
   .icon {
     @include templateHead;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    max-width: 100px;
     padding-right: 16px;
     font-size: 12px;
     text-align: center;
@@ -105,14 +109,14 @@
 
     .manicon {
       display: block;
-      margin-bottom: 3px;
     }
 
     span {
       display: none;
 
-      @include respond($break75) {
+      @include respond($break90) {
         display: block;
+        word-break: break-word;
       }
     }
   }

--- a/client/src/theme/Components/browse/project/_hero.scss
+++ b/client/src/theme/Components/browse/project/_hero.scss
@@ -68,24 +68,16 @@
     display: -ms-grid;
     display: grid;
     grid-row-gap: $grid-gap-small;
-    // grid-template:
-    //   'right-top' auto
-    //   'left-top' auto
-    //   'left-bottom' auto
-    //   'right-bottom' auto / auto;
     max-width: 1178px;
     -ms-grid-rows: auto $grid-gap-small auto $grid-gap-small auto $grid-gap-small auto;
     -ms-grid-columns: 100%;
 
     @include respond($break60) {
-      // grid-template:
-      //   'left-top right-top' auto
-      //   'left-bottom right-bottom' auto / 1fr minmax(200px, $right-column-width);
-      grid-template-columns: 1fr minmax(200px, $right-column-width);
+      grid-template-columns: 1fr minmax(220px, $right-column-width);
       row-gap: $row-gap-medium;
       column-gap: $column-gap-medium;
       -ms-grid-rows: auto $row-gap-medium auto;
-      -ms-grid-columns: 1fr $column-gap-medium minmax(200px, $right-column-width);
+      -ms-grid-columns: 1fr $column-gap-medium minmax(220px, $right-column-width);
     }
 
     @include respond($break120) {

--- a/client/src/theme/Components/browse/text/_text-block.scss
+++ b/client/src/theme/Components/browse/text/_text-block.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
 
-  @include respond($break80) {
+  @include respond($break60) {
     flex-direction: row;
   }
 
@@ -40,7 +40,7 @@
     margin-bottom: 0;
     line-height: 1;
 
-    @include respond($break80) {
+    @include respond($break60) {
       display: block;
     }
 
@@ -147,7 +147,7 @@
     padding-left: 15px;
     margin-top: 20px;
 
-    @include respond($break80) {
+    @include respond($break60) {
       padding-right: 0;
       padding-left: 0;
       margin-top: 4px;
@@ -169,12 +169,12 @@
     }
 
     &--inline {
-      @include respond($break80) {
+      @include respond($break60) {
         flex-direction: row;
         justify-content: flex-end;
 
         > :not(:first-child) {
-          @include respond($break80) {
+          @include respond($break60) {
             margin-top: 0;
             margin-left: 12px;
           }
@@ -224,7 +224,7 @@
       padding-top: 15px;
     }
 
-    @include respond($break80) {
+    @include respond($break60) {
       justify-content: flex-end;
     }
   }


### PR DESCRIPTION
Fixes various issues detected during device & browser testing:

* Adjusts breakpoint for text block layout change to show cover and
two-column layout until narrower viewport width
* Improves responsive sizing of elements in resource collection thumbs
* Increases min-width of hero right-hand block
* Fixes iOS text selection blocking use of drag handles on backend
* Fixes collapse of callout chip buttons when long title present
* Prevents hero block "Edit" label from showing on very narrow viewports
* Reduces spacing between content block buttons on narrow viewports
* Sets `overflow` to `auto` on drawers to prevent empty scrollbars