### PR TITLE
[B] Fix error serializing search results

### DIFF
--- a/api/app/serializers/search_result_serializer.rb
+++ b/api/app/serializers/search_result_serializer.rb
@@ -34,6 +34,8 @@ class SearchResultSerializer < ApplicationSerializer
   end
 
   def parents
+    return unless object.model.present?
+
     message = "parents_for_#{object._type}"
     return send message if respond_to? message
 

--- a/client/src/global/components/search/results/List.js
+++ b/client/src/global/components/search/results/List.js
@@ -36,6 +36,13 @@ export default class SearchResultsList extends PureComponent {
 
   renderResult(result) {
     const { searchableType } = result.attributes;
+    const { model } = result.relationships;
+
+    // This is a fallback in cases where the associated model has been destroyed, but the
+    // ElasticSearch index hasn't been correctly updated.  This should be considered a temporary
+    // solution.  We need to fix the cause in the API as well.
+    if (!model) return null;
+
     const Component = this.componentForType(searchableType);
     const typeLabel = this.labelForType(searchableType);
     if (Component) {


### PR DESCRIPTION
This is a an interim solution to fixing an issue where serializing
search result objects.  It seems like the removal of SearchableNodes
is being interupted when a project or text is destroyed.  This leaves
orphaned SearchableNodes that get indexed by searchkick.

This commit makes the SearchResultSerializer and corresponding client
component a little more resilient to a result without an existing,
associated model in the DB.

Relates to #1958