### PR TITLE
[R] Standardize frontend event lists with single class "event-list"

### DIFF
--- a/client/src/frontend/components/event/List.js
+++ b/client/src/frontend/components/event/List.js
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Event from "./Event";
-import classNames from "classnames";
 import Utility from "global/components/utility";
 import lh from "helpers/linkHandler";
 
@@ -11,12 +10,10 @@ export default class EventList extends Component {
   static propTypes = {
     events: PropTypes.array.isRequired,
     project: PropTypes.object.isRequired,
-    columns: PropTypes.number.isRequired,
     pagination: PropTypes.object
   };
 
   static defaultProps = {
-    columns: 2,
     limit: 10
   };
 
@@ -31,15 +28,10 @@ export default class EventList extends Component {
   render() {
     if (!this.props.events) return null;
 
-    const listClass = classNames({
-      "event-list-primary": this.props.columns === 2,
-      "event-list-secondary": this.props.columns === 3
-    });
-
     return (
-      <div>
+      <div className="entity-section-wrapper__body">
         <ul
-          className={listClass}
+          className="event-list"
           ref={eventList => {
             this.eventList = eventList;
           }}
@@ -49,16 +41,18 @@ export default class EventList extends Component {
               <Event
                 event={event}
                 key={event.id}
-                itemClass={`${listClass}__item`}
+                itemClass={"event-list__item"}
               />
             );
           })}
         </ul>
         {this.props.pagination ? (
-          <Utility.Pagination
-            paginationClickHandler={this.paginationClickHandler}
-            pagination={this.props.pagination}
-          />
+          <div className="entity-section-wrapper__pagination">
+            <Utility.Pagination
+              paginationClickHandler={this.paginationClickHandler}
+              pagination={this.props.pagination}
+            />
+          </div>
         ) : null}
       </div>
     );

--- a/client/src/frontend/components/event/__tests__/List-test.js
+++ b/client/src/frontend/components/event/__tests__/List-test.js
@@ -17,11 +17,11 @@ describe("Frontend.Event.List Component", () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it("has the event-list-primary class", () => {
+  it("has the event-list class", () => {
     expect(
       shallow(<List project={project} events={[]} />)
         .find("ul")
-        .is(".event-list-primary")
+        .is(".event-list")
     ).toBe(true);
   });
 

--- a/client/src/frontend/components/event/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/frontend/components/event/__tests__/__snapshots__/List-test.js.snap
@@ -1,12 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frontend.Event.List Component renders correctly 1`] = `
-<div>
+<div
+  className="entity-section-wrapper__body"
+>
   <ul
-    className="event-list-primary"
+    className="event-list"
   >
     <div
-      className="event-list-primary__item"
+      className="event-list__item"
     >
       <div
         className="event-tile event-tile--linked"
@@ -56,7 +58,7 @@ exports[`Frontend.Event.List Component renders correctly 1`] = `
       </div>
     </div>
     <div
-      className="event-list-primary__item"
+      className="event-list__item"
     >
       <div
         className="event-tile event-tile--linked"

--- a/client/src/frontend/components/project/Events.js
+++ b/client/src/frontend/components/project/Events.js
@@ -34,8 +34,8 @@ export default class ProjectEvents extends Component {
           />
         </section>
         <section>
-          <div className="container">
-            <header className="section-heading">
+          <div className="container entity-section-wrapper">
+            <header className="section-heading entity-section-wrapper__heading">
               <div className="main">
                 <i className="manicon manicon-pulse" aria-hidden="true" />
                 <div className="body">
@@ -43,7 +43,6 @@ export default class ProjectEvents extends Component {
                 </div>
               </div>
             </header>
-
             <Event.List
               project={this.props.project}
               events={this.props.events}

--- a/client/src/frontend/components/project/__tests__/__snapshots__/Events-test.js.snap
+++ b/client/src/frontend/components/project/__tests__/__snapshots__/Events-test.js.snap
@@ -26,10 +26,10 @@ exports[`Frontend.Project.Events component renders correctly 1`] = `
   </section>
   <section>
     <div
-      className="container"
+      className="container entity-section-wrapper"
     >
       <header
-        className="section-heading"
+        className="section-heading entity-section-wrapper__heading"
       >
         <div
           className="main"
@@ -49,12 +49,14 @@ exports[`Frontend.Project.Events component renders correctly 1`] = `
           </div>
         </div>
       </header>
-      <div>
+      <div
+        className="entity-section-wrapper__body"
+      >
         <ul
-          className="event-list-primary"
+          className="event-list"
         >
           <div
-            className="event-list-primary__item"
+            className="event-list__item"
           >
             <div
               className="event-tile event-tile--linked"
@@ -104,7 +106,7 @@ exports[`Frontend.Project.Events component renders correctly 1`] = `
             </div>
           </div>
           <div
-            className="event-list-primary__item"
+            className="event-list__item"
           >
             <div
               className="event-tile event-tile--linked"
@@ -154,130 +156,134 @@ exports[`Frontend.Project.Events component renders correctly 1`] = `
             </div>
           </div>
         </ul>
-        <nav
-          className="list-pagination"
+        <div
+          className="entity-section-wrapper__pagination"
         >
-          <ul
-            className="list-pagination__columns"
+          <nav
+            className="list-pagination"
           >
-            <li
-              className="list-pagination__column"
+            <ul
+              className="list-pagination__columns"
             >
-              <ul>
-                <li
-                  className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
-                >
-                  <a
-                    disabled={true}
-                    href="/projects/slug-1/events/0"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--arrowLongLeft16"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 16"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                        transform="rotate(180 12 8)"
-                      />
-                    </svg>
-                    <span
-                      className="list-pagination__icon-label"
-                    >
-                      PREV
-                    </span>
-                  </a>
-                </li>
-              </ul>
-            </li>
-            <li
-              className="list-pagination__column-middle"
-            >
-              <ul
-                className="list-pagination__pages"
+              <li
+                className="list-pagination__column"
               >
-                <li
-                  className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
-                >
-                  <a
-                    href="/projects/slug-1/events/1"
-                    onClick={[Function]}
+                <ul>
+                  <li
+                    className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
                   >
-                    <span
-                      aria-hidden="true"
+                    <a
+                      disabled={true}
+                      href="/projects/slug-1/events/0"
+                      onClick={[Function]}
                     >
-                      1
-                    </span>
-                    <span
-                      className="screen-reader-text"
-                    >
-                      Go to page: 
-                      1
-                    </span>
-                  </a>
-                </li>
-                <li
-                  className="list-pagination__page list-pagination__page--ordinal"
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--arrowLongLeft16"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 16"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                          transform="rotate(180 12 8)"
+                        />
+                      </svg>
+                      <span
+                        className="list-pagination__icon-label"
+                      >
+                        PREV
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+              <li
+                className="list-pagination__column-middle"
+              >
+                <ul
+                  className="list-pagination__pages"
                 >
-                  <a
-                    href="/projects/slug-1/events/2"
-                    onClick={[Function]}
+                  <li
+                    className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                   >
-                    <span
-                      aria-hidden="true"
+                    <a
+                      href="/projects/slug-1/events/1"
+                      onClick={[Function]}
                     >
-                      2
-                    </span>
-                    <span
-                      className="screen-reader-text"
-                    >
-                      Go to page: 
-                      2
-                    </span>
-                  </a>
-                </li>
-              </ul>
-            </li>
-            <li
-              className="list-pagination__column"
-            >
-              <ul>
-                <li
-                  className="list-pagination__page list-pagination__page--next"
-                >
-                  <a
-                    href="/projects/slug-1/events/2"
-                    onClick={[Function]}
+                      <span
+                        aria-hidden="true"
+                      >
+                        1
+                      </span>
+                      <span
+                        className="screen-reader-text"
+                      >
+                        Go to page: 
+                        1
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    className="list-pagination__page list-pagination__page--ordinal"
                   >
-                    <span
-                      className="list-pagination__icon-label"
+                    <a
+                      href="/projects/slug-1/events/2"
+                      onClick={[Function]}
                     >
-                      NEXT
-                    </span>
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--arrowLongRight16"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 16"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
+                      <span
+                        aria-hidden="true"
+                      >
+                        2
+                      </span>
+                      <span
+                        className="screen-reader-text"
+                      >
+                        Go to page: 
+                        2
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+              <li
+                className="list-pagination__column"
+              >
+                <ul>
+                  <li
+                    className="list-pagination__page list-pagination__page--next"
+                  >
+                    <a
+                      href="/projects/slug-1/events/2"
+                      onClick={[Function]}
                     >
-                      <path
-                        d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                      />
-                    </svg>
-                  </a>
-                </li>
-              </ul>
-            </li>
-          </ul>
-        </nav>
+                      <span
+                        className="list-pagination__icon-label"
+                      >
+                        NEXT
+                      </span>
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--arrowLongRight16"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 16"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                        />
+                      </svg>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </nav>
+        </div>
       </div>
     </div>
   </section>

--- a/client/src/frontend/containers/EventList/__tests__/__snapshots__/EventList-test.js.snap
+++ b/client/src/frontend/containers/EventList/__tests__/__snapshots__/EventList-test.js.snap
@@ -26,10 +26,10 @@ exports[`Frontend EventList Container renders correctly 1`] = `
   </section>
   <section>
     <div
-      className="container"
+      className="container entity-section-wrapper"
     >
       <header
-        className="section-heading"
+        className="section-heading entity-section-wrapper__heading"
       >
         <div
           className="main"
@@ -49,12 +49,14 @@ exports[`Frontend EventList Container renders correctly 1`] = `
           </div>
         </div>
       </header>
-      <div>
+      <div
+        className="entity-section-wrapper__body"
+      >
         <ul
-          className="event-list-primary"
+          className="event-list"
         >
           <div
-            className="event-list-primary__item"
+            className="event-list__item"
           >
             <div
               className="event-tile event-tile--linked"
@@ -104,7 +106,7 @@ exports[`Frontend EventList Container renders correctly 1`] = `
             </div>
           </div>
           <div
-            className="event-list-primary__item"
+            className="event-list__item"
           >
             <div
               className="event-tile event-tile--linked"
@@ -154,130 +156,134 @@ exports[`Frontend EventList Container renders correctly 1`] = `
             </div>
           </div>
         </ul>
-        <nav
-          className="list-pagination"
+        <div
+          className="entity-section-wrapper__pagination"
         >
-          <ul
-            className="list-pagination__columns"
+          <nav
+            className="list-pagination"
           >
-            <li
-              className="list-pagination__column"
+            <ul
+              className="list-pagination__columns"
             >
-              <ul>
-                <li
-                  className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
-                >
-                  <a
-                    disabled={true}
-                    href="/projects/slug-1/events/0"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--arrowLongLeft16"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 16"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                        transform="rotate(180 12 8)"
-                      />
-                    </svg>
-                    <span
-                      className="list-pagination__icon-label"
-                    >
-                      PREV
-                    </span>
-                  </a>
-                </li>
-              </ul>
-            </li>
-            <li
-              className="list-pagination__column-middle"
-            >
-              <ul
-                className="list-pagination__pages"
+              <li
+                className="list-pagination__column"
               >
-                <li
-                  className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
-                >
-                  <a
-                    href="/projects/slug-1/events/1"
-                    onClick={[Function]}
+                <ul>
+                  <li
+                    className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
                   >
-                    <span
-                      aria-hidden="true"
+                    <a
+                      disabled={true}
+                      href="/projects/slug-1/events/0"
+                      onClick={[Function]}
                     >
-                      1
-                    </span>
-                    <span
-                      className="screen-reader-text"
-                    >
-                      Go to page: 
-                      1
-                    </span>
-                  </a>
-                </li>
-                <li
-                  className="list-pagination__page list-pagination__page--ordinal"
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--arrowLongLeft16"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 16"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                          transform="rotate(180 12 8)"
+                        />
+                      </svg>
+                      <span
+                        className="list-pagination__icon-label"
+                      >
+                        PREV
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+              <li
+                className="list-pagination__column-middle"
+              >
+                <ul
+                  className="list-pagination__pages"
                 >
-                  <a
-                    href="/projects/slug-1/events/2"
-                    onClick={[Function]}
+                  <li
+                    className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                   >
-                    <span
-                      aria-hidden="true"
+                    <a
+                      href="/projects/slug-1/events/1"
+                      onClick={[Function]}
                     >
-                      2
-                    </span>
-                    <span
-                      className="screen-reader-text"
-                    >
-                      Go to page: 
-                      2
-                    </span>
-                  </a>
-                </li>
-              </ul>
-            </li>
-            <li
-              className="list-pagination__column"
-            >
-              <ul>
-                <li
-                  className="list-pagination__page list-pagination__page--next"
-                >
-                  <a
-                    href="/projects/slug-1/events/2"
-                    onClick={[Function]}
+                      <span
+                        aria-hidden="true"
+                      >
+                        1
+                      </span>
+                      <span
+                        className="screen-reader-text"
+                      >
+                        Go to page: 
+                        1
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    className="list-pagination__page list-pagination__page--ordinal"
                   >
-                    <span
-                      className="list-pagination__icon-label"
+                    <a
+                      href="/projects/slug-1/events/2"
+                      onClick={[Function]}
                     >
-                      NEXT
-                    </span>
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--arrowLongRight16"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 16"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
+                      <span
+                        aria-hidden="true"
+                      >
+                        2
+                      </span>
+                      <span
+                        className="screen-reader-text"
+                      >
+                        Go to page: 
+                        2
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+              <li
+                className="list-pagination__column"
+              >
+                <ul>
+                  <li
+                    className="list-pagination__page list-pagination__page--next"
+                  >
+                    <a
+                      href="/projects/slug-1/events/2"
+                      onClick={[Function]}
                     >
-                      <path
-                        d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                      />
-                    </svg>
-                  </a>
-                </li>
-              </ul>
-            </li>
-          </ul>
-        </nav>
+                      <span
+                        className="list-pagination__icon-label"
+                      >
+                        NEXT
+                      </span>
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--arrowLongRight16"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 16"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                        />
+                      </svg>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </nav>
+        </div>
       </div>
     </div>
   </section>

--- a/client/src/theme/styles/components/frontend/event/_events.scss
+++ b/client/src/theme/styles/components/frontend/event/_events.scss
@@ -1,40 +1,4 @@
-// <ul>
-.event-list-primary {
-  @include listUnstyled;
-  display: flex;
-  flex-wrap: wrap;
-  padding-top: 20px;
-
-  @include respond($break60) {
-    padding-top: 39px;
-  }
-
-  @include respond($break60) {
-    margin-left: -40px;
-  }
-
-  li {
-    display: flex;
-    width: 100%;
-
-    @include respond($break60) {
-      width: 50%;
-      min-height: 170px;
-      padding-left: 40px;
-      margin-bottom: 28px;
-    }
-
-    + li {
-      border-top: 2px solid $neutral20;
-
-      @include respond($break60) {
-        border: 0;
-      }
-    }
-  }
-}
-
-.event-list-secondary {
+.event-list {
   @include listUnstyled;
   display: flex;
   flex-flow: row wrap;
@@ -93,14 +57,5 @@
         display: flex;
       }
     }
-  }
-}
-
-// List styles that apply to either type of list
-.event-list-primary li, .event-list-secondary li {
-  padding-bottom: 20px;
-
-  @include respond($break60) {
-    padding-bottom: 0;
   }
 }


### PR DESCRIPTION
This PR simplifies frontend event tile lists with a single "event-list" class. This also fixes a bug where the layout for "event-list-primary" was broken.