### PR TITLE
[B] Remove noop from seed upgrade call

### DIFF
--- a/api/app/services/seed.rb
+++ b/api/app/services/seed.rb
@@ -45,7 +45,7 @@ class Seed
   end
 
   def self.upgrade_system(logger)
-    SystemUpgrades::Perform.run force: false, noop: true, stdout: true
+    SystemUpgrades::Perform.run force: false, noop: false, stdout: true
     logger.info("Running system upgrades".green)
   end
 


### PR DESCRIPTION
We agreed that regardless of whether Manifold is actually upgrading or a fresh install, these should be run for real.  This prevents us from artificially creating `UpgradeResult` records for fresh installations and actually runs the contents of them.

As an example, going from 2.1 to 3.0 involves creating content blocks for all existing projects.  Currently, when reconfiguring manifold after installation, the 3.0 UpgradeRecord will be created, but content blocks will not.