### PR TITLE
[B] Fix error serializing search results

### DIFF
--- a/api/app/serializers/search_result_serializer.rb
+++ b/api/app/serializers/search_result_serializer.rb
@@ -41,6 +41,8 @@ class SearchResultSerializer < ApplicationSerializer
   end
 
   def parents_for_text_section_child
+    return {} unless object.model.text_section.present?
+
     text_section = object.model.text_section
     {
       text_section: text_section_properties(text_section),
@@ -52,6 +54,8 @@ class SearchResultSerializer < ApplicationSerializer
   alias parents_for_searchable_node parents_for_text_section_child
 
   def parents_for_project_child
+    return {} unless object.model.project.present?
+
     {
       project: project_properties(object.model.project)
     }

--- a/api/app/services/search/results.rb
+++ b/api/app/services/search/results.rb
@@ -43,9 +43,8 @@ module Search
 
     def adjusted_results
       @adjusted_results ||= begin
-        return @searchkick_results.results if @searchkick_results.options[:load]
-
-        inject_associations(@searchkick_results)
+        raw = @searchkick_results.options[:load] ? @searchkick_results.results : inject_associations(@searchkick_results)
+        raw.select { |result| result.model.present? }
       end
     end
 


### PR DESCRIPTION
This commit improves search results by filtering out ones where the
associated model no longer exists.  Due to how we handle some project child
association deletions, there are cases where our search indices reference
models that no longer exist in the DB.  This then throws an error when serializing
the result and trying to render the result on the frontend.

The raw Search::Result has to be the initial point of filtering because
of pagination.  We could render null in the client and serialize results with
empty parents, but then the list of visible results would differ from the
pagination shown.

Fixes to #1958