### PR TITLE
[B] Fix citations not being generated on children

### DIFF
--- a/api/app/models/concerns/citable.rb
+++ b/api/app/models/concerns/citable.rb
@@ -40,7 +40,7 @@ module Citable
   end
 
   def update_citable_children
-    return unless citations != citations_was
+    return unless previous_changes.key?(:citations)
 
     UpdateCitatableChildren.perform_later(self)
   end


### PR DESCRIPTION
This was a regression introduced in 96c9e76.  Since the callback for
`update_citable_children` was moved into `after_commit` the comparison
of `citations` to `citations_was` always returned true.  This commit adjusts
that check to see if the previous changes to a record include `:citations`.  If so,
we know that the parent citations changed and can run the children update.

Fixes #2057