### PR TITLE
[C] Address resource collection rename in migrations

### DIFF
--- a/api/config/initializers/55_shrine.rb
+++ b/api/config/initializers/55_shrine.rb
@@ -1,7 +1,6 @@
 require "shrine/storage/file_system"
 require "shrine/storage/memory"
 require "shrine/storage/tus"
-require Rails.root.join "lib", "paperclip_migrator"
 
 Shrine.storages = {
   cache: Shrine::Storage::FileSystem.new("public", prefix: "system/cache"),

--- a/api/db/migrate/20181025181234_migrate_existing_attachments_to_shrine.rb
+++ b/api/db/migrate/20181025181234_migrate_existing_attachments_to_shrine.rb
@@ -1,3 +1,5 @@
+require Rails.root.join "lib", "paperclip_migrator"
+
 using Refinements::HandleRenamedCollections
 
 class MigrateExistingAttachmentsToShrine < ActiveRecord::Migration[5.0]
@@ -43,7 +45,7 @@ class MigrateExistingAttachmentsToShrine < ActiveRecord::Migration[5.0]
             say_with_time "Restoring #{klass}##{attachment.to_s} paperclip columns" do
               %w(file_name content_type file_size updated_at).each do |suffix|
                 column_name = "#{attachment}_#{suffix}"
-                rename_column klass.underscore.pluralize.to_sym, "#{column_name}_deprecated".to_sym, column_name.to_sym
+                rename_column klass.constantize.table_name, "#{column_name}_deprecated".to_sym, column_name.to_sym
               end
             end
           end

--- a/api/lib/paperclip_migrator.rb
+++ b/api/lib/paperclip_migrator.rb
@@ -1,3 +1,4 @@
+using Refinements::HandleRenamedCollections
 # The primary entry point for this subsystem is {PaperclipMigrator.migrate_all!}.
 #
 # Its intention is to divorce all dependencies on Paperclip itself so that migrations


### PR DESCRIPTION
Upgrading from v2.0.x to v3.0.x was failing because the refinment to
ResourceCollections that we wrote wasn't being properly applied to
the PaperclipMigrator class. This all stemmed from an effort to make
our migrations backwards compatible after renaming the Collection model
to ResourceCollection.

Resolves #2148