### PR TITLE
[B] Remove tag eager loading from projects

### DIFF
--- a/api/app/controllers/api/v1/projects_controller.rb
+++ b/api/app/controllers/api/v1/projects_controller.rb
@@ -55,12 +55,10 @@ module Api
       def scope_for_projects
         Project.friendly.includes(
           { texts: [:titles, :text_subjects] },
-          { resource_collections: { resources: :tags } },
           :events,
           :twitter_queries,
           :text_categories,
-          :subjects,
-          resources: :tags
+          :subjects
         )
       end
 


### PR DESCRIPTION
This was causing an issue with deleting projects were resource tags
were destroyed early.  Then when ActsAsTaggableOn went to clean up
the unused tags, it would throw an error trying to find the destroyed
tags.

Removing this eager loading does not seem to have any negative impact
on the AR time of projects controller requests. If anything, they seem
to be a hair quicker.

Fixes #1803