### PR TITLE
[WIP] Searchkick results

### DIFF
--- a/api/app/serializers/search_result_serializer.rb
+++ b/api/app/serializers/search_result_serializer.rb
@@ -41,6 +41,8 @@ class SearchResultSerializer < ApplicationSerializer
   end
 
   def parents_for_text_section_child
+    return {} unless object.model.text_section.present?
+
     text_section = object.model.text_section
     {
       text_section: text_section_properties(text_section),
@@ -52,6 +54,8 @@ class SearchResultSerializer < ApplicationSerializer
   alias parents_for_searchable_node parents_for_text_section_child
 
   def parents_for_project_child
+    return {} unless object.model.project.present?
+
     {
       project: project_properties(object.model.project)
     }

--- a/api/app/services/search/results.rb
+++ b/api/app/services/search/results.rb
@@ -43,9 +43,8 @@ module Search
 
     def adjusted_results
       @adjusted_results ||= begin
-        return @searchkick_results.results if @searchkick_results.options[:load]
-
-        inject_associations(@searchkick_results)
+        raw = @searchkick_results.options[:load] ? @searchkick_results.results : inject_associations(@searchkick_results)
+        raw.select { |result| result.model.present? }
       end
     end
 

--- a/client/src/global/components/search/results/List.js
+++ b/client/src/global/components/search/results/List.js
@@ -36,6 +36,9 @@ export default class SearchResultsList extends PureComponent {
 
   renderResult(result) {
     const { searchableType } = result.attributes;
+    const { model } = result.relationships;
+    if (!model) return null;
+
     const Component = this.componentForType(searchableType);
     const typeLabel = this.labelForType(searchableType);
     if (Component) {

--- a/client/src/global/components/search/results/Types/SearchableNode.js
+++ b/client/src/global/components/search/results/Types/SearchableNode.js
@@ -20,6 +20,8 @@ export default class SearchResultsTypeAnnotation extends PureComponent {
     const { result } = this.props;
     const searchableNode = result.relationships.model;
     const { project, text, textSection } = result.attributes.parents;
+    if (!project || !text || !textSection) return null;
+    
     const url = lh.link("readerSection", text.slug, textSection.id);
 
     return (


### PR DESCRIPTION
- Added guards to `parents_for` methods in SearchResultsSerializer.
	- This works alright, but leads to client errors rendering each result item.

- Added guards to client components when relevant parent attributes are missing.
	- This works and resolves the above point, but can lead to states where the list is very misleading (empty pages, visibly incorrect items vs. count, etc.).

- Several changes to move SearchableNode indexing to Texts
	- As talked about, moves away from TextSections being editable.

- Filter SearchResults to remove those where `model` is nil.
	- Not sure I found the correct place to do this.  Results were still inconsistent, seemed to still need the serializer guards.

- Tried implementing `Searchkick::QueueProcessJob` to bulk reindex.
	- This seemed promising as it sped things up a bit, but it was hard to implement in a way that didn't fire off just as many as these as the normal SearchReindex jobs.
	- I think this is typically done through a timed job.

- Tried adjusting `TextSection::DestroySearchableNodes` to bulk reindex `SearchableNodes`.
	- Seemed to work, but also had inconsistent results.

Notes:
  - searchkick callbacks: :async enqueues a `Searchkick::ReindexV2Job` for each item
  - searchkick callbacks: :queue relies on a `Searchkick::QueueProcessJob` with the class name
  - `TextSections::ReindexSearchableNodes` resets `SearchableNode` records for the text section, then creates new ones and reindexes them. This uses `.reindex`, so it's performed in the same job.