### PR TITLE
[R] Improve a11y of radio groups

### DIFF
--- a/client/src/backend/components/content-block/TypeForm/types/__tests__/__snapshots__/Markdown-test.js.snap
+++ b/client/src/backend/components/content-block/TypeForm/types/__tests__/__snapshots__/Markdown-test.js.snap
@@ -32,51 +32,60 @@ Array [
     className="form-input form-input-radios extra-space-bottom wide"
     style={Object {}}
   >
-    <label
-      htmlFor="radios-1"
+    <fieldset
+      className="form-input-radios__wrapper"
     >
-      Style
-    </label>
-    <label
-      className="form-toggle radio inline"
-    >
-      <input
-        checked={false}
-        name="Normal"
-        onChange={[Function]}
-        type="radio"
-        value="normal"
-      />
-      <span
-        aria-hidden="true"
-        className="toggle-indicator"
-      />
-      <span
-        className="toggle-label"
+      <legend
+        className="form-input-radios__legend"
       >
-        Normal
-      </span>
-    </label>
-    <label
-      className="form-toggle radio inline"
-    >
-      <input
-        checked={false}
-        name="Shaded"
-        onChange={[Function]}
-        type="radio"
-        value="shaded"
-      />
-      <span
-        aria-hidden="true"
-        className="toggle-indicator"
-      />
-      <span
-        className="toggle-label"
+        <span
+          aria-hidden={true}
+          className="form-input-radios__title"
+        >
+          Style
+        </span>
+      </legend>
+      <label
+        className="form-toggle radio inline"
       >
-        Shaded
-      </span>
-    </label>
+        <input
+          checked={false}
+          name="Normal"
+          onChange={[Function]}
+          type="radio"
+          value="normal"
+        />
+        <span
+          aria-hidden="true"
+          className="toggle-indicator"
+        />
+        <span
+          className="toggle-label"
+        >
+          Normal
+        </span>
+      </label>
+      <label
+        className="form-toggle radio inline"
+      >
+        <input
+          checked={false}
+          name="Shaded"
+          onChange={[Function]}
+          type="radio"
+          value="shaded"
+        />
+        <span
+          aria-hidden="true"
+          className="toggle-indicator"
+        />
+        <span
+          className="toggle-label"
+        >
+          Shaded
+        </span>
+      </label>
+    </fieldset>
   </div>,
 ]
 `;

--- a/client/src/backend/components/form/Radio/Label.js
+++ b/client/src/backend/components/form/Radio/Label.js
@@ -5,8 +5,7 @@ export default class FormRadioLabel extends Component {
   static displayName = "Form.Radio.Label";
 
   static propTypes = {
-    id: PropTypes.string.isRequired,
-    label: PropTypes.string,
+    label: PropTypes.string.isRequired,
     prompt: PropTypes.string
   };
 
@@ -20,12 +19,16 @@ export default class FormRadioLabel extends Component {
 
   render() {
     return (
-      <React.Fragment>
-        {this.label && <label htmlFor={this.props.id}>{this.label}</label>}
+      <legend className="form-input-radios__legend">
+        {this.label && (
+          <span className="form-input-radios__title" aria-hidden>
+            {this.label}
+          </span>
+        )}
         {this.prompt && (
           <span className="form-input-radios__prompt">{this.prompt}</span>
         )}
-      </React.Fragment>
+      </legend>
     );
   }
 }

--- a/client/src/backend/components/form/Radios.js
+++ b/client/src/backend/components/form/Radios.js
@@ -74,21 +74,22 @@ class FormRadios extends Component {
         label={this.props.label}
         idForError={this.props.idForError}
       >
-        <RadioLabel
-          id={this.props.id}
-          label={this.props.label}
-          prompt={this.props.prompt}
-          hasInstructions={isString(this.props.instructions)}
-        />
-        <Instructions instructions={this.props.instructions} />
-        {this.options.map((option, index) => (
-          <Option
-            key={`${this.props.id}-${option.internalValue}`}
-            option={option}
-            focusOnMount={this.focusOnMount && index === 0}
-            {...this.optionProps}
+        <fieldset className="form-input-radios__wrapper">
+          <RadioLabel
+            label={this.props.label}
+            prompt={this.props.prompt}
+            hasInstructions={isString(this.props.instructions)}
           />
-        ))}
+          <Instructions instructions={this.props.instructions} />
+          {this.options.map((option, index) => (
+            <Option
+              key={`${this.props.id}-${option.internalValue}`}
+              option={option}
+              focusOnMount={this.focusOnMount && index === 0}
+              {...this.optionProps}
+            />
+          ))}
+        </fieldset>
       </GlobalForm.Errorable>
     );
   }

--- a/client/src/backend/components/form/__tests__/__snapshots__/Radios-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/Radios-test.js.snap
@@ -5,60 +5,69 @@ exports[`Backend.Form.Radios component renders correctly 1`] = `
   className="form-input form-input-radios extra-space-bottom"
   style={Object {}}
 >
-  <label
-    htmlFor="radios-1"
+  <fieldset
+    className="form-input-radios__wrapper"
   >
-    Label this
-  </label>
-  <span
-    className="form-input-radios__prompt"
-  >
-    Pick the right choice
-  </span>
-  <label
-    className="form-toggle radio"
-  >
-    <input
-      checked={false}
-      name="option-1"
-      onChange={[Function]}
-      type="radio"
-      value="1"
-    />
-    <span
-      aria-hidden="true"
-      className="toggle-indicator"
-    />
-    <span
-      className="toggle-label"
+    <legend
+      className="form-input-radios__legend"
     >
-      option-1
-    </span>
-  </label>
-  <span
-    className="toggle-instructions"
-  >
-    What does this option really mean?
-  </span>
-  <label
-    className="form-toggle radio"
-  >
-    <input
-      checked={false}
-      name="option-2"
-      onChange={[Function]}
-      type="radio"
-      value="2"
-    />
-    <span
-      aria-hidden="true"
-      className="toggle-indicator"
-    />
-    <span
-      className="toggle-label"
+      <span
+        aria-hidden={true}
+        className="form-input-radios__title"
+      >
+        Label this
+      </span>
+      <span
+        className="form-input-radios__prompt"
+      >
+        Pick the right choice
+      </span>
+    </legend>
+    <label
+      className="form-toggle radio"
     >
-      option-2
+      <input
+        checked={false}
+        name="option-1"
+        onChange={[Function]}
+        type="radio"
+        value="1"
+      />
+      <span
+        aria-hidden="true"
+        className="toggle-indicator"
+      />
+      <span
+        className="toggle-label"
+      >
+        option-1
+      </span>
+    </label>
+    <span
+      className="toggle-instructions"
+    >
+      What does this option really mean?
     </span>
-  </label>
+    <label
+      className="form-toggle radio"
+    >
+      <input
+        checked={false}
+        name="option-2"
+        onChange={[Function]}
+        type="radio"
+        value="2"
+      />
+      <span
+        aria-hidden="true"
+        className="toggle-indicator"
+      />
+      <span
+        className="toggle-label"
+      >
+        option-2
+      </span>
+    </label>
+  </fieldset>
 </div>
 `;

--- a/client/src/backend/containers/project/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/New-test.js.snap
@@ -248,241 +248,277 @@ exports[`Backend Project New Container renders correctly 1`] = `
                   className="form-input form-input-radios extra-space-bottom wide"
                   style={Object {}}
                 >
-                  <label
-                    htmlFor="radios-1"
+                  <fieldset
+                    className="form-input-radios__wrapper"
                   >
-                    Texts
-                  </label>
-                  <span
-                    className="form-input-radios__prompt"
-                  >
-                    Will your project include more than one text?
-                  </span>
-                  <span
-                    className="instructions"
-                  >
-                    Manifold projects can include a single text or multiple texts.
-                  </span>
-                  <label
-                    className="form-toggle radio checked inline"
-                  >
-                    <input
-                      checked={true}
-                      name="Yes"
-                      onChange={[Function]}
-                      type="radio"
-                      value={true}
-                    />
-                    <span
-                      aria-hidden="true"
-                      className="toggle-indicator"
-                    />
-                    <span
-                      className="toggle-label"
+                    <legend
+                      className="form-input-radios__legend"
                     >
-                      Yes
-                    </span>
-                  </label>
-                  <label
-                    className="form-toggle radio inline"
-                  >
-                    <input
-                      checked={false}
-                      name="No"
-                      onChange={[Function]}
-                      type="radio"
-                      value=""
-                    />
+                      <span
+                        aria-hidden={true}
+                        className="form-input-radios__title"
+                      >
+                        Texts
+                      </span>
+                      <span
+                        className="form-input-radios__prompt"
+                      >
+                        Will your project include more than one text?
+                      </span>
+                    </legend>
                     <span
-                      aria-hidden="true"
-                      className="toggle-indicator"
-                    />
-                    <span
-                      className="toggle-label"
+                      className="instructions"
                     >
-                      No
+                      Manifold projects can include a single text or multiple texts.
                     </span>
-                  </label>
+                    <label
+                      className="form-toggle radio checked inline"
+                    >
+                      <input
+                        checked={true}
+                        name="Yes"
+                        onChange={[Function]}
+                        type="radio"
+                        value={true}
+                      />
+                      <span
+                        aria-hidden="true"
+                        className="toggle-indicator"
+                      />
+                      <span
+                        className="toggle-label"
+                      >
+                        Yes
+                      </span>
+                    </label>
+                    <label
+                      className="form-toggle radio inline"
+                    >
+                      <input
+                        checked={false}
+                        name="No"
+                        onChange={[Function]}
+                        type="radio"
+                        value=""
+                      />
+                      <span
+                        aria-hidden="true"
+                        className="toggle-indicator"
+                      />
+                      <span
+                        className="toggle-label"
+                      >
+                        No
+                      </span>
+                    </label>
+                  </fieldset>
                 </div>
                 <div
                   className="form-input form-input-radios extra-space-bottom wide"
                   style={Object {}}
                 >
-                  <label
-                    htmlFor="radios-1"
+                  <fieldset
+                    className="form-input-radios__wrapper"
                   >
-                    Resources
-                  </label>
-                  <span
-                    className="form-input-radios__prompt"
-                  >
-                    Do you have resources you want to add in addition to any texts you are loading?
-                  </span>
-                  <span
-                    className="instructions"
-                  >
-                    Enhance your texts with media or create a project composed only of media resources.
-                  </span>
-                  <label
-                    className="form-toggle radio checked inline"
-                  >
-                    <input
-                      checked={true}
-                      name="Yes"
-                      onChange={[Function]}
-                      type="radio"
-                      value={true}
-                    />
-                    <span
-                      aria-hidden="true"
-                      className="toggle-indicator"
-                    />
-                    <span
-                      className="toggle-label"
+                    <legend
+                      className="form-input-radios__legend"
                     >
-                      Yes
-                    </span>
-                  </label>
-                  <label
-                    className="form-toggle radio inline"
-                  >
-                    <input
-                      checked={false}
-                      name="No"
-                      onChange={[Function]}
-                      type="radio"
-                      value=""
-                    />
+                      <span
+                        aria-hidden={true}
+                        className="form-input-radios__title"
+                      >
+                        Resources
+                      </span>
+                      <span
+                        className="form-input-radios__prompt"
+                      >
+                        Do you have resources you want to add in addition to any texts you are loading?
+                      </span>
+                    </legend>
                     <span
-                      aria-hidden="true"
-                      className="toggle-indicator"
-                    />
-                    <span
-                      className="toggle-label"
+                      className="instructions"
                     >
-                      No
+                      Enhance your texts with media or create a project composed only of media resources.
                     </span>
-                  </label>
+                    <label
+                      className="form-toggle radio checked inline"
+                    >
+                      <input
+                        checked={true}
+                        name="Yes"
+                        onChange={[Function]}
+                        type="radio"
+                        value={true}
+                      />
+                      <span
+                        aria-hidden="true"
+                        className="toggle-indicator"
+                      />
+                      <span
+                        className="toggle-label"
+                      >
+                        Yes
+                      </span>
+                    </label>
+                    <label
+                      className="form-toggle radio inline"
+                    >
+                      <input
+                        checked={false}
+                        name="No"
+                        onChange={[Function]}
+                        type="radio"
+                        value=""
+                      />
+                      <span
+                        aria-hidden="true"
+                        className="toggle-indicator"
+                      />
+                      <span
+                        className="toggle-label"
+                      >
+                        No
+                      </span>
+                    </label>
+                  </fieldset>
                 </div>
                 <div
                   className="form-input form-input-radios extra-space-bottom wide"
                   style={Object {}}
                 >
-                  <label
-                    htmlFor="radios-1"
+                  <fieldset
+                    className="form-input-radios__wrapper"
                   >
-                    Extended Description
-                  </label>
-                  <span
-                    className="form-input-radios__prompt"
-                  >
-                    Do you need additional space to describe your project?
-                  </span>
-                  <span
-                    className="instructions"
-                  >
-                    A freeform content block can be used to add text contextualizing your project.
-                  </span>
-                  <label
-                    className="form-toggle radio checked inline"
-                  >
-                    <input
-                      checked={true}
-                      name="Yes"
-                      onChange={[Function]}
-                      type="radio"
-                      value={true}
-                    />
-                    <span
-                      aria-hidden="true"
-                      className="toggle-indicator"
-                    />
-                    <span
-                      className="toggle-label"
+                    <legend
+                      className="form-input-radios__legend"
                     >
-                      Yes
-                    </span>
-                  </label>
-                  <label
-                    className="form-toggle radio inline"
-                  >
-                    <input
-                      checked={false}
-                      name="No"
-                      onChange={[Function]}
-                      type="radio"
-                      value=""
-                    />
+                      <span
+                        aria-hidden={true}
+                        className="form-input-radios__title"
+                      >
+                        Extended Description
+                      </span>
+                      <span
+                        className="form-input-radios__prompt"
+                      >
+                        Do you need additional space to describe your project?
+                      </span>
+                    </legend>
                     <span
-                      aria-hidden="true"
-                      className="toggle-indicator"
-                    />
-                    <span
-                      className="toggle-label"
+                      className="instructions"
                     >
-                      No
+                      A freeform content block can be used to add text contextualizing your project.
                     </span>
-                  </label>
+                    <label
+                      className="form-toggle radio checked inline"
+                    >
+                      <input
+                        checked={true}
+                        name="Yes"
+                        onChange={[Function]}
+                        type="radio"
+                        value={true}
+                      />
+                      <span
+                        aria-hidden="true"
+                        className="toggle-indicator"
+                      />
+                      <span
+                        className="toggle-label"
+                      >
+                        Yes
+                      </span>
+                    </label>
+                    <label
+                      className="form-toggle radio inline"
+                    >
+                      <input
+                        checked={false}
+                        name="No"
+                        onChange={[Function]}
+                        type="radio"
+                        value=""
+                      />
+                      <span
+                        aria-hidden="true"
+                        className="toggle-indicator"
+                      />
+                      <span
+                        className="toggle-label"
+                      >
+                        No
+                      </span>
+                    </label>
+                  </fieldset>
                 </div>
                 <div
                   className="form-input form-input-radios extra-space-bottom wide"
                   style={Object {}}
                 >
-                  <label
-                    htmlFor="radios-1"
+                  <fieldset
+                    className="form-input-radios__wrapper"
                   >
-                    Activity
-                  </label>
-                  <span
-                    className="form-input-radios__prompt"
-                  >
-                    Will your project change frequently?
-                  </span>
-                  <span
-                    className="instructions"
-                  >
-                    Manifold can showcase the evolution of your project on the platform and in the Twitterverse.
-                  </span>
-                  <label
-                    className="form-toggle radio checked inline"
-                  >
-                    <input
-                      checked={true}
-                      name="Yes"
-                      onChange={[Function]}
-                      type="radio"
-                      value={true}
-                    />
-                    <span
-                      aria-hidden="true"
-                      className="toggle-indicator"
-                    />
-                    <span
-                      className="toggle-label"
+                    <legend
+                      className="form-input-radios__legend"
                     >
-                      Yes
-                    </span>
-                  </label>
-                  <label
-                    className="form-toggle radio inline"
-                  >
-                    <input
-                      checked={false}
-                      name="No"
-                      onChange={[Function]}
-                      type="radio"
-                      value=""
-                    />
+                      <span
+                        aria-hidden={true}
+                        className="form-input-radios__title"
+                      >
+                        Activity
+                      </span>
+                      <span
+                        className="form-input-radios__prompt"
+                      >
+                        Will your project change frequently?
+                      </span>
+                    </legend>
                     <span
-                      aria-hidden="true"
-                      className="toggle-indicator"
-                    />
-                    <span
-                      className="toggle-label"
+                      className="instructions"
                     >
-                      No
+                      Manifold can showcase the evolution of your project on the platform and in the Twitterverse.
                     </span>
-                  </label>
+                    <label
+                      className="form-toggle radio checked inline"
+                    >
+                      <input
+                        checked={true}
+                        name="Yes"
+                        onChange={[Function]}
+                        type="radio"
+                        value={true}
+                      />
+                      <span
+                        aria-hidden="true"
+                        className="toggle-indicator"
+                      />
+                      <span
+                        className="toggle-label"
+                      >
+                        Yes
+                      </span>
+                    </label>
+                    <label
+                      className="form-toggle radio inline"
+                    >
+                      <input
+                        checked={false}
+                        name="No"
+                        onChange={[Function]}
+                        type="radio"
+                        value=""
+                      />
+                      <span
+                        aria-hidden="true"
+                        className="toggle-indicator"
+                      />
+                      <span
+                        className="toggle-label"
+                      >
+                        No
+                      </span>
+                    </label>
+                  </fieldset>
                 </div>
               </div>
             </div>

--- a/client/src/frontend/containers/Subscriptions/__tests__/__snapshots__/Subscriptions-test.js.snap
+++ b/client/src/frontend/containers/Subscriptions/__tests__/__snapshots__/Subscriptions-test.js.snap
@@ -44,17 +44,14 @@ exports[`Frontend Subscriptions Container renders correctly 1`] = `
             resources, and resource collections that have been added to projects.
             </span>
           </div>
-          <div
-            className="form-input"
+          <fieldset
+            className="subscriptions__radio-group form-input"
           >
-            <label
-              htmlFor="digest"
+            <legend
+              className="subscriptions__legend"
             >
               How often would you like to be notified?
-            </label>
-            <span
-              className="instructions"
-            />
+            </legend>
             <label
               className="form-toggle radio inline"
             >
@@ -116,7 +113,7 @@ exports[`Frontend Subscriptions Container renders correctly 1`] = `
                 Weekly
               </span>
             </label>
-          </div>
+          </fieldset>
         </div>
         <h3
           className="section-heading-secondary"
@@ -126,14 +123,14 @@ exports[`Frontend Subscriptions Container renders correctly 1`] = `
         <div
           className="form-group"
         >
-          <div
-            className="form-input"
+          <fieldset
+            className="subscriptions__radio-group form-input"
           >
-            <label
-              htmlFor="repliesToMe"
+            <legend
+              className="subscriptions__legend"
             >
               Notify you when someone replies to you?
-            </label>
+            </legend>
             <span
               className="instructions"
             >
@@ -181,7 +178,7 @@ exports[`Frontend Subscriptions Container renders correctly 1`] = `
                 Yes
               </span>
             </label>
-          </div>
+          </fieldset>
         </div>
         <button
           className="utility-button"

--- a/client/src/global/components/preferences/NotificationsForm.js
+++ b/client/src/global/components/preferences/NotificationsForm.js
@@ -12,6 +12,10 @@ export default class NotificationsForm extends Component {
     unsubscribeAllHandler: PropTypes.func.isRequired
   };
 
+  get defaultOptions() {
+    return { never: "No", always: "Yes" };
+  }
+
   renderNotificationSettings(preferences) {
     const digestOpen = preferences.digest !== "never";
 
@@ -27,7 +31,7 @@ export default class NotificationsForm extends Component {
           </div>
           {this.renderDigestFrequency(preferences)}
           <Collapse isOpened={digestOpen}>
-            {this.renderDigestContent(preferences)}
+            {this.renderDigestContent(preferences, digestOpen)}
           </Collapse>
         </div>
         <h3 className="section-heading-secondary">Other Activity</h3>
@@ -46,7 +50,7 @@ export default class NotificationsForm extends Component {
     );
   }
 
-  renderDigestContent(preferences) {
+  renderDigestContent(preferences, digestOpen) {
     const items = config.app.locale.notificationPreferences.digest;
 
     const options = [
@@ -57,10 +61,14 @@ export default class NotificationsForm extends Component {
 
     return (
       <React.Fragment>
-        <div className="form-input" key="digest-projects">
-          <label htmlFor="digest-projects">
+        <fieldset
+          className="subscriptions__radio-group form-input"
+          key="digest-projects"
+          disabled={!digestOpen}
+        >
+          <legend className="subscriptions__legend">
             Which projects should be included?
-          </label>
+          </legend>
           {options.map(option => {
             const checked = preferences[option.key] === "always";
             const inputClassNames = classNames(
@@ -90,11 +98,16 @@ export default class NotificationsForm extends Component {
               </label>
             );
           })}
-        </div>
+        </fieldset>
 
         {items.map(item => {
           const checked = preferences[item.key];
-          return this.renderContentOption(item, checked);
+          return this.renderContentOption(
+            item,
+            checked,
+            this.defaultOptions,
+            !digestOpen
+          );
         })}
       </React.Fragment>
     );
@@ -122,14 +135,21 @@ export default class NotificationsForm extends Component {
   renderContentOption(
     preference,
     value,
-    options = { never: "No", always: "Yes" }
+    options = this.defaultOptions,
+    disabled
   ) {
     if (!preference || !value) return null;
 
     return (
-      <div className="form-input" key={preference.key}>
-        <label htmlFor={preference.key}>{preference.label}</label>
-        <span className="instructions">{preference.instructions}</span>
+      <fieldset
+        className="subscriptions__radio-group form-input"
+        key={preference.key}
+        disabled={disabled}
+      >
+        <legend className="subscriptions__legend">{preference.label}</legend>
+        {preference.instructions && (
+          <span className="instructions">{preference.instructions}</span>
+        )}
         {Object.keys(options).map(option => {
           const checked = value === option;
           const inputClassNames = classNames("form-toggle", "radio", "inline", {
@@ -155,7 +175,7 @@ export default class NotificationsForm extends Component {
             </label>
           );
         })}
-      </div>
+      </fieldset>
     );
   }
 

--- a/client/src/global/components/preferences/__tests__/__snapshots__/NotificationsForm-test.js.snap
+++ b/client/src/global/components/preferences/__tests__/__snapshots__/NotificationsForm-test.js.snap
@@ -22,17 +22,14 @@ exports[`Global.Preferences.NotificationsForm component renders correctly 1`] = 
             resources, and resource collections that have been added to projects.
       </span>
     </div>
-    <div
-      className="form-input"
+    <fieldset
+      className="subscriptions__radio-group form-input"
     >
-      <label
-        htmlFor="digest"
+      <legend
+        className="subscriptions__legend"
       >
         How often would you like to be notified?
-      </label>
-      <span
-        className="instructions"
-      />
+      </legend>
       <label
         className="form-toggle radio inline"
       >
@@ -94,7 +91,7 @@ exports[`Global.Preferences.NotificationsForm component renders correctly 1`] = 
           Weekly
         </span>
       </label>
-    </div>
+    </fieldset>
   </div>
   <h3
     className="section-heading-secondary"
@@ -104,14 +101,14 @@ exports[`Global.Preferences.NotificationsForm component renders correctly 1`] = 
   <div
     className="form-group"
   >
-    <div
-      className="form-input"
+    <fieldset
+      className="subscriptions__radio-group form-input"
     >
-      <label
-        htmlFor="repliesToMe"
+      <legend
+        className="subscriptions__legend"
       >
         Notify you when someone replies to you?
-      </label>
+      </legend>
       <span
         className="instructions"
       >
@@ -159,7 +156,7 @@ exports[`Global.Preferences.NotificationsForm component renders correctly 1`] = 
           Yes
         </span>
       </label>
-    </div>
+    </fieldset>
   </div>
   <button
     className="utility-button"

--- a/client/src/theme/styles/components/frontend/subscriptions/_subscriptions.scss
+++ b/client/src/theme/styles/components/frontend/subscriptions/_subscriptions.scss
@@ -45,6 +45,25 @@
     }
   }
 
+  &__legend,
+  &__radio-group {
+    padding: 0;
+    margin: 0;
+    border: none;
+  }
+
+  &__legend {
+    @include formLabelPrimary;
+    display: block;
+    margin-bottom: 1em;
+    font-size: 14px;
+    color: $neutral50;
+
+    + .form-toggle {
+      margin-top: 4px;
+    }
+  }
+
   .sign-in-up-update & {
     width: auto;
     margin-top: 50px;

--- a/client/src/theme/styles/components/global/forms/_form-inputs-primary.scss
+++ b/client/src/theme/styles/components/global/forms/_form-inputs-primary.scss
@@ -117,10 +117,24 @@
   }
 
   & &-radios {
-    label {
-      + .form-input-radios__prompt {
-        margin-top: 16px;
+    &__wrapper,
+    &__legend {
+      padding: 0;
+      margin: 0;
+      border: none;
+    }
+
+    &__legend {
+      + .instructions {
+        margin-top: 7px;
       }
+    }
+
+    &__title {
+      @include formLabelPrimary;
+      display: inline-block;
+      margin-bottom: 1em;
+      color: $neutral70;
     }
 
     &__prompt {
@@ -131,10 +145,6 @@
       color: $neutral30;
       text-transform: none;
       letter-spacing: 0;
-
-      + .instructions {
-        margin-top: 7px;
-      }
     }
   }
 


### PR DESCRIPTION
* Refactors markup to use `fieldset` and `legend` elements. This establishes connected inputs as radio groups and creates an association between groups and their caption/question.
* Sets `disabled` attribute on collapsed input groups.

Resolves #2195