### PR TITLE
[R] Improve usage of headings & landmarks

### DIFF
--- a/client/src/backend/components/category/List/Category.js
+++ b/client/src/backend/components/category/List/Category.js
@@ -66,12 +66,12 @@ export default class CategoryListCategory extends PureComponent {
               className="text-categories__category"
             >
               <header className="text-categories__header">
-                <h4 className="text-categories__label">
+                <h2 className="text-categories__label">
                   <span className="text-categories__label-type--light">
                     Category:{" "}
                   </span>
                   {this.title}
-                </h4>
+                </h2>
                 <div className="text-categories__utility">
                   <button
                     className="text-categories__button text-categories__button--notice"

--- a/client/src/backend/components/category/List/Uncategorized.js
+++ b/client/src/backend/components/category/List/Uncategorized.js
@@ -37,11 +37,11 @@ export default class CategoryListUncategorized extends PureComponent {
     return (
       <div className="text-categories__category">
         <header className="text-categories__header">
-          <h4 className="text-categories__label">
+          <h2 className="text-categories__label">
             <span className="text-categories__label--notice">
               Uncategorized
             </span>
-          </h4>
+          </h2>
         </header>
         <Texts
           activeType={this.props.activeType}

--- a/client/src/backend/components/content-block/Builder/sections/parts/Header.js
+++ b/client/src/backend/components/content-block/Builder/sections/parts/Header.js
@@ -23,7 +23,7 @@ export default class ProjectContentSectionsPartsHeader extends PureComponent {
         )}
         {this.props.subtitle && (
           <header className="form-subsection-label">
-            <h2>{this.props.subtitle}</h2>
+            <h3>{this.props.subtitle}</h3>
           </header>
         )}
       </React.Fragment>

--- a/client/src/backend/components/form/Date.js
+++ b/client/src/backend/components/form/Date.js
@@ -203,7 +203,7 @@ class FormDate extends Component {
         label={this.props.label}
         idForError={this.props.idForError}
       >
-        <h4 className="form-input-heading">{this.props.label}</h4>
+        <div className="form-input-heading">{this.props.label}</div>
         <div className="form-date">
           <div className="form-select input-month">
             {this.renderSelectIcon()}

--- a/client/src/backend/components/form/FieldGroup.js
+++ b/client/src/backend/components/form/FieldGroup.js
@@ -48,7 +48,7 @@ export default class FieldGroup extends PureComponent {
       <div className={classes} key="group">
         {isString(this.props.label) ? (
           <header className="form-section-label">
-            <span>{this.props.label}</span>
+            <h2>{this.props.label}</h2>
           </header>
         ) : null}
         <Instructions instructions={this.props.instructions} />

--- a/client/src/backend/components/form/HasMany/Header.js
+++ b/client/src/backend/components/form/HasMany/Header.js
@@ -7,9 +7,18 @@ export default class FormHasManyHeader extends PureComponent {
 
   static propTypes = {
     label: PropTypes.string.isRequired,
+    labelTag: PropTypes.oneOf(["div", "h2", "h3", "h4"]),
     labelHeader: PropTypes.bool,
     instructions: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
   };
+
+  static defaultProps = {
+    labelTag: "div"
+  };
+
+  get labelTag() {
+    return this.props.labelTag;
+  }
 
   renderLabelHeader(label, instructions) {
     return (
@@ -23,9 +32,15 @@ export default class FormHasManyHeader extends PureComponent {
   }
 
   renderHeader(label, instructions) {
+    const Label = props => (
+      <this.labelTag className="form-input-heading">
+        {props.children}
+      </this.labelTag>
+    );
+
     return (
       <React.Fragment>
-        <h4 className="form-input-heading">{label}</h4>
+        <Label>{label}</Label>
         <Instructions instructions={instructions} />
       </React.Fragment>
     );

--- a/client/src/backend/components/form/HasMany/ListItem.js
+++ b/client/src/backend/components/form/HasMany/ListItem.js
@@ -121,7 +121,7 @@ export default class FormHasManyList extends PureComponent {
       <li>
         <div className="association">
           {this.renderAvatar()}
-          <h4 className="association-name">{this.name()}</h4>
+          <div className="association-name">{this.name()}</div>
         </div>
 
         <div className="utility">

--- a/client/src/backend/components/form/HasMany/index.js
+++ b/client/src/backend/components/form/HasMany/index.js
@@ -14,6 +14,7 @@ export class FormHasMany extends PureComponent {
 
   static propTypes = {
     label: PropTypes.string.isRequired,
+    labelTag: PropTypes.oneOf(["div", "h2", "h3", "h4"]),
     labelHeader: PropTypes.bool,
     emptyMessage: PropTypes.string,
     onNew: PropTypes.func,
@@ -119,6 +120,7 @@ export class FormHasMany extends PureComponent {
       >
         <Header
           label={this.props.label}
+          labelTag={this.props.labelTag}
           labelHeader={this.props.labelHeader}
           instructions={this.props.instructions}
         />

--- a/client/src/backend/components/form/__tests__/__snapshots__/Date-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/Date-test.js.snap
@@ -5,11 +5,11 @@ exports[`Backend.Form.Date component renders correctly 1`] = `
   className="form-input"
   style={Object {}}
 >
-  <h4
+  <div
     className="form-input-heading"
   >
     Some date
-  </h4>
+  </div>
   <div
     className="form-date"
   >

--- a/client/src/backend/components/form/__tests__/__snapshots__/HasMany-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/HasMany-test.js.snap
@@ -5,11 +5,11 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
   className="form-input"
   style={Object {}}
 >
-  <h4
+  <div
     className="form-input-heading"
   >
     makers
-  </h4>
+  </div>
   <nav
     className="has-many-list"
   >
@@ -20,11 +20,11 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
         <div
           className="association"
         >
-          <h4
+          <div
             className="association-name"
           >
             John
-          </h4>
+          </div>
         </div>
         <div
           className="utility"
@@ -88,11 +88,11 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
         <div
           className="association"
         >
-          <h4
+          <div
             className="association-name"
           >
             Jane
-          </h4>
+          </div>
         </div>
         <div
           className="utility"

--- a/client/src/backend/components/form/__tests__/__snapshots__/SwitchArray-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/SwitchArray-test.js.snap
@@ -11,9 +11,9 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
     <header
       className="form-section-label"
     >
-      <span>
+      <h2>
         Label this
-      </span>
+      </h2>
     </header>
     <div
       className="form-input-group"

--- a/client/src/backend/components/layout/DashboardPanel.js
+++ b/client/src/backend/components/layout/DashboardPanel.js
@@ -27,10 +27,10 @@ export default class DashboardPanel extends PureComponent {
       <div className="dashboard-panel">
         {this.title && (
           <header className="section-heading-secondary">
-            <h3>
+            <h2>
               {this.icon && <Utility.IconComposer icon={this.icon} />}
               {this.title}
-            </h3>
+            </h2>
           </header>
         )}
         <div className="panel">{this.props.children}</div>

--- a/client/src/backend/components/layout/Header.js
+++ b/client/src/backend/components/layout/Header.js
@@ -6,6 +6,7 @@ import PressLogo from "global/components/PressLogo";
 import HeaderNotifications from "global/components/HeaderNotifications";
 import lh from "helpers/linkHandler";
 import navigation from "helpers/router/navigation";
+import Utility from "global/components/utility";
 
 import BlurOnLocationChange from "hoc/blur-on-location-change";
 
@@ -26,6 +27,7 @@ export default class LayoutHeader extends Component {
     return (
       <BlurOnLocationChange location={this.props.location}>
         <header className={"header-app dark"}>
+          <Utility.SkipLink />
           <div className="header-container">
             <Link to={lh.link("frontend")} className="header-logo">
               <span className="screen-reader-text">Return to home</span>

--- a/client/src/backend/components/layout/__tests__/__snapshots__/Header-test.js.snap
+++ b/client/src/backend/components/layout/__tests__/__snapshots__/Header-test.js.snap
@@ -5,6 +5,13 @@ exports[`Backend.Layout.Header component renders correctly 1`] = `
   <header
     className="header-app dark"
   >
+    <a
+      className="skip-to-main screen-reader-text"
+      href="#skip-to-main"
+      onClick={[Function]}
+    >
+      Skip to main content
+    </a>
     <div
       className="header-container"
     >
@@ -48,6 +55,7 @@ exports[`Backend.Layout.Header component renders correctly 1`] = `
         </figure>
       </a>
       <nav
+        aria-label="Primary Navigation"
         className="page-nav show-75"
       >
         <ul

--- a/client/src/backend/components/list/EntitiesList/Entity/Row.js
+++ b/client/src/backend/components/list/EntitiesList/Entity/Row.js
@@ -264,7 +264,7 @@ export default class EntitiesListRow extends PureComponent {
             )}
             <div className={this.textClassNames}>
               {this.title && (
-                <h4 className={this.titleClassNames}>
+                <h3 className={this.titleClassNames}>
                   <span className="entity-row__title-inner">
                     {this.inlineLink(this.title)}
                   </span>
@@ -275,19 +275,19 @@ export default class EntitiesListRow extends PureComponent {
                   >
                     {`View ${this.titlePlainText}`}
                   </span>
-                </h4>
+                </h3>
               )}
               {!this.title && this.hasLabels && (
                 <LabelSet labels={this.labels} />
               )}
               {this.hasSubtitle && (
-                <h5 className={this.subtitleClassNames}>{this.subtitle}</h5>
+                <h4 className={this.subtitleClassNames}>{this.subtitle}</h4>
               )}
               {this.hasCount && (
-                <h5 className={this.countClassNames}>{this.count}</h5>
+                <h4 className={this.countClassNames}>{this.count}</h4>
               )}
               {this.hasMeta && (
-                <h6 className={this.metaClassNames}>{this.meta}</h6>
+                <div className={this.metaClassNames}>{this.meta}</div>
               )}
             </div>
             {this.utility && (

--- a/client/src/backend/components/list/EntitiesList/List/TextTitle.js
+++ b/client/src/backend/components/list/EntitiesList/List/TextTitle.js
@@ -45,7 +45,7 @@ export default class ListEntitiesListTextTitle extends PureComponent {
 
   render() {
     return (
-      <h3 className="entity-list__title-block entity-list__title">
+      <h2 className="entity-list__title-block entity-list__title">
         {this.link(
           <React.Fragment>
             {this.titleIcon && (
@@ -56,7 +56,7 @@ export default class ListEntitiesListTextTitle extends PureComponent {
             {this.title}
           </React.Fragment>
         )}
-      </h3>
+      </h2>
     );
   }
 }

--- a/client/src/backend/components/navigation/DetailHeader.js
+++ b/client/src/backend/components/navigation/DetailHeader.js
@@ -128,6 +128,7 @@ export default class DetailHeader extends PureComponent {
   breadcrumbs() {
     return (
       <nav
+        aria-label="Breadcrumbs"
         className={classNames("backend-header__breadcrumbs", "breadcrumbs", {
           "breadcrumbs--hidden-desktop": this.backHiddenDesktop
         })}

--- a/client/src/backend/components/navigation/Secondary.js
+++ b/client/src/backend/components/navigation/Secondary.js
@@ -14,7 +14,12 @@ export class NavigationSecondary extends Component {
   static propTypes = {
     links: PropTypes.array,
     location: PropTypes.object,
-    panel: PropTypes.bool
+    panel: PropTypes.bool,
+    ariaLabel: PropTypes.string
+  };
+
+  static defaultProps = {
+    ariaLabel: "Secondary Navigation"
   };
 
   pathForLink(link) {
@@ -39,7 +44,7 @@ export class NavigationSecondary extends Component {
     });
 
     return (
-      <nav className={navClasses}>
+      <nav className={navClasses} aria-label={this.props.ariaLabel}>
         <ul>
           {this.props.links.map(link => {
             if (link.ability)

--- a/client/src/backend/components/navigation/__tests__/__snapshots__/Secondary-test.js.snap
+++ b/client/src/backend/components/navigation/__tests__/__snapshots__/Secondary-test.js.snap
@@ -3,6 +3,7 @@
 exports[`Backend.Navigation.Secondary component renders correctly 1`] = `
 <div>
   <nav
+    aria-label="Secondary Navigation"
     className="secondary-nav"
   >
     <ul>

--- a/client/src/backend/components/project-collection/Header.js
+++ b/client/src/backend/components/project-collection/Header.js
@@ -64,8 +64,11 @@ export default class ProjectCollectionHeader extends PureComponent {
       <section className="backend-header">
         <div className="backend-header__inner backend-header__inner--empty">
           <header className="backend-header__empty-text">
-            Please select a Project Collection from the list to edit its content
-            and settings.
+            <h1 className="screen-reader-text">Project Collections</h1>
+            <span>
+              Please select a Project Collection from the list to edit its
+              content and settings.
+            </span>
           </header>
         </div>
       </section>

--- a/client/src/backend/components/project-collection/SortBy.js
+++ b/client/src/backend/components/project-collection/SortBy.js
@@ -105,7 +105,7 @@ export default class ProjectCollectionSortBy extends PureComponent {
     return (
       <form className="form-secondary">
         <div className="form-input">
-          <h4 className="form-input-heading">Order Manually</h4>
+          <div className="form-input-heading">Order Manually</div>
           <div className="toggle-indicator">
             <div
               onClick={this.handleClick}

--- a/client/src/backend/components/project-collection/__tests__/__snapshots__/Header-test.js.snap
+++ b/client/src/backend/components/project-collection/__tests__/__snapshots__/Header-test.js.snap
@@ -5,6 +5,7 @@ exports[`Backend.ProjectCollection.Header component renders correctly 1`] = `
   className="backend-header"
 >
   <nav
+    aria-label="Breadcrumbs"
     className="backend-header__breadcrumbs breadcrumbs breadcrumbs--hidden-desktop"
   >
     <div

--- a/client/src/backend/components/project-collection/__tests__/__snapshots__/SortBy-test.js.snap
+++ b/client/src/backend/components/project-collection/__tests__/__snapshots__/SortBy-test.js.snap
@@ -24,11 +24,11 @@ exports[`Backend.ProjectCollection.SortBy component renders correctly 1`] = `
     <div
       className="form-input"
     >
-      <h4
+      <div
         className="form-input-heading"
       >
         Order Manually
-      </h4>
+      </div>
       <div
         className="toggle-indicator"
       >

--- a/client/src/backend/components/project-collection/form/__tests__/__snapshots__/SmartAttributes-test.js.snap
+++ b/client/src/backend/components/project-collection/form/__tests__/__snapshots__/SmartAttributes-test.js.snap
@@ -64,11 +64,11 @@ Array [
     className="form-input"
     style={Object {}}
   >
-    <h4
+    <div
       className="form-input-heading"
     >
       Subjects
-    </h4>
+    </div>
     <span
       className="instructions"
     >

--- a/client/src/backend/components/project/form/AvatarBuilder.js
+++ b/client/src/backend/components/project/form/AvatarBuilder.js
@@ -111,7 +111,7 @@ class AvatarBuilder extends Component {
         label="Avatar"
       >
         <div className={inputClasses}>
-          <h4 className="form-input-heading">Project Thumbnail</h4>
+          <div className="form-input-heading">Project Thumbnail</div>
           <div className="grid">
             <div className="section current">
               <span className="label" aria-hidden="true">

--- a/client/src/backend/components/project/form/__tests__/__snapshots__/Subjects-test.js.snap
+++ b/client/src/backend/components/project/form/__tests__/__snapshots__/Subjects-test.js.snap
@@ -5,11 +5,11 @@ exports[`Backend Project Form Subjects Component renders correctly 1`] = `
   className="form-input wide"
   style={Object {}}
 >
-  <h4
+  <div
     className="form-input-heading"
   >
     Subjects
-  </h4>
+  </div>
   <nav
     className="has-many-list"
   >
@@ -48,11 +48,11 @@ exports[`Backend Project Form Subjects Component renders correctly 1`] = `
         <div
           className="association"
         >
-          <h4
+          <div
             className="association-name"
           >
             Hip Hop
-          </h4>
+          </div>
         </div>
         <div
           className="utility"

--- a/client/src/backend/containers/Backend/__tests__/__snapshots__/Backend-test.js.snap
+++ b/client/src/backend/containers/Backend/__tests__/__snapshots__/Backend-test.js.snap
@@ -15,11 +15,6 @@ exports[`Backend Backend Container renders correctly 1`] = `
                   </Connect(RedirectToFirstMatch)>
                 </Route>
               </withRouter(Connect(RedirectToFirstMatch))>
-              <SkipLink skipId=\\"skip-to-main\\" skipLinkText=\\"Skip to main content\\" skipMessage=\\"Skipped to Main Content\\">
-                <a className=\\"skip-to-main screen-reader-text\\" href=\\"#skip-to-main\\" onClick={[Function]}>
-                  Skip to main content
-                </a>
-              </SkipLink>
               <withRouter(ScrollToTop)>
                 <Route>
                   <ScrollToTop match={{...}} location={{...}} history={{...}} staticContext={[undefined]} />
@@ -31,6 +26,11 @@ exports[`Backend Backend Container renders correctly 1`] = `
                     <BlurOnLocationChange location={[undefined]}>
                       <div>
                         <header className=\\"header-app dark\\">
+                          <SkipLink skipId=\\"skip-to-main\\" skipLinkText=\\"Skip to main content\\" skipMessage=\\"Skipped to Main Content\\">
+                            <a className=\\"skip-to-main screen-reader-text\\" href=\\"#skip-to-main\\" onClick={[Function]}>
+                              Skip to main content
+                            </a>
+                          </SkipLink>
                           <div className=\\"header-container\\">
                             <Link to=\\"/\\" className=\\"header-logo\\" replace={false}>
                               <a className=\\"header-logo\\" onClick={[Function]} href=\\"/\\">
@@ -61,7 +61,7 @@ exports[`Backend Backend Container renders correctly 1`] = `
                                   <withRouter(Navigation.Static) backendButton={{...}} links={{...}} commonActions={{...}} authentication={{...}} visibility={{...}} mode=\\"backend\\" match={{...}} location={{...}} history={{...}} staticContext={[undefined]} exact={false} style={[undefined]}>
                                     <Route>
                                       <Navigation.Static backendButton={{...}} links={{...}} commonActions={{...}} authentication={{...}} visibility={{...}} mode=\\"backend\\" match={{...}} location={{...}} history={{...}} staticContext={[undefined]} exact={false} style={[undefined]}>
-                                        <nav className=\\"page-nav show-75\\">
+                                        <nav className=\\"page-nav show-75\\" aria-label=\\"Primary Navigation\\">
                                           <ul style={[undefined]} className=\\"links\\">
                                             <li>
                                               <NavLink to=\\"/backend/dashboard\\" exact={false} target={{...}} activeClassName=\\"active\\" aria-current=\\"page\\">
@@ -233,7 +233,7 @@ exports[`Backend Backend Container renders correctly 1`] = `
                                           </div>
                                           <div className=\\"rel left\\">
                                             <Layout.Footer.Navigation commonActions={{...}} pages={{...}} settings={{...}} authentication={{...}}>
-                                              <nav className=\\"text-nav\\">
+                                              <nav className=\\"text-nav\\" aria-label=\\"Footer Navigation\\">
                                                 <ul className=\\"text-nav__list\\">
                                                   <li className=\\"text-nav__link-group\\">
                                                     <ul className=\\"footer-nav-list\\">

--- a/client/src/backend/containers/Backend/index.js
+++ b/client/src/backend/containers/Backend/index.js
@@ -92,7 +92,6 @@ export class BackendContainer extends PureComponent {
             ]}
           />
 
-          <Utility.SkipLink />
           <Utility.ScrollToTop />
           <ScrollAware>
             <LayoutBackend.Header

--- a/client/src/backend/containers/dashboards/Admin.js
+++ b/client/src/backend/containers/dashboards/Admin.js
@@ -134,6 +134,7 @@ class DashboardsAdminContainerImplementation extends PureComponent {
   render() {
     return (
       <div>
+        <h1 className="screen-reader-text">Dashboard</h1>
         <section>
           <div className="container">
             <section className="backend-dashboard">

--- a/client/src/backend/containers/dashboards/__tests__/__snapshots__/Admin-test.js.snap
+++ b/client/src/backend/containers/dashboards/__tests__/__snapshots__/Admin-test.js.snap
@@ -2,6 +2,11 @@
 
 exports[`Backend Dashboards Admin Container renders correctly 1`] = `
 <div>
+  <h1
+    className="screen-reader-text"
+  >
+    Dashboard
+  </h1>
   <section>
     <div
       className="container"
@@ -22,7 +27,7 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                 className="entity-list"
                 id="entities-list1"
               >
-                <h3
+                <h2
                   className="entity-list__title-block entity-list__title"
                 >
                   <a
@@ -49,7 +54,7 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                     </figure>
                     2 Projects
                   </a>
-                </h3>
+                </h2>
                 <div
                   className="entity-list__contents-wrapper"
                 >
@@ -391,7 +396,7 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                           <div
                             className="entity-row__text entity-row__text--in-rows"
                           >
-                            <h4
+                            <h3
                               className="entity-row__title entity-row__title--in-rows"
                             >
                               <span
@@ -411,13 +416,13 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                               >
                                 View Rowan Test
                               </span>
-                            </h4>
-                            <h5
+                            </h3>
+                            <h4
                               className="entity-row__subtitle entity-row__subtitle--in-rows"
                             >
                               World's Greatest Dog
-                            </h5>
-                            <h6
+                            </h4>
+                            <div
                               className="entity-row__meta entity-row__meta--in-rows"
                             />
                           </div>
@@ -515,7 +520,7 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                           <div
                             className="entity-row__text entity-row__text--in-rows"
                           >
-                            <h4
+                            <h3
                               className="entity-row__title entity-row__title--in-rows"
                             >
                               <span
@@ -535,13 +540,13 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                               >
                                 View Rowan Test
                               </span>
-                            </h4>
-                            <h5
+                            </h3>
+                            <h4
                               className="entity-row__subtitle entity-row__subtitle--in-rows"
                             >
                               World's Greatest Dog
-                            </h5>
-                            <h6
+                            </h4>
+                            <div
                               className="entity-row__meta entity-row__meta--in-rows"
                             />
                           </div>
@@ -553,6 +558,7 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                     className="entity-list__pagination"
                   >
                     <nav
+                      aria-label="Pagination"
                       className="list-pagination"
                     >
                       <ul
@@ -695,7 +701,7 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                 className="entity-list"
                 id="entities-list1"
               >
-                <h3
+                <h2
                   className="entity-list__title-block entity-list__title"
                 >
                   <figure
@@ -717,7 +723,7 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                     </svg>
                   </figure>
                   Recently Updated
-                </h3>
+                </h2>
                 <div
                   className="entity-list__contents-wrapper"
                 >
@@ -742,7 +748,7 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                           <div
                             className="entity-row__text entity-row__text--in-rows"
                           >
-                            <h4
+                            <h3
                               className="entity-row__title entity-row__title--in-rows"
                             >
                               <span
@@ -762,8 +768,8 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                               >
                                 View Rowan Test
                               </span>
-                            </h4>
-                            <h6
+                            </h3>
+                            <div
                               className="entity-row__meta entity-row__meta--in-rows"
                             />
                           </div>
@@ -785,7 +791,7 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                           <div
                             className="entity-row__text entity-row__text--in-rows"
                           >
-                            <h4
+                            <h3
                               className="entity-row__title entity-row__title--in-rows"
                             >
                               <span
@@ -805,8 +811,8 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                               >
                                 View Rowan Test
                               </span>
-                            </h4>
-                            <h6
+                            </h3>
+                            <div
                               className="entity-row__meta entity-row__meta--in-rows"
                             />
                           </div>

--- a/client/src/backend/containers/form-inputs/composite-inputs/Collaborators.js
+++ b/client/src/backend/containers/form-inputs/composite-inputs/Collaborators.js
@@ -85,6 +85,7 @@ export class FormCollaborators extends Component {
         <form className="form-secondary">
           <Form.HasMany
             label="Authors"
+            labelTag="h2"
             placeholder="Add an Author"
             onNew={value => {
               return this.newMaker(value, "creator");
@@ -103,6 +104,7 @@ export class FormCollaborators extends Component {
           />
           <Form.HasMany
             label="Contributors"
+            labelTag="h2"
             placeholder="Add a Contributor"
             onNew={value => {
               return this.newMaker(value, "contributor");

--- a/client/src/backend/containers/form-inputs/composite-inputs/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/backend/containers/form-inputs/composite-inputs/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -9,11 +9,11 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
       className="form-input"
       style={Object {}}
     >
-      <h4
+      <h2
         className="form-input-heading"
       >
         Authors
-      </h4>
+      </h2>
       <nav
         className="has-many-list"
       >
@@ -44,11 +44,11 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
                   </svg>
                 </div>
               </figure>
-              <h4
+              <div
                 className="association-name"
               >
                 Rowan Ida
-              </h4>
+              </div>
             </div>
             <div
               className="utility"
@@ -166,11 +166,11 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
       className="form-input"
       style={Object {}}
     >
-      <h4
+      <h2
         className="form-input-heading"
       >
         Contributors
-      </h4>
+      </h2>
       <nav
         className="has-many-list"
       >
@@ -201,11 +201,11 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
                   </svg>
                 </div>
               </figure>
-              <h4
+              <div
                 className="association-name"
               >
                 Rowan Ida
-              </h4>
+              </div>
             </div>
             <div
               className="utility"

--- a/client/src/backend/containers/makers/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/containers/makers/__tests__/__snapshots__/List-test.js.snap
@@ -218,7 +218,7 @@ Array [
               <div
                 className="entity-row__text entity-row__text--valign-center entity-row__text--in-rows"
               >
-                <h4
+                <h3
                   className="entity-row__title entity-row__title--in-rows"
                 >
                   <span
@@ -232,7 +232,7 @@ Array [
                   >
                     View Rowan Ida
                   </span>
-                </h4>
+                </h3>
               </div>
             </div>
           </a>
@@ -242,6 +242,7 @@ Array [
         className="entity-list__pagination"
       >
         <nav
+          aria-label="Pagination"
           className="list-pagination"
         >
           <ul

--- a/client/src/backend/containers/pages/Detail.js
+++ b/client/src/backend/containers/pages/Detail.js
@@ -206,7 +206,13 @@ class PageDetailContainer extends PureComponent {
         />
         {this.renderExistingHeader(page)}
         <Layout.BackendPanel
-          sidebar={<Navigation.Secondary links={secondaryLinks} panel />}
+          sidebar={
+            <Navigation.Secondary
+              links={secondaryLinks}
+              panel
+              ariaLabel="Page Settings"
+            />
+          }
         >
           <div>{this.renderRoutes()}</div>
         </Layout.BackendPanel>

--- a/client/src/backend/containers/permission/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/backend/containers/permission/__tests__/__snapshots__/Edit-test.js.snap
@@ -60,9 +60,9 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
             <header
               className="form-section-label"
             >
-              <span>
+              <h2>
                 Permissions
-              </span>
+              </h2>
             </header>
             <div
               className="form-input-group"

--- a/client/src/backend/containers/permission/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/backend/containers/permission/__tests__/__snapshots__/Form-test.js.snap
@@ -50,9 +50,9 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
           <header
             className="form-section-label"
           >
-            <span>
+            <h2>
               Permissions
-            </span>
+            </h2>
           </header>
           <div
             className="form-input-group"

--- a/client/src/backend/containers/permission/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/containers/permission/__tests__/__snapshots__/List-test.js.snap
@@ -79,7 +79,7 @@ exports[`Backend Permissions List Container renders correctly 1`] = `
               <div
                 className="entity-row__text entity-row__text--valign-center entity-row__text--in-rows"
               >
-                <h4
+                <h3
                   className="entity-row__title entity-row__title--in-rows"
                 >
                   <span
@@ -102,7 +102,7 @@ exports[`Backend Permissions List Container renders correctly 1`] = `
                   >
                     View Rowan Ida
                   </span>
-                </h4>
+                </h3>
               </div>
             </div>
           </a>

--- a/client/src/backend/containers/permission/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/permission/__tests__/__snapshots__/New-test.js.snap
@@ -64,9 +64,9 @@ exports[`Backend Permission New Container renders correctly 1`] = `
             <header
               className="form-section-label"
             >
-              <span>
+              <h2>
                 Permissions
-              </span>
+              </h2>
             </header>
             <div
               className="form-input-group"

--- a/client/src/backend/containers/project-collection/Detail/__tests__/__snapshots__/Manual-test.js.snap
+++ b/client/src/backend/containers/project-collection/Detail/__tests__/__snapshots__/Manual-test.js.snap
@@ -189,7 +189,7 @@ exports[`Backend.ProjectCollection.Detail.Manual component renders correctly 1`]
             <div
               className="entity-row__text entity-row__text--in-grid"
             >
-              <h4
+              <h3
                 className="entity-row__title entity-row__title--in-grid"
               >
                 <span
@@ -209,13 +209,13 @@ exports[`Backend.ProjectCollection.Detail.Manual component renders correctly 1`]
                 >
                   View Rowan Test
                 </span>
-              </h4>
-              <h5
+              </h3>
+              <h4
                 className="entity-row__subtitle entity-row__subtitle--in-grid"
               >
                 World's Greatest Dog
-              </h5>
-              <h6
+              </h4>
+              <div
                 className="entity-row__meta entity-row__meta--in-grid"
               />
             </div>

--- a/client/src/backend/containers/project-collection/Detail/__tests__/__snapshots__/Smart-test.js.snap
+++ b/client/src/backend/containers/project-collection/Detail/__tests__/__snapshots__/Smart-test.js.snap
@@ -189,7 +189,7 @@ exports[`Backend.ProjectCollection.Detail.Smart component renders correctly 1`] 
             <div
               className="entity-row__text entity-row__text--in-grid"
             >
-              <h4
+              <h3
                 className="entity-row__title entity-row__title--in-grid"
               >
                 <span
@@ -209,13 +209,13 @@ exports[`Backend.ProjectCollection.Detail.Smart component renders correctly 1`] 
                 >
                   View Rowan Test
                 </span>
-              </h4>
-              <h5
+              </h3>
+              <h4
                 className="entity-row__subtitle entity-row__subtitle--in-grid"
               >
                 World's Greatest Dog
-              </h5>
-              <h6
+              </h4>
+              <div
                 className="entity-row__meta entity-row__meta--in-grid"
               />
             </div>

--- a/client/src/backend/containers/project-collection/Detail/index.js
+++ b/client/src/backend/containers/project-collection/Detail/index.js
@@ -161,6 +161,7 @@ export class ProjectCollectionDetail extends PureComponent {
         ability="update"
       >
         <div>
+          <h2 className="screen-reader-text">Project List</h2>
           <ProjectCollection.SortBy
             sortChangeHandler={this.handleSortOrderChange}
             projectCollection={this.props.projectCollection}

--- a/client/src/backend/containers/project-collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/backend/containers/project-collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -2,6 +2,11 @@
 
 exports[`Backend.ProjectCollection.Detail container renders correctly 1`] = `
 <div>
+  <h2
+    className="screen-reader-text"
+  >
+    Project List
+  </h2>
   <div
     className="project-collection-sort"
   >
@@ -25,11 +30,11 @@ exports[`Backend.ProjectCollection.Detail container renders correctly 1`] = `
       <div
         className="form-input"
       >
-        <h4
+        <div
           className="form-input-heading"
         >
           Order Manually
-        </h4>
+        </div>
         <div
           className="toggle-indicator"
         >

--- a/client/src/backend/containers/project-collection/__tests__/__snapshots__/ManageProjects-test.js.snap
+++ b/client/src/backend/containers/project-collection/__tests__/__snapshots__/ManageProjects-test.js.snap
@@ -564,7 +564,7 @@ Array [
               <div
                 className="entity-row__text entity-row__text--in-grid"
               >
-                <h4
+                <h3
                   className="entity-row__title entity-row__title--in-grid"
                 >
                   <span
@@ -584,13 +584,13 @@ Array [
                   >
                     View Rowan Test
                   </span>
-                </h4>
-                <h5
+                </h3>
+                <h4
                   className="entity-row__subtitle entity-row__subtitle--in-grid"
                 >
                   World's Greatest Dog
-                </h5>
-                <h6
+                </h4>
+                <div
                   className="entity-row__meta entity-row__meta--in-grid"
                 />
               </div>
@@ -860,7 +860,7 @@ Array [
               <div
                 className="entity-row__text entity-row__text--in-grid"
               >
-                <h4
+                <h3
                   className="entity-row__title entity-row__title--in-grid"
                 >
                   <span
@@ -880,13 +880,13 @@ Array [
                   >
                     View Rowan Test
                   </span>
-                </h4>
-                <h5
+                </h3>
+                <h4
                   className="entity-row__subtitle entity-row__subtitle--in-grid"
                 >
                   World's Greatest Dog
-                </h5>
-                <h6
+                </h4>
+                <div
                   className="entity-row__meta entity-row__meta--in-grid"
                 />
               </div>
@@ -898,6 +898,7 @@ Array [
         className="entity-list__pagination"
       >
         <nav
+          aria-label="Pagination"
           className="list-pagination"
         >
           <ul

--- a/client/src/backend/containers/project-collection/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/backend/containers/project-collection/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -293,6 +293,7 @@ exports[`Backend.ProjectCollection.Wrapper container renders correctly when no p
           className="backend-header"
         >
           <nav
+            aria-label="Breadcrumbs"
             className="backend-header__breadcrumbs breadcrumbs breadcrumbs--hidden-desktop"
           >
             <div

--- a/client/src/backend/containers/project/Wrapper.js
+++ b/client/src/backend/containers/project/Wrapper.js
@@ -146,7 +146,13 @@ export class ProjectWrapperContainer extends PureComponent {
             secondaryLinks={secondaryLinks}
           />
           <Layout.BackendPanel
-            sidebar={<Navigation.Secondary links={secondaryLinks} panel />}
+            sidebar={
+              <Navigation.Secondary
+                links={secondaryLinks}
+                panel
+                ariaLabel="Project Settings"
+              />
+            }
           >
             <div>{this.renderRoutes()}</div>
           </Layout.BackendPanel>

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -10,11 +10,11 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <h4
+        <h2
           className="form-input-heading"
         >
           Authors
-        </h4>
+        </h2>
         <nav
           className="has-many-list"
         >
@@ -45,11 +45,11 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
                     </svg>
                   </div>
                 </figure>
-                <h4
+                <div
                   className="association-name"
                 >
                   Rowan Ida
-                </h4>
+                </div>
               </div>
               <div
                 className="utility"
@@ -167,11 +167,11 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <h4
+        <h2
           className="form-input-heading"
         >
           Contributors
-        </h4>
+        </h2>
         <nav
           className="has-many-list"
         >
@@ -202,11 +202,11 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
                     </svg>
                   </div>
                 </figure>
-                <h4
+                <div
                   className="association-name"
                 >
                   Rowan Ida
-                </h4>
+                </div>
               </div>
               <div
                 className="utility"

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Collections-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Collections-test.js.snap
@@ -6,7 +6,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
     className="entity-list"
     id="entities-list1"
   >
-    <h3
+    <h2
       className="entity-list__title-block entity-list__title"
     >
       <figure
@@ -27,7 +27,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
         </svg>
       </figure>
       Resources
-    </h3>
+    </h2>
     <div
       className="entity-list__contents-wrapper"
     >
@@ -352,6 +352,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
         className="entity-list__pagination"
       >
         <nav
+          aria-label="Pagination"
           className="list-pagination"
         >
           <ul

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Events-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Events-test.js.snap
@@ -6,7 +6,7 @@ exports[`Backend Project Events Container renders correctly 1`] = `
     className="entity-list"
     id="entities-list1"
   >
-    <h3
+    <h2
       className="entity-list__title-block entity-list__title"
     >
       <figure
@@ -27,7 +27,7 @@ exports[`Backend Project Events Container renders correctly 1`] = `
         </svg>
       </figure>
       Activity
-    </h3>
+    </h2>
     <div
       className="entity-list__contents-wrapper"
     >
@@ -238,7 +238,7 @@ exports[`Backend Project Events Container renders correctly 1`] = `
                 >
                   Text Added
                 </div>
-                <h5
+                <h3
                   className="event-tile__title"
                   dangerouslySetInnerHTML={
                     Object {
@@ -318,7 +318,7 @@ exports[`Backend Project Events Container renders correctly 1`] = `
                 >
                   Text Added
                 </div>
-                <h5
+                <h3
                   className="event-tile__title"
                   dangerouslySetInnerHTML={
                     Object {
@@ -370,6 +370,7 @@ exports[`Backend Project Events Container renders correctly 1`] = `
         className="entity-list__pagination"
       >
         <nav
+          aria-label="Pagination"
           className="list-pagination"
         >
           <ul

--- a/client/src/backend/containers/project/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/General-test.js.snap
@@ -14,9 +14,9 @@ exports[`Backend Project General Container renders correctly 1`] = `
         <header
           className="form-section-label"
         >
-          <span>
+          <h2>
             Title
-          </span>
+          </h2>
         </header>
         <div
           className="form-input-group"
@@ -86,9 +86,9 @@ exports[`Backend Project General Container renders correctly 1`] = `
         <header
           className="form-section-label"
         >
-          <span>
+          <h2>
             Visibility
-          </span>
+          </h2>
         </header>
         <div
           className="form-input-group"
@@ -171,9 +171,9 @@ exports[`Backend Project General Container renders correctly 1`] = `
         <header
           className="form-section-label"
         >
-          <span>
+          <h2>
             Other
-          </span>
+          </h2>
         </header>
         <div
           className="form-input-group"
@@ -182,11 +182,11 @@ exports[`Backend Project General Container renders correctly 1`] = `
             className="form-input"
             style={Object {}}
           >
-            <h4
+            <div
               className="form-input-heading"
             >
               Publication Date
-            </h4>
+            </div>
             <div
               className="form-date"
             >
@@ -408,11 +408,11 @@ exports[`Backend Project General Container renders correctly 1`] = `
             className="form-input wide"
             style={Object {}}
           >
-            <h4
+            <div
               className="form-input-heading"
             >
               Subjects
-            </h4>
+            </div>
             <nav
               className="has-many-list"
             >
@@ -471,11 +471,11 @@ exports[`Backend Project General Container renders correctly 1`] = `
                   <div
                     className="association"
                   >
-                    <h4
+                    <div
                       className="association-name"
                     >
                       Hip Hop
-                    </h4>
+                    </div>
                   </div>
                   <div
                     className="utility"
@@ -592,11 +592,11 @@ exports[`Backend Project General Container renders correctly 1`] = `
             <div
               className="form-input avatar-builder wide"
             >
-              <h4
+              <div
                 className="form-input-heading"
               >
                 Project Thumbnail
-              </h4>
+              </div>
               <div
                 className="grid"
               >

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Log-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Log-test.js.snap
@@ -5,7 +5,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
   className="entity-list"
   id="entities-list1"
 >
-  <h3
+  <h2
     className="entity-list__title-block entity-list__title"
   >
     <figure
@@ -26,7 +26,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
       </svg>
     </figure>
     Project Changes
-  </h3>
+  </h2>
   <div
     className="entity-list__contents-wrapper"
   >
@@ -63,7 +63,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
           <div
             className="entity-row__text entity-row__text--in-rows"
           >
-            <h4
+            <h3
               className="entity-row__title entity-row__title--in-rows"
             >
               <span
@@ -102,8 +102,8 @@ exports[`Backend Project Log Container renders correctly 1`] = `
               >
                 View [object Object]
               </span>
-            </h4>
-            <h6
+            </h3>
+            <div
               className="entity-row__meta entity-row__meta--in-rows"
             >
               <span>
@@ -112,7 +112,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
                   title
                 </em>
               </span>
-            </h6>
+            </div>
           </div>
         </div>
       </li>
@@ -125,7 +125,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
           <div
             className="entity-row__text entity-row__text--in-rows"
           >
-            <h4
+            <h3
               className="entity-row__title entity-row__title--in-rows"
             >
               <span
@@ -153,8 +153,8 @@ exports[`Backend Project Log Container renders correctly 1`] = `
               >
                 View [object Object]
               </span>
-            </h4>
-            <h6
+            </h3>
+            <div
               className="entity-row__meta entity-row__meta--in-rows"
             >
               <span>
@@ -163,7 +163,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
                   title
                 </em>
               </span>
-            </h6>
+            </div>
           </div>
         </div>
       </li>
@@ -172,6 +172,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
       className="entity-list__pagination"
     >
       <nav
+        aria-label="Pagination"
         className="list-pagination"
       >
         <ul

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Metadata-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Metadata-test.js.snap
@@ -14,9 +14,9 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         <header
           className="form-section-label"
         >
-          <span>
+          <h2>
             Identity
-          </span>
+          </h2>
         </header>
         <div
           className="form-input-group"
@@ -67,9 +67,9 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         <header
           className="form-section-label"
         >
-          <span>
+          <h2>
             Publisher
-          </span>
+          </h2>
         </header>
         <div
           className="form-input-group"
@@ -163,9 +163,9 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         <header
           className="form-section-label"
         >
-          <span>
+          <h2>
             Bibliographic
-          </span>
+          </h2>
         </header>
         <div
           className="form-input-group"
@@ -312,9 +312,9 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         <header
           className="form-section-label"
         >
-          <span>
+          <h2>
             Other
-          </span>
+          </h2>
         </header>
         <div
           className="form-input-group"

--- a/client/src/backend/containers/project/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/New-test.js.snap
@@ -142,9 +142,9 @@ exports[`Backend Project New Container renders correctly 1`] = `
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Title and Description
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"
@@ -221,9 +221,9 @@ exports[`Backend Project New Container renders correctly 1`] = `
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Layout
-                </span>
+                </h2>
               </header>
               <span
                 className="instructions"

--- a/client/src/backend/containers/project/__tests__/__snapshots__/ProjectPage-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/ProjectPage-test.js.snap
@@ -14,9 +14,9 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
         <header
           className="form-section-label"
         >
-          <span>
+          <h2>
             Appearance
-          </span>
+          </h2>
         </header>
         <div
           className="form-input-group"
@@ -265,9 +265,9 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
         <header
           className="form-section-label"
         >
-          <span>
+          <h2>
             Purchase Options
-          </span>
+          </h2>
         </header>
         <div
           className="form-input-group"
@@ -374,9 +374,9 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
         <header
           className="form-section-label"
         >
-          <span>
+          <h2>
             Download Options
-          </span>
+          </h2>
         </header>
         <span
           className="instructions"

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Resources-test.js.snap
@@ -6,7 +6,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
     className="entity-list"
     id="entities-list1"
   >
-    <h3
+    <h2
       className="entity-list__title-block entity-list__title"
     >
       <figure
@@ -27,7 +27,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
         </svg>
       </figure>
       Resources
-    </h3>
+    </h2>
     <div
       className="entity-list__contents-wrapper"
     >
@@ -352,6 +352,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
         className="entity-list__pagination"
       >
         <nav
+          aria-label="Pagination"
           className="list-pagination"
         >
           <ul

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Texts-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Texts-test.js.snap
@@ -99,7 +99,7 @@ Array [
           <header
             className="text-categories__header"
           >
-            <h4
+            <h2
               className="text-categories__label"
             >
               <span
@@ -109,7 +109,7 @@ Array [
                  
               </span>
               Hip Hop Classics
-            </h4>
+            </h2>
             <div
               className="text-categories__utility"
             >
@@ -215,7 +215,7 @@ Array [
       <header
         className="text-categories__header"
       >
-        <h4
+        <h2
           className="text-categories__label"
         >
           <span
@@ -223,7 +223,7 @@ Array [
           >
             Uncategorized
           </span>
-        </h4>
+        </h2>
       </header>
       <div
         className="texts-list"

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -345,6 +345,7 @@ exports[`Backend Project Wrapper Container renders correctly 1`] = `
           className="aside"
         >
           <nav
+            aria-label="Project Settings"
             className="secondary-nav panel-nav"
           >
             <ul>

--- a/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourceCollectionsList-test.js.snap
+++ b/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourceCollectionsList-test.js.snap
@@ -5,7 +5,7 @@ exports[`Backend Project Resource CollectionList Container renders correctly 1`]
   className="entity-list"
   id="entities-list1"
 >
-  <h3
+  <h2
     className="entity-list__title-block entity-list__title"
   >
     <figure
@@ -26,7 +26,7 @@ exports[`Backend Project Resource CollectionList Container renders correctly 1`]
       </svg>
     </figure>
     Resource Collections
-  </h3>
+  </h2>
   <div
     className="entity-list__contents-wrapper"
   >
@@ -232,7 +232,7 @@ exports[`Backend Project Resource CollectionList Container renders correctly 1`]
             <div
               className="entity-row__text entity-row__text--in-rows"
             >
-              <h4
+              <h3
                 className="entity-row__title entity-row__title--in-rows"
               >
                 <span
@@ -246,13 +246,13 @@ exports[`Backend Project Resource CollectionList Container renders correctly 1`]
                 >
                   View Rowan
                 </span>
-              </h4>
-              <h5
+              </h3>
+              <h4
                 className="entity-row__count entity-row__count--in-rows"
               >
                 0 resources
-              </h5>
-              <h6
+              </h4>
+              <div
                 className="entity-row__meta entity-row__meta--in-rows"
               >
                 <time
@@ -260,7 +260,7 @@ exports[`Backend Project Resource CollectionList Container renders correctly 1`]
                 >
                   Created April 24, 2017
                 </time>
-              </h6>
+              </div>
             </div>
           </div>
         </a>
@@ -294,7 +294,7 @@ exports[`Backend Project Resource CollectionList Container renders correctly 1`]
             <div
               className="entity-row__text entity-row__text--in-rows"
             >
-              <h4
+              <h3
                 className="entity-row__title entity-row__title--in-rows"
               >
                 <span
@@ -308,13 +308,13 @@ exports[`Backend Project Resource CollectionList Container renders correctly 1`]
                 >
                   View Rowan
                 </span>
-              </h4>
-              <h5
+              </h3>
+              <h4
                 className="entity-row__count entity-row__count--in-rows"
               >
                 0 resources
-              </h5>
-              <h6
+              </h4>
+              <div
                 className="entity-row__meta entity-row__meta--in-rows"
               >
                 <time
@@ -322,7 +322,7 @@ exports[`Backend Project Resource CollectionList Container renders correctly 1`]
                 >
                   Created April 24, 2017
                 </time>
-              </h6>
+              </div>
             </div>
           </div>
         </a>
@@ -332,6 +332,7 @@ exports[`Backend Project Resource CollectionList Container renders correctly 1`]
       className="entity-list__pagination"
     >
       <nav
+        aria-label="Pagination"
         className="list-pagination"
       >
         <ul

--- a/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourcesList-test.js.snap
+++ b/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourcesList-test.js.snap
@@ -5,7 +5,7 @@ exports[`Backend Project Resource ResourcesList Container renders correctly 1`] 
   className="entity-list"
   id="entities-list1"
 >
-  <h3
+  <h2
     className="entity-list__title-block entity-list__title"
   >
     <figure
@@ -26,7 +26,7 @@ exports[`Backend Project Resource ResourcesList Container renders correctly 1`] 
       </svg>
     </figure>
     Resources
-  </h3>
+  </h2>
   <div
     className="entity-list__contents-wrapper"
   >
@@ -374,7 +374,7 @@ exports[`Backend Project Resource ResourcesList Container renders correctly 1`] 
             <div
               className="entity-row__text entity-row__text--in-rows"
             >
-              <h4
+              <h3
                 className="entity-row__title entity-row__title--in-rows"
               >
                 <span
@@ -397,8 +397,8 @@ exports[`Backend Project Resource ResourcesList Container renders correctly 1`] 
                 >
                   View Image
                 </span>
-              </h4>
-              <h6
+              </h3>
+              <div
                 className="entity-row__meta entity-row__meta--in-rows"
               >
                 <time
@@ -406,7 +406,7 @@ exports[`Backend Project Resource ResourcesList Container renders correctly 1`] 
                 >
                   Created April 24, 2017
                 </time>
-              </h6>
+              </div>
             </div>
           </div>
         </a>
@@ -440,7 +440,7 @@ exports[`Backend Project Resource ResourcesList Container renders correctly 1`] 
             <div
               className="entity-row__text entity-row__text--in-rows"
             >
-              <h4
+              <h3
                 className="entity-row__title entity-row__title--in-rows"
               >
                 <span
@@ -463,8 +463,8 @@ exports[`Backend Project Resource ResourcesList Container renders correctly 1`] 
                 >
                   View Image
                 </span>
-              </h4>
-              <h6
+              </h3>
+              <div
                 className="entity-row__meta entity-row__meta--in-rows"
               >
                 <time
@@ -472,7 +472,7 @@ exports[`Backend Project Resource ResourcesList Container renders correctly 1`] 
                 >
                   Created April 24, 2017
                 </time>
-              </h6>
+              </div>
             </div>
           </div>
         </a>
@@ -482,6 +482,7 @@ exports[`Backend Project Resource ResourcesList Container renders correctly 1`] 
       className="entity-list__pagination"
     >
       <nav
+        aria-label="Pagination"
         className="list-pagination"
       >
         <ul

--- a/client/src/backend/containers/project/social/__tests__/__snapshots__/TwitterQueries-test.js.snap
+++ b/client/src/backend/containers/project/social/__tests__/__snapshots__/TwitterQueries-test.js.snap
@@ -71,7 +71,7 @@ exports[`Backend Project Social Twitter Queries Container renders correctly 1`] 
             <div
               className="entity-row__text entity-row__text--in-rows"
             >
-              <h4
+              <h3
                 className="entity-row__title entity-row__title--in-rows"
               >
                 <span
@@ -94,12 +94,12 @@ exports[`Backend Project Social Twitter Queries Container renders correctly 1`] 
                 >
                   View from:manifoldscholar
                 </span>
-              </h4>
-              <h6
+              </h3>
+              <div
                 className="entity-row__meta entity-row__meta--in-rows"
               >
                 No tweets have been fetched yet.
-              </h6>
+              </div>
             </div>
           </div>
         </a>

--- a/client/src/backend/containers/resource-collection/Wrapper.js
+++ b/client/src/backend/containers/resource-collection/Wrapper.js
@@ -177,7 +177,13 @@ export class ResourceCollectionWrapperContainer extends PureComponent {
             secondaryLinks={secondaryLinks}
           />
           <Layout.BackendPanel
-            sidebar={<Navigation.Secondary links={secondaryLinks} panel />}
+            sidebar={
+              <Navigation.Secondary
+                links={secondaryLinks}
+                panel
+                ariaLabel="Resource Collection Settings"
+              />
+            }
           >
             <div>{this.renderRoutes()}</div>
           </Layout.BackendPanel>

--- a/client/src/backend/containers/resource-collection/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/resource-collection/__tests__/__snapshots__/New-test.js.snap
@@ -6,6 +6,7 @@ exports[`Backend ResourceCollection New Container renders correctly 1`] = `
     className="backend-header"
   >
     <nav
+      aria-label="Breadcrumbs"
       className="backend-header__breadcrumbs breadcrumbs"
     >
       <div

--- a/client/src/backend/containers/resource-collection/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/backend/containers/resource-collection/__tests__/__snapshots__/Resources-test.js.snap
@@ -5,7 +5,7 @@ exports[`Backend ResourceCollection Resources Container renders correctly 1`] = 
   className="entity-list"
   id="entities-list1"
 >
-  <h3
+  <h2
     className="entity-list__title-block entity-list__title"
   >
     <figure
@@ -41,7 +41,7 @@ exports[`Backend ResourceCollection Resources Container renders correctly 1`] = 
         Show collection only
       </span>
     </button>
-  </h3>
+  </h2>
   <div
     className="entity-list__contents-wrapper"
   >
@@ -345,7 +345,7 @@ exports[`Backend ResourceCollection Resources Container renders correctly 1`] = 
             <div
               className="entity-row__text entity-row__text--in-rows"
             >
-              <h4
+              <h3
                 className="entity-row__title entity-row__title--in-rows"
               >
                 <span
@@ -368,8 +368,8 @@ exports[`Backend ResourceCollection Resources Container renders correctly 1`] = 
                 >
                   View Image
                 </span>
-              </h4>
-              <h6
+              </h3>
+              <div
                 className="entity-row__meta entity-row__meta--in-rows"
               >
                 <time
@@ -377,7 +377,7 @@ exports[`Backend ResourceCollection Resources Container renders correctly 1`] = 
                 >
                   Created April 24, 2017
                 </time>
-              </h6>
+              </div>
             </div>
             <div
               className="entity-row__utility"
@@ -435,7 +435,7 @@ exports[`Backend ResourceCollection Resources Container renders correctly 1`] = 
             <div
               className="entity-row__text entity-row__text--in-rows"
             >
-              <h4
+              <h3
                 className="entity-row__title entity-row__title--in-rows"
               >
                 <span
@@ -458,8 +458,8 @@ exports[`Backend ResourceCollection Resources Container renders correctly 1`] = 
                 >
                   View Image
                 </span>
-              </h4>
-              <h6
+              </h3>
+              <div
                 className="entity-row__meta entity-row__meta--in-rows"
               >
                 <time
@@ -467,7 +467,7 @@ exports[`Backend ResourceCollection Resources Container renders correctly 1`] = 
                 >
                   Created April 24, 2017
                 </time>
-              </h6>
+              </div>
             </div>
             <div
               className="entity-row__utility"
@@ -501,6 +501,7 @@ exports[`Backend ResourceCollection Resources Container renders correctly 1`] = 
       className="entity-list__pagination"
     >
       <nav
+        aria-label="Pagination"
         className="list-pagination"
       >
         <ul

--- a/client/src/backend/containers/resource-collection/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/backend/containers/resource-collection/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -6,6 +6,7 @@ exports[`Backend ResourceCollection Wrapper Container renders correctly 1`] = `
     className="backend-header"
   >
     <nav
+      aria-label="Breadcrumbs"
       className="backend-header__breadcrumbs breadcrumbs"
     >
       <div
@@ -219,6 +220,7 @@ exports[`Backend ResourceCollection Wrapper Container renders correctly 1`] = `
           className="aside"
         >
           <nav
+            aria-label="Resource Collection Settings"
             className="secondary-nav panel-nav"
           >
             <ul>

--- a/client/src/backend/containers/resource/Wrapper.js
+++ b/client/src/backend/containers/resource/Wrapper.js
@@ -165,7 +165,13 @@ export class ResourceWrapperContainer extends PureComponent {
             secondaryLinks={secondaryLinks}
           />
           <Layout.BackendPanel
-            sidebar={<Navigation.Secondary links={secondaryLinks} panel />}
+            sidebar={
+              <Navigation.Secondary
+                links={secondaryLinks}
+                panel
+                ariaLabel="Resource Settings"
+              />
+            }
           >
             <div>{this.renderRoutes()}</div>
           </Layout.BackendPanel>

--- a/client/src/backend/containers/resource/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/resource/__tests__/__snapshots__/General-test.js.snap
@@ -233,11 +233,11 @@ exports[`Backend Resource General Container renders correctly 1`] = `
               <div
                 className="association"
               >
-                <h4
+                <div
                   className="association-name"
                 >
                   dog
-                </h4>
+                </div>
               </div>
               <div
                 className="utility"
@@ -276,11 +276,11 @@ exports[`Backend Resource General Container renders correctly 1`] = `
               <div
                 className="association"
               >
-                <h4
+                <div
                   className="association-name"
                 >
                   puppy
-                </h4>
+                </div>
               </div>
               <div
                 className="utility"
@@ -319,11 +319,11 @@ exports[`Backend Resource General Container renders correctly 1`] = `
               <div
                 className="association"
               >
-                <h4
+                <div
                   className="association-name"
                 >
                   GOAT
-                </h4>
+                </div>
               </div>
               <div
                 className="utility"

--- a/client/src/backend/containers/resource/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/resource/__tests__/__snapshots__/New-test.js.snap
@@ -6,6 +6,7 @@ exports[`Backend Resource New Container renders correctly 1`] = `
     className="backend-header"
   >
     <nav
+      aria-label="Breadcrumbs"
       className="backend-header__breadcrumbs breadcrumbs"
     >
       <div

--- a/client/src/backend/containers/resource/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/backend/containers/resource/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -6,6 +6,7 @@ exports[`Backend Resource Wrapper Container renders correctly 1`] = `
     className="backend-header"
   >
     <nav
+      aria-label="Breadcrumbs"
       className="backend-header__breadcrumbs breadcrumbs"
     >
       <div
@@ -231,6 +232,7 @@ exports[`Backend Resource Wrapper Container renders correctly 1`] = `
           className="aside"
         >
           <nav
+            aria-label="Resource Settings"
             className="secondary-nav panel-nav"
           >
             <ul>

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Email-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Email-test.js.snap
@@ -36,9 +36,9 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Message Settings
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"
@@ -179,9 +179,9 @@ The Manifold Team"
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Email Delivery Method
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"
@@ -244,9 +244,9 @@ The Manifold Team"
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Sendmail Configuration
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"
@@ -360,9 +360,9 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Message Settings
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"
@@ -503,9 +503,9 @@ The Manifold Team"
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Email Delivery Method
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"
@@ -568,9 +568,9 @@ The Manifold Team"
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   SMTP Configuration
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Integrations-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Integrations-test.js.snap
@@ -36,9 +36,9 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Facebook
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"
@@ -87,9 +87,9 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Twitter
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"
@@ -174,9 +174,9 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Google Services Integration
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"
@@ -367,9 +367,9 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Google OAuth
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"
@@ -418,9 +418,9 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Google Analytics
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Theme-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Theme-test.js.snap
@@ -36,9 +36,9 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Branding
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"
@@ -463,9 +463,9 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
               <header
                 className="form-section-label"
               >
-                <span>
+                <h2>
                   Typography
-                </span>
+                </h2>
               </header>
               <div
                 className="form-input-group"

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -4,6 +4,7 @@ exports[`Backend Settings Wrapper Container renders correctly 1`] = `
 <section>
   <div>
     <nav
+      aria-label="Secondary Navigation"
       className="secondary-nav"
     >
       <ul>

--- a/client/src/backend/containers/settings/subjects/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/containers/settings/subjects/__tests__/__snapshots__/List-test.js.snap
@@ -56,7 +56,7 @@ Array [
               <div
                 className="entity-row__text entity-row__text--valign-center entity-row__text--in-rows"
               >
-                <h4
+                <h3
                   className="entity-row__title entity-row__title--in-rows"
                 >
                   <span
@@ -70,7 +70,7 @@ Array [
                   >
                     View Hip Hop
                   </span>
-                </h4>
+                </h3>
               </div>
             </div>
           </a>
@@ -80,6 +80,7 @@ Array [
         className="entity-list__pagination"
       >
         <nav
+          aria-label="Pagination"
           className="list-pagination"
         >
           <ul

--- a/client/src/backend/containers/text/Wrapper.js
+++ b/client/src/backend/containers/text/Wrapper.js
@@ -160,7 +160,13 @@ export class TextWrapperContainer extends PureComponent {
             secondaryLinks={secondaryLinks}
           />
           <Layout.BackendPanel
-            sidebar={<Navigation.Secondary links={secondaryLinks} panel />}
+            sidebar={
+              <Navigation.Secondary
+                links={secondaryLinks}
+                panel
+                ariaLabel="Text Settings"
+              />
+            }
           >
             <div>{this.renderRoutes()}</div>
           </Layout.BackendPanel>

--- a/client/src/backend/containers/text/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/backend/containers/text/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -10,11 +10,11 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <h4
+        <h2
           className="form-input-heading"
         >
           Authors
-        </h4>
+        </h2>
         <nav
           className="has-many-list"
         >
@@ -45,11 +45,11 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
                     </svg>
                   </div>
                 </figure>
-                <h4
+                <div
                   className="association-name"
                 >
                   Rowan Ida
-                </h4>
+                </div>
               </div>
               <div
                 className="utility"
@@ -167,11 +167,11 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <h4
+        <h2
           className="form-input-heading"
         >
           Contributors
-        </h4>
+        </h2>
         <nav
           className="has-many-list"
         >
@@ -202,11 +202,11 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
                     </svg>
                   </div>
                 </figure>
-                <h4
+                <div
                   className="association-name"
                 >
                   Rowan Ida
-                </h4>
+                </div>
               </div>
               <div
                 className="utility"

--- a/client/src/backend/containers/text/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/text/__tests__/__snapshots__/General-test.js.snap
@@ -87,11 +87,11 @@ exports[`Backend Text General Container renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <h4
+        <div
           className="form-input-heading"
         >
           Publication Date
-        </h4>
+        </div>
         <div
           className="form-date"
         >

--- a/client/src/backend/containers/text/__tests__/__snapshots__/Metadata-test.js.snap
+++ b/client/src/backend/containers/text/__tests__/__snapshots__/Metadata-test.js.snap
@@ -18,9 +18,9 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                           <FieldGroup label=\\"Identity\\" disabled={false} horizontal={false} wide={false} instructions={{...}}>
                             <div className=\\"form-section\\">
                               <header className=\\"form-section-label\\">
-                                <span>
+                                <h2>
                                   Identity
-                                </span>
+                                </h2>
                               </header>
                               <Instructions instructions={{...}} />
                               <div className=\\"form-input-group\\">
@@ -64,9 +64,9 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                           <FieldGroup label=\\"Publisher\\" disabled={false} horizontal={false} wide={false} instructions={{...}}>
                             <div className=\\"form-section\\">
                               <header className=\\"form-section-label\\">
-                                <span>
+                                <h2>
                                   Publisher
-                                </span>
+                                </h2>
                               </header>
                               <Instructions instructions={{...}} />
                               <div className=\\"form-input-group\\">
@@ -148,9 +148,9 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                           <FieldGroup label=\\"Bibliographic\\" disabled={false} horizontal={false} wide={false} instructions={{...}}>
                             <div className=\\"form-section\\">
                               <header className=\\"form-section-label\\">
-                                <span>
+                                <h2>
                                   Bibliographic
-                                </span>
+                                </h2>
                               </header>
                               <Instructions instructions={{...}} />
                               <div className=\\"form-input-group\\">
@@ -278,9 +278,9 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                           <FieldGroup label=\\"Other\\" disabled={false} horizontal={false} wide={false} instructions={{...}}>
                             <div className=\\"form-section\\">
                               <header className=\\"form-section-label\\">
-                                <span>
+                                <h2>
                                   Other
-                                </span>
+                                </h2>
                               </header>
                               <Instructions instructions={{...}} />
                               <div className=\\"form-input-group\\">

--- a/client/src/backend/containers/text/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/backend/containers/text/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -6,6 +6,7 @@ exports[`Backend Text Wrapper Container renders correctly 1`] = `
     className="backend-header"
   >
     <nav
+      aria-label="Breadcrumbs"
       className="backend-header__breadcrumbs breadcrumbs"
     >
       <div
@@ -255,6 +256,7 @@ exports[`Backend Text Wrapper Container renders correctly 1`] = `
           className="aside"
         >
           <nav
+            aria-label="Text Settings"
             className="secondary-nav panel-nav"
           >
             <ul>

--- a/client/src/backend/containers/users/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/containers/users/__tests__/__snapshots__/List-test.js.snap
@@ -305,7 +305,7 @@ Array [
               <div
                 className="entity-row__text entity-row__text--valign-center entity-row__text--in-rows"
               >
-                <h4
+                <h3
                   className="entity-row__title entity-row__title--in-rows"
                 >
                   <span
@@ -329,7 +329,7 @@ Array [
                   >
                     View Rowan Ida
                   </span>
-                </h4>
+                </h3>
               </div>
             </div>
           </a>
@@ -339,6 +339,7 @@ Array [
         className="entity-list__pagination"
       >
         <nav
+          aria-label="Pagination"
           className="list-pagination"
         >
           <ul

--- a/client/src/frontend/components/TextList/ListItem/Bibliographic.js
+++ b/client/src/frontend/components/TextList/ListItem/Bibliographic.js
@@ -33,7 +33,7 @@ export default class TextListListItemBibliographic extends Component {
     return (
       <div className={`${baseClass}__bibliographic`}>
         <Link to={this.readUrl}>
-          <h3 className={`${baseClass}__name`}>
+          <h4 className={`${baseClass}__name`}>
             <span
               className={`${baseClass}__title`}
               dangerouslySetInnerHTML={{
@@ -45,7 +45,7 @@ export default class TextListListItemBibliographic extends Component {
                 {this.props.subtitle}
               </span>
             )}
-          </h3>
+          </h4>
         </Link>
         {this.props.creatorNames && (
           <div className={`${baseClass}__creators`}>

--- a/client/src/frontend/components/TextList/ListItem/__tests__/__snapshots__/Bibliographic-test.js.snap
+++ b/client/src/frontend/components/TextList/ListItem/__tests__/__snapshots__/Bibliographic-test.js.snap
@@ -8,7 +8,7 @@ exports[`Frontend.TextList.ListItem.Bibliographic component renders correctly 1`
     href="/foo"
     onClick={[Function]}
   >
-    <h3
+    <h4
       className="text-block__name"
     >
       <span
@@ -19,7 +19,7 @@ exports[`Frontend.TextList.ListItem.Bibliographic component renders correctly 1`
           }
         }
       />
-    </h3>
+    </h4>
   </a>
   <div
     className="text-block__creators"

--- a/client/src/frontend/components/TextList/ListItem/__tests__/__snapshots__/Content-test.js.snap
+++ b/client/src/frontend/components/TextList/ListItem/__tests__/__snapshots__/Content-test.js.snap
@@ -36,7 +36,7 @@ exports[`Frontend.TextList.ListItem.Content component renders correctly 1`] = `
         href="/foo"
         onClick={[Function]}
       >
-        <h3
+        <h4
           className="text-block__name"
         >
           <span
@@ -47,7 +47,7 @@ exports[`Frontend.TextList.ListItem.Content component renders correctly 1`] = `
               }
             }
           />
-        </h3>
+        </h4>
       </a>
       <div
         className="text-block__creators"

--- a/client/src/frontend/components/TextList/__tests__/__snapshots__/TextList-test.js.snap
+++ b/client/src/frontend/components/TextList/__tests__/__snapshots__/TextList-test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frontend.TextList component renders correctly 1`] = `
-<nav
+<div
   className="text-list__category"
 >
-  <h4
+  <h3
     className="text-list__category-heading"
   >
     A Label
-  </h4>
+  </h3>
   <ul
     className="text-list__list"
   >
@@ -55,7 +55,7 @@ exports[`Frontend.TextList component renders correctly 1`] = `
                 href="/read/slug-1"
                 onClick={[Function]}
               >
-                <h3
+                <h4
                   className="text-block__name"
                 >
                   <span
@@ -66,7 +66,7 @@ exports[`Frontend.TextList component renders correctly 1`] = `
                       }
                     }
                   />
-                </h3>
+                </h4>
               </a>
               <div
                 className="text-block__creators"
@@ -202,7 +202,7 @@ exports[`Frontend.TextList component renders correctly 1`] = `
                 href="/read/slug-2"
                 onClick={[Function]}
               >
-                <h3
+                <h4
                   className="text-block__name"
                 >
                   <span
@@ -213,7 +213,7 @@ exports[`Frontend.TextList component renders correctly 1`] = `
                       }
                     }
                   />
-                </h3>
+                </h4>
               </a>
               <div
                 className="text-block__creators"
@@ -307,5 +307,5 @@ exports[`Frontend.TextList component renders correctly 1`] = `
       </div>
     </li>
   </ul>
-</nav>
+</div>
 `;

--- a/client/src/frontend/components/TextList/index.js
+++ b/client/src/frontend/components/TextList/index.js
@@ -36,11 +36,11 @@ export default class TextList extends Component {
     if (!this.texts || this.texts.length === 0) return null;
 
     return (
-      <nav className={classNames(`${baseClass}__category`)}>
+      <div className={classNames(`${baseClass}__category`)}>
         {this.props.label && (
-          <h4 className={`${baseClass}__category-heading`}>
+          <h3 className={`${baseClass}__category-heading`}>
             {this.props.label}
-          </h4>
+          </h3>
         )}
         <ul
           className={classNames(`${baseClass}__list`, {
@@ -63,7 +63,7 @@ export default class TextList extends Component {
             );
           })}
         </ul>
-      </nav>
+      </div>
     );
   }
 }

--- a/client/src/frontend/components/content-block/Block/parts/Heading.js
+++ b/client/src/frontend/components/content-block/Block/parts/Heading.js
@@ -21,7 +21,7 @@ export default class ProjectContentBlockHeading extends PureComponent {
           <div className="main">
             <Utility.IconComposer icon={icon} />
             <div className="body">
-              <h4 className="title">{title}</h4>
+              <h2 className="title">{title}</h2>
             </div>
           </div>
         </header>

--- a/client/src/frontend/components/content-block/Block/types/Resources.js
+++ b/client/src/frontend/components/content-block/Block/types/Resources.js
@@ -78,6 +78,7 @@ export default class ProjectContentBlockResourcesBlock extends PureComponent {
       <div className="entity-section-wrapper__body">
         {this.hasVisibleCollections && (
           <React.Fragment>
+            <h3 className="screen-reader-text">Resource Collections</h3>
             <ResourceCollectionList.Grid
               project={this.project}
               resourceCollections={this.visibleCollections}
@@ -89,6 +90,7 @@ export default class ProjectContentBlockResourcesBlock extends PureComponent {
             />
           </React.Fragment>
         )}
+        <h3 className="screen-reader-text">Single Resources</h3>
         <ResourceList.Thumbnails
           project={this.project}
           resources={this.visibleResources}

--- a/client/src/frontend/components/content-block/Block/types/TOCBlock/Contents.js
+++ b/client/src/frontend/components/content-block/Block/types/TOCBlock/Contents.js
@@ -141,7 +141,7 @@ export default class TocBlockToc extends PureComponent {
 
   render() {
     return (
-      <nav role="navigation" className={this.props.blockClass}>
+      <nav aria-label="Table of Contents" className={this.props.blockClass}>
         {this.props.showTextTitle && this.renderTextHeading()}
         {this.renderContents()}
       </nav>

--- a/client/src/frontend/components/event/Tile.js
+++ b/client/src/frontend/components/event/Tile.js
@@ -82,7 +82,7 @@ export class EventTile extends Component {
             )}
             {header && <div className={`${baseClass}__header`}>{header}</div>}
             {title && (
-              <h5
+              <h3
                 className={`${baseClass}__title`}
                 dangerouslySetInnerHTML={{ __html: title }}
               />

--- a/client/src/frontend/components/event/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/frontend/components/event/__tests__/__snapshots__/List-test.js.snap
@@ -37,7 +37,7 @@ exports[`Frontend.Event.List Component renders correctly 1`] = `
           >
             Text Added
           </div>
-          <h5
+          <h3
             className="event-tile__title"
             dangerouslySetInnerHTML={
               Object {
@@ -87,7 +87,7 @@ exports[`Frontend.Event.List Component renders correctly 1`] = `
           >
             Text Added
           </div>
-          <h5
+          <h3
             className="event-tile__title"
             dangerouslySetInnerHTML={
               Object {

--- a/client/src/frontend/components/layout/ButtonNavigation.js
+++ b/client/src/frontend/components/layout/ButtonNavigation.js
@@ -80,10 +80,11 @@ export class LayoutButtonNavigation extends Component {
     return (
       <section className={sectionClass}>
         <div className="container">
-          <nav className="button-nav button-nav--default">
+          <h2 className="screen-reader-text">Project Navigation</h2>
+          <div className="button-nav button-nav--default">
             {this.renderProjectsButton()}
             {this.renderFollowingButton()}
-          </nav>
+          </div>
         </div>
       </section>
     );

--- a/client/src/frontend/components/layout/Footer/Navigation.js
+++ b/client/src/frontend/components/layout/Footer/Navigation.js
@@ -198,7 +198,7 @@ export default class Navigation extends PureComponent {
     const socialLinks = this.buildSocialsArray();
 
     return (
-      <nav className="text-nav">
+      <nav className="text-nav" aria-label="Footer Navigation">
         <ul className="text-nav__list">
           {chunkedPages.map(
             (pageGroup, pageGroupIndex) => (

--- a/client/src/frontend/components/layout/Header.js
+++ b/client/src/frontend/components/layout/Header.js
@@ -11,6 +11,7 @@ import navigation from "helpers/router/navigation";
 import PreHeader from "./PreHeader";
 import BodyClass from "hoc/body-class";
 import BlurOnLocationChange from "hoc/blur-on-location-change";
+import Utility from "global/components/utility";
 
 export default class LayoutHeader extends PureComponent {
   static displayName = "Layout.Header";
@@ -84,6 +85,7 @@ export default class LayoutHeader extends PureComponent {
       <BlurOnLocationChange location={this.props.location}>
         <BodyClass className={bodyClasses}>
           <header className="header-app">
+            <Utility.SkipLink />
             <PreHeader />
             <div className="header-container">
               <Link to={lh.link("frontend")} className="header-logo">

--- a/client/src/frontend/components/layout/Splash.js
+++ b/client/src/frontend/components/layout/Splash.js
@@ -170,23 +170,25 @@ export default class Splash extends Component {
             &nbsp;
           </figure>
           <div className="left">
-            <h2
+            <h1
               style={this.headerStyle()}
               className="heading-primary"
               dangerouslySetInnerHTML={{ __html: this.header() }}
             />
-            <h3
-              style={this.headerStyle()}
-              className="heading-secondary"
-              dangerouslySetInnerHTML={{ __html: this.subheader() }}
-            />
+            {this.subheader() && (
+              <h2
+                style={this.headerStyle()}
+                className="heading-secondary"
+                dangerouslySetInnerHTML={{ __html: this.subheader() }}
+              />
+            )}
             <div
               style={this.foregroundTextStyle()}
               className="feature-body"
               dangerouslySetInnerHTML={{ __html: this.body() }}
             />
             <div className="splash-content" />
-            <nav className="feature__buttons utility-button-group utility-button-group--inline">
+            <div className="feature__buttons utility-button-group utility-button-group--inline">
               {this.hasLink() ? (
                 <a
                   href={this.attribute("linkUrl")}
@@ -229,7 +231,7 @@ export default class Splash extends Component {
                   </span>
                 </span>
               ) : null}
-            </nav>
+            </div>
           </div>
         </div>
       </section>

--- a/client/src/frontend/components/layout/__tests__/__snapshots__/ButtonNavigation-test.js.snap
+++ b/client/src/frontend/components/layout/__tests__/__snapshots__/ButtonNavigation-test.js.snap
@@ -7,7 +7,12 @@ exports[`Frontend.Layout.ButtonNavigation component doesn't render anything when
   <div
     className="container"
   >
-    <nav
+    <h2
+      className="screen-reader-text"
+    >
+      Project Navigation
+    </h2>
+    <div
       className="button-nav button-nav--default"
     >
       <a
@@ -35,7 +40,7 @@ exports[`Frontend.Layout.ButtonNavigation component doesn't render anything when
           See All Projects
         </span>
       </a>
-    </nav>
+    </div>
   </div>
 </section>
 `;
@@ -47,7 +52,12 @@ exports[`Frontend.Layout.ButtonNavigation component renders correctly 1`] = `
   <div
     className="container"
   >
-    <nav
+    <h2
+      className="screen-reader-text"
+    >
+      Project Navigation
+    </h2>
+    <div
       className="button-nav button-nav--default"
     >
       <a
@@ -75,7 +85,7 @@ exports[`Frontend.Layout.ButtonNavigation component renders correctly 1`] = `
           See All Projects
         </span>
       </a>
-    </nav>
+    </div>
   </div>
 </section>
 `;
@@ -87,7 +97,12 @@ exports[`Frontend.Layout.ButtonNavigation component respects the grayBg prop 1`]
   <div
     className="container"
   >
-    <nav
+    <h2
+      className="screen-reader-text"
+    >
+      Project Navigation
+    </h2>
+    <div
       className="button-nav button-nav--default"
     >
       <a
@@ -115,7 +130,7 @@ exports[`Frontend.Layout.ButtonNavigation component respects the grayBg prop 1`]
           See All Projects
         </span>
       </a>
-    </nav>
+    </div>
   </div>
 </section>
 `;
@@ -127,7 +142,12 @@ exports[`Frontend.Layout.ButtonNavigation component respects the showBrowse prop
   <div
     className="container"
   >
-    <nav
+    <h2
+      className="screen-reader-text"
+    >
+      Project Navigation
+    </h2>
+    <div
       className="button-nav button-nav--default"
     >
       <a
@@ -155,7 +175,7 @@ exports[`Frontend.Layout.ButtonNavigation component respects the showBrowse prop
           See All Projects
         </span>
       </a>
-    </nav>
+    </div>
   </div>
 </section>
 `;
@@ -167,7 +187,12 @@ exports[`Frontend.Layout.ButtonNavigation component respects the showFollowing p
   <div
     className="container"
   >
-    <nav
+    <h2
+      className="screen-reader-text"
+    >
+      Project Navigation
+    </h2>
+    <div
       className="button-nav button-nav--default"
     >
       <a
@@ -195,7 +220,7 @@ exports[`Frontend.Layout.ButtonNavigation component respects the showFollowing p
           See All Projects
         </span>
       </a>
-    </nav>
+    </div>
   </div>
 </section>
 `;

--- a/client/src/frontend/components/layout/__tests__/__snapshots__/Footer-tests.js.snap
+++ b/client/src/frontend/components/layout/__tests__/__snapshots__/Footer-tests.js.snap
@@ -66,6 +66,7 @@ exports[`Frontend.Layout.Footer component renders correctly 1`] = `
             className="rel left"
           >
             <nav
+              aria-label="Footer Navigation"
               className="text-nav"
             >
               <ul

--- a/client/src/frontend/components/layout/__tests__/__snapshots__/Header-test.js.snap
+++ b/client/src/frontend/components/layout/__tests__/__snapshots__/Header-test.js.snap
@@ -5,6 +5,13 @@ exports[`Frontend.Layout.Header component renders correctly 1`] = `
   <header
     className="header-app"
   >
+    <a
+      className="skip-to-main screen-reader-text"
+      href="#skip-to-main"
+      onClick={[Function]}
+    >
+      Skip to main content
+    </a>
     <div
       className="header-container"
     >
@@ -48,6 +55,7 @@ exports[`Frontend.Layout.Header component renders correctly 1`] = `
         </figure>
       </a>
       <nav
+        aria-label="Primary Navigation"
         className="page-nav show-75"
       >
         <ul

--- a/client/src/frontend/components/layout/__tests__/__snapshots__/NoFollow-test.js.snap
+++ b/client/src/frontend/components/layout/__tests__/__snapshots__/NoFollow-test.js.snap
@@ -36,7 +36,12 @@ exports[`Frontend.Layout.NoFollow component renders correctly 1`] = `
     <div
       className="container"
     >
-      <nav
+      <h2
+        className="screen-reader-text"
+      >
+        Project Navigation
+      </h2>
+      <div
         className="button-nav button-nav--default"
       >
         <a
@@ -64,7 +69,7 @@ exports[`Frontend.Layout.NoFollow component renders correctly 1`] = `
             See All Projects
           </span>
         </a>
-      </nav>
+      </div>
     </div>
   </section>
 </div>

--- a/client/src/frontend/components/layout/__tests__/__snapshots__/Splash-test.js.snap
+++ b/client/src/frontend/components/layout/__tests__/__snapshots__/Splash-test.js.snap
@@ -16,7 +16,7 @@ exports[`Frontend.Layout.Splash component renders correctly 1`] = `
     <div
       className="left"
     >
-      <h2
+      <h1
         className="heading-primary"
         dangerouslySetInnerHTML={
           Object {
@@ -25,7 +25,7 @@ exports[`Frontend.Layout.Splash component renders correctly 1`] = `
         }
         style={Object {}}
       />
-      <h3
+      <h2
         className="heading-secondary"
         dangerouslySetInnerHTML={
           Object {
@@ -46,7 +46,7 @@ exports[`Frontend.Layout.Splash component renders correctly 1`] = `
       <div
         className="splash-content"
       />
-      <nav
+      <div
         className="feature__buttons utility-button-group utility-button-group--inline"
       >
         <a
@@ -60,7 +60,7 @@ exports[`Frontend.Layout.Splash component renders correctly 1`] = `
             Click it, dog
           </span>
         </a>
-      </nav>
+      </div>
     </div>
   </div>
 </section>

--- a/client/src/frontend/components/project-collection/Detail.js
+++ b/client/src/frontend/components/project-collection/Detail.js
@@ -44,7 +44,7 @@ export default class ProjectCollectionDetail extends Component {
                 fill={iconFill}
               />
               <div className="body">
-                <h4 className="title">{projectCollection.attributes.title}</h4>
+                <h2 className="title">{projectCollection.attributes.title}</h2>
               </div>
             </div>
           </div>

--- a/client/src/frontend/components/project-collection/Placeholder.js
+++ b/client/src/frontend/components/project-collection/Placeholder.js
@@ -60,11 +60,11 @@ export default class ProjectListPlaceholder extends Component {
             <header className="section-heading">
               <div className="main">
                 <div className="body">
-                  <h4 className="title">
+                  <h2 className="title">
                     {
                       "Oh no. There are no project collections in this Manifold Library."
                     }
-                  </h4>
+                  </h2>
                 </div>
               </div>
             </header>

--- a/client/src/frontend/components/project-collection/Summary.js
+++ b/client/src/frontend/components/project-collection/Summary.js
@@ -74,7 +74,7 @@ export default class ProjectCollectionSummary extends Component {
                 fill={iconFill}
               />
               <div className="body">
-                <h4 className="title">{this.collection.attributes.title}</h4>
+                <h2 className="title">{this.collection.attributes.title}</h2>
               </div>
             </div>
           </Link>

--- a/client/src/frontend/components/project-collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/project-collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -29,11 +29,11 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
         <div
           className="body"
         >
-          <h4
+          <h2
             className="title"
           >
             A Project Collection
-          </h4>
+          </h2>
         </div>
       </div>
     </div>
@@ -141,7 +141,7 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
          projects
       </p>
     </div>
-    <nav
+    <div
       className="project-list grid entity-section-wrapper__body"
     >
       <ul>
@@ -512,11 +512,12 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
           </a>
         </li>
       </ul>
-    </nav>
+    </div>
     <div
       className="entity-section-wrapper__pagination"
     >
       <nav
+        aria-label="Pagination"
         className="list-pagination"
       >
         <ul

--- a/client/src/frontend/components/project-collection/__tests__/__snapshots__/Placeholder-test.js.snap
+++ b/client/src/frontend/components/project-collection/__tests__/__snapshots__/Placeholder-test.js.snap
@@ -19,11 +19,11 @@ exports[`Frontend.ProjectCollection.Placeholder component renders correctly 1`] 
           <div
             className="body"
           >
-            <h4
+            <h2
               className="title"
             >
               Oh no. There are no project collections in this Manifold Library.
-            </h4>
+            </h2>
           </div>
         </div>
       </header>

--- a/client/src/frontend/components/project-collection/__tests__/__snapshots__/Summary-test.js.snap
+++ b/client/src/frontend/components/project-collection/__tests__/__snapshots__/Summary-test.js.snap
@@ -31,15 +31,15 @@ exports[`Frontend.ProjectCollection.Placeholder component renders correctly 1`] 
         <div
           className="body"
         >
-          <h4
+          <h2
             className="title"
           >
             A Project Collection
-          </h4>
+          </h2>
         </div>
       </div>
     </a>
-    <nav
+    <div
       className="project-list grid entity-section-wrapper__body"
     >
       <ul>
@@ -227,7 +227,7 @@ exports[`Frontend.ProjectCollection.Placeholder component renders correctly 1`] 
           </a>
         </li>
       </ul>
-    </nav>
+    </div>
     <div
       className="entity-section-wrapper__utility entity-section-wrapper__utility--footer"
     >

--- a/client/src/frontend/components/project-list/Following.js
+++ b/client/src/frontend/components/project-list/Following.js
@@ -45,7 +45,7 @@ export default class ProjectListFollowing extends Component {
             <div className="main">
               <Utility.IconComposer size={56} icon="following64" />
               <div className="body">
-                <h4 className="title">{"Projects You’re Following"}</h4>
+                <h2 className="title">{"Projects You’re Following"}</h2>
               </div>
             </div>
           </header>

--- a/client/src/frontend/components/project-list/Grid.js
+++ b/client/src/frontend/components/project-list/Grid.js
@@ -103,7 +103,7 @@ export default class ProjectListGrid extends Component {
 
     return (
       <React.Fragment>
-        <nav className="project-list grid entity-section-wrapper__body">
+        <div className="project-list grid entity-section-wrapper__body">
           <ReactCSSTransitionGroup
             transitionName="project-list grid"
             transitionEnter={this.enableAnimation}
@@ -126,7 +126,7 @@ export default class ProjectListGrid extends Component {
               );
             })}
           </ReactCSSTransitionGroup>
-        </nav>
+        </div>
         {this.props.pagination
           ? this.renderPagination(this.props)
           : this.renderViewAll(this.props)}

--- a/client/src/frontend/components/project-list/Placeholder.js
+++ b/client/src/frontend/components/project-list/Placeholder.js
@@ -53,9 +53,9 @@ export default class ProjectListPlaceholder extends Component {
             <header className="section-heading">
               <div className="main">
                 <div className="body">
-                  <h4 className="title">
+                  <h2 className="title">
                     {"Uh-oh. This Manifold Library is empty."}
-                  </h4>
+                  </h2>
                 </div>
               </div>
             </header>

--- a/client/src/frontend/components/project-list/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/frontend/components/project-list/__tests__/__snapshots__/Following-test.js.snap
@@ -29,11 +29,11 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
         <div
           className="body"
         >
-          <h4
+          <h2
             className="title"
           >
             Projects You’re Following
-          </h4>
+          </h2>
         </div>
       </div>
     </header>
@@ -161,7 +161,7 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
         Reset Search + Filters
       </button>
     </form>
-    <nav
+    <div
       className="project-list grid entity-section-wrapper__body"
     >
       <ul>
@@ -532,7 +532,7 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
           </a>
         </li>
       </ul>
-    </nav>
+    </div>
   </div>
 </section>
 `;
@@ -573,7 +573,12 @@ exports[`Frontend.ProjectList.Following component renders correctly with no proj
     <div
       className="container"
     >
-      <nav
+      <h2
+        className="screen-reader-text"
+      >
+        Project Navigation
+      </h2>
+      <div
         className="button-nav button-nav--default"
       >
         <a
@@ -601,7 +606,7 @@ exports[`Frontend.ProjectList.Following component renders correctly with no proj
             See All Projects
           </span>
         </a>
-      </nav>
+      </div>
     </div>
   </section>
 </div>

--- a/client/src/frontend/components/project-list/__tests__/__snapshots__/Grid-test.js.snap
+++ b/client/src/frontend/components/project-list/__tests__/__snapshots__/Grid-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frontend.ProjectList.Grid component renders correctly 1`] = `
-<nav
+<div
   className="project-list grid entity-section-wrapper__body"
 >
   <ul>
@@ -273,5 +273,5 @@ exports[`Frontend.ProjectList.Grid component renders correctly 1`] = `
       </a>
     </li>
   </ul>
-</nav>
+</div>
 `;

--- a/client/src/frontend/components/project-list/__tests__/__snapshots__/Placeholder-test.js.snap
+++ b/client/src/frontend/components/project-list/__tests__/__snapshots__/Placeholder-test.js.snap
@@ -19,11 +19,11 @@ exports[`Frontend.ProjectList.Placeholder component renders correctly 1`] = `
           <div
             className="body"
           >
-            <h4
+            <h2
               className="title"
             >
               Uh-oh. This Manifold Library is empty.
-            </h4>
+            </h2>
           </div>
         </div>
       </header>

--- a/client/src/frontend/components/project/Events.js
+++ b/client/src/frontend/components/project/Events.js
@@ -40,7 +40,7 @@ export default class ProjectEvents extends Component {
               <div className="main">
                 <IconComposer icon="recentActivity64" size={56} />
                 <div className="body">
-                  <h4 className="title">{"All Activity"}</h4>
+                  <h2 className="title">{"All Activity"}</h2>
                 </div>
               </div>
             </header>

--- a/client/src/frontend/components/project/Resources.js
+++ b/client/src/frontend/components/project/Resources.js
@@ -12,11 +12,12 @@ export default class ProjectResources extends Component {
     pagination: PropTypes.object,
     paginationClickHandler: PropTypes.func,
     filterChange: PropTypes.func.isRequired,
-    initialFilterState: PropTypes.object
+    initialFilterState: PropTypes.object,
+    itemHeadingLevel: PropTypes.oneOf([2, 3, 4, 5, 6])
   };
 
   render() {
-    const project = this.props.project;
+    const { project, itemHeadingLevel } = this.props;
     return (
       <section>
         <div className="entity-section-wrapper container">
@@ -40,6 +41,7 @@ export default class ProjectResources extends Component {
             pagination={this.props.pagination}
             resources={this.props.resources}
             paginationClickHandler={this.props.paginationClickHandler}
+            itemHeadingLevel={itemHeadingLevel}
           />
         </div>
       </section>

--- a/client/src/frontend/components/project/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/project/__tests__/__snapshots__/Detail-test.js.snap
@@ -236,7 +236,12 @@ exports[`Frontend.Project.Detail component renders correctly 1`] = `
     <div
       className="container"
     >
-      <nav
+      <h2
+        className="screen-reader-text"
+      >
+        Project Navigation
+      </h2>
+      <div
         className="button-nav button-nav--default"
       >
         <a
@@ -264,7 +269,7 @@ exports[`Frontend.Project.Detail component renders correctly 1`] = `
             See All Projects
           </span>
         </a>
-      </nav>
+      </div>
     </div>
   </section>
 </div>
@@ -506,7 +511,12 @@ exports[`Frontend.Project.Detail component renders correctly when hideActivity i
     <div
       className="container"
     >
-      <nav
+      <h2
+        className="screen-reader-text"
+      >
+        Project Navigation
+      </h2>
+      <div
         className="button-nav button-nav--default"
       >
         <a
@@ -534,7 +544,7 @@ exports[`Frontend.Project.Detail component renders correctly when hideActivity i
             See All Projects
           </span>
         </a>
-      </nav>
+      </div>
     </div>
   </section>
 </div>

--- a/client/src/frontend/components/project/__tests__/__snapshots__/Events-test.js.snap
+++ b/client/src/frontend/components/project/__tests__/__snapshots__/Events-test.js.snap
@@ -66,11 +66,11 @@ exports[`Frontend.Project.Events component renders correctly 1`] = `
           <div
             className="body"
           >
-            <h4
+            <h2
               className="title"
             >
               All Activity
-            </h4>
+            </h2>
           </div>
         </div>
       </header>
@@ -110,7 +110,7 @@ exports[`Frontend.Project.Events component renders correctly 1`] = `
                 >
                   Text Added
                 </div>
-                <h5
+                <h3
                   className="event-tile__title"
                   dangerouslySetInnerHTML={
                     Object {
@@ -160,7 +160,7 @@ exports[`Frontend.Project.Events component renders correctly 1`] = `
                 >
                   Text Added
                 </div>
-                <h5
+                <h3
                   className="event-tile__title"
                   dangerouslySetInnerHTML={
                     Object {
@@ -185,6 +185,7 @@ exports[`Frontend.Project.Events component renders correctly 1`] = `
           className="entity-section-wrapper__pagination"
         >
           <nav
+            aria-label="Pagination"
             className="list-pagination"
           >
             <ul
@@ -318,7 +319,12 @@ exports[`Frontend.Project.Events component renders correctly 1`] = `
     <div
       className="container"
     >
-      <nav
+      <h2
+        className="screen-reader-text"
+      >
+        Project Navigation
+      </h2>
+      <div
         className="button-nav button-nav--default"
       >
         <a
@@ -346,7 +352,7 @@ exports[`Frontend.Project.Events component renders correctly 1`] = `
             See All Projects
           </span>
         </a>
-      </nav>
+      </div>
     </div>
   </section>
 </div>

--- a/client/src/frontend/components/project/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/frontend/components/project/__tests__/__snapshots__/Resources-test.js.snap
@@ -184,7 +184,7 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
     <div
       className="entity-section-wrapper__body"
     >
-      <nav
+      <div
         className="resource-list"
       >
         <div
@@ -286,10 +286,9 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
               tabIndex="0"
             >
               <div>
-                <header
-                  className="resource-card__title"
-                >
+                <header>
                   <h4
+                    className="resource-card__title"
                     dangerouslySetInnerHTML={
                       Object {
                         "__html": "Image",
@@ -451,10 +450,9 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
               tabIndex="0"
             >
               <div>
-                <header
-                  className="resource-card__title"
-                >
+                <header>
                   <h4
+                    className="resource-card__title"
                     dangerouslySetInnerHTML={
                       Object {
                         "__html": "Image",
@@ -537,6 +535,7 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
           </li>
         </ul>
         <nav
+          aria-label="Pagination"
           className="list-pagination"
         >
           <ul
@@ -656,7 +655,7 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
             </li>
           </ul>
         </nav>
-      </nav>
+      </div>
     </div>
   </div>
 </section>

--- a/client/src/frontend/components/resource-collection-list/Grid.js
+++ b/client/src/frontend/components/resource-collection-list/Grid.js
@@ -8,7 +8,8 @@ export default class ResourceCollectionGrid extends Component {
 
   static propTypes = {
     project: PropTypes.object.isRequired,
-    resourceCollections: PropTypes.array.isRequired
+    resourceCollections: PropTypes.array.isRequired,
+    itemHeadingLevel: PropTypes.oneOf([2, 3, 4, 5, 6])
   };
 
   urlCreator = collection => {
@@ -20,11 +21,11 @@ export default class ResourceCollectionGrid extends Component {
   };
 
   render() {
-    const resourceCollections = this.props.resourceCollections;
+    const { resourceCollections, itemHeadingLevel } = this.props;
     if (!resourceCollections) return null;
 
     return (
-      <nav className="resource-collections-list">
+      <div className="resource-collections-list">
         <ul>
           {resourceCollections.map(collection => {
             return (
@@ -32,11 +33,12 @@ export default class ResourceCollectionGrid extends Component {
                 key={collection.id}
                 urlCreator={this.urlCreator}
                 resourceCollection={collection}
+                itemHeadingLevel={itemHeadingLevel}
               />
             );
           })}
         </ul>
-      </nav>
+      </div>
     );
   }
 }

--- a/client/src/frontend/components/resource-collection-list/__tests__/__snapshots__/Grid-test.js.snap
+++ b/client/src/frontend/components/resource-collection-list/__tests__/__snapshots__/Grid-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frontend.ResourceCollectionList.Grid component renders correctly 1`] = `
-<nav
+<div
   className="resource-collections-list"
 >
   <ul>
@@ -98,5 +98,5 @@ exports[`Frontend.ResourceCollectionList.Grid component renders correctly 1`] = 
       </a>
     </li>
   </ul>
-</nav>
+</div>
 `;

--- a/client/src/frontend/components/resource-collection/Cover.js
+++ b/client/src/frontend/components/resource-collection/Cover.js
@@ -8,16 +8,31 @@ export default class ResourceCollectionCover extends Component {
 
   static propTypes = {
     resourceCollection: PropTypes.object.isRequired,
-    urlCreator: PropTypes.func.isRequired
+    urlCreator: PropTypes.func.isRequired,
+    itemHeadingLevel: PropTypes.oneOf([2, 3, 4, 5, 6])
   };
+
+  static defaultProps = {
+    itemHeadingLevel: 4
+  };
+
+  get titleTag() {
+    return `h${this.props.itemHeadingLevel}`;
+  }
 
   render() {
     const collectionsBackground = "/static/images/resource-collection.jpg";
-    const resourceCollection = this.props.resourceCollection;
+    const { resourceCollection, itemHeadingLevel } = this.props;
     const attr = resourceCollection.attributes;
     const bgImage = attr.thumbnailStyles.medium
       ? attr.thumbnailStyles.medium
       : collectionsBackground;
+    const Title = props => (
+      <this.titleTag className="collection-title">
+        {props.children}
+      </this.titleTag>
+    );
+
     return (
       <li>
         <Link
@@ -25,7 +40,7 @@ export default class ResourceCollectionCover extends Component {
           style={{ backgroundImage: "url(" + bgImage + ")" }}
         >
           <div className="title-overlay">
-            <h4 className="collection-title">{attr.title}</h4>
+            <Title>{attr.title}</Title>
             <div className="icon">
               <i className="manicon" aria-hidden="true">
                 <Utility.IconComposer size={48} icon="resourceCollection64" />

--- a/client/src/frontend/components/resource-collection/Detail.js
+++ b/client/src/frontend/components/resource-collection/Detail.js
@@ -47,6 +47,7 @@ export default class ResourceCollectionDetail extends PureComponent {
             <Utility.ShareBar url={this.props.resourceCollectionUrl} />
           </div>
         </div>
+        <h2 className="screen-reader-text">Resource Slideshow</h2>
         <ResourceList.Slideshow
           resourceCollection={this.props.resourceCollection}
           collectionResources={this.props.slideshowResources}
@@ -55,6 +56,7 @@ export default class ResourceCollectionDetail extends PureComponent {
           dispatch={this.props.dispatch}
         />
         <div className="container flush-top">
+          <h2 className="screen-reader-text">Resource List</h2>
           <ResourceList.Totals
             belongsTo="collection"
             count={count}
@@ -74,6 +76,7 @@ export default class ResourceCollectionDetail extends PureComponent {
             paginationClickHandler={
               this.props.resourceCollectionPaginationHandler
             }
+            itemHeadingLevel={3}
           />
         </div>
       </section>

--- a/client/src/frontend/components/resource-collection/Title.js
+++ b/client/src/frontend/components/resource-collection/Title.js
@@ -44,7 +44,7 @@ export default class ResourceCollectionTitle extends Component {
         <div className="main">
           <Utility.IconComposer size={54} icon="resourceCollection64" />
           <div className="body">
-            <h2 className="title">{attr.title}</h2>
+            <h1 className="title">{attr.title}</h1>
             {this.renderDate(attr)}
           </div>
         </div>

--- a/client/src/frontend/components/resource-collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/resource-collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -29,11 +29,11 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
         <div
           className="body"
         >
-          <h2
+          <h1
             className="title"
           >
             Rowan
-          </h2>
+          </h1>
           <span
             className="date"
           >
@@ -50,6 +50,7 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
       className="collection-detail__utility"
     >
       <nav
+        aria-label="Share"
         className="share-nav-primary"
       >
         <span
@@ -92,6 +93,11 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
       </nav>
     </div>
   </div>
+  <h2
+    className="screen-reader-text"
+  >
+    Resource Slideshow
+  </h2>
   <div
     className="resource-slideshow"
   >
@@ -151,7 +157,7 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
           className="resource-slideshow__caption"
         >
           <header>
-            <h2
+            <h3
               className="resource-slideshow__title"
               dangerouslySetInnerHTML={
                 Object {
@@ -332,6 +338,11 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
   <div
     className="container flush-top"
   >
+    <h2
+      className="screen-reader-text"
+    >
+      Resource List
+    </h2>
     <div
       className="resource-total"
     >
@@ -526,7 +537,7 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
     <div
       className="entity-section-wrapper__body"
     >
-      <nav
+      <div
         className="resource-list"
       >
         <div
@@ -628,10 +639,9 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
               tabIndex="0"
             >
               <div>
-                <header
-                  className="resource-card__title"
-                >
-                  <h4
+                <header>
+                  <h3
+                    className="resource-card__title"
                     dangerouslySetInnerHTML={
                       Object {
                         "__html": "Image",
@@ -714,6 +724,7 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
           </li>
         </ul>
         <nav
+          aria-label="Pagination"
           className="list-pagination"
         >
           <ul
@@ -833,7 +844,7 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
             </li>
           </ul>
         </nav>
-      </nav>
+      </div>
     </div>
   </div>
 </section>

--- a/client/src/frontend/components/resource-list/Cards.js
+++ b/client/src/frontend/components/resource-list/Cards.js
@@ -12,16 +12,17 @@ export default class ResourceListCards extends PureComponent {
     resources: PropTypes.array.isRequired,
     project: PropTypes.object.isRequired,
     pagination: PropTypes.object,
-    paginationClickHandler: PropTypes.func
+    paginationClickHandler: PropTypes.func,
+    itemHeadingLevel: PropTypes.oneOf([2, 3, 4, 5, 6])
   };
 
   render() {
     if (!this.props.resources) return null;
-    const project = this.props.project;
+    const { project, itemHeadingLevel } = this.props;
 
     return (
       <div className="entity-section-wrapper__body">
-        <nav className="resource-list">
+        <div className="resource-list">
           <div className="resource-count">
             <Utility.EntityCount
               pagination={this.props.pagination}
@@ -42,6 +43,7 @@ export default class ResourceListCards extends PureComponent {
                   key={resource.id}
                   resource={resource}
                   project={this.props.project}
+                  itemHeadingLevel={itemHeadingLevel}
                 />
               );
             })}
@@ -52,7 +54,7 @@ export default class ResourceListCards extends PureComponent {
               pagination={this.props.pagination}
             />
           ) : null}
-        </nav>
+        </div>
       </div>
     );
   }

--- a/client/src/frontend/components/resource-list/Thumbnails.js
+++ b/client/src/frontend/components/resource-list/Thumbnails.js
@@ -15,7 +15,7 @@ export default class ResourceListThumbnails extends Component {
   render() {
     if (!this.props.resources) return null;
     return (
-      <nav className="resource-thumbnail-list">
+      <div className="resource-thumbnail-list">
         <ul>
           {this.props.resources.map(resource => {
             return (
@@ -38,7 +38,7 @@ export default class ResourceListThumbnails extends Component {
             );
           })}
         </ul>
-      </nav>
+      </div>
     );
   }
 }

--- a/client/src/frontend/components/resource-list/__tests__/__snapshots__/Cards-test.js.snap
+++ b/client/src/frontend/components/resource-list/__tests__/__snapshots__/Cards-test.js.snap
@@ -4,7 +4,7 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
 <div
   className="entity-section-wrapper__body"
 >
-  <nav
+  <div
     className="resource-list"
   >
     <div
@@ -106,10 +106,9 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
           tabIndex="0"
         >
           <div>
-            <header
-              className="resource-card__title"
-            >
+            <header>
               <h4
+                className="resource-card__title"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "Image",
@@ -271,10 +270,9 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
           tabIndex="0"
         >
           <div>
-            <header
-              className="resource-card__title"
-            >
+            <header>
               <h4
+                className="resource-card__title"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "Image",
@@ -357,6 +355,7 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
       </li>
     </ul>
     <nav
+      aria-label="Pagination"
       className="list-pagination"
     >
       <ul
@@ -480,6 +479,6 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
         </li>
       </ul>
     </nav>
-  </nav>
+  </div>
 </div>
 `;

--- a/client/src/frontend/components/resource-list/__tests__/__snapshots__/Slideshow-test.js.snap
+++ b/client/src/frontend/components/resource-list/__tests__/__snapshots__/Slideshow-test.js.snap
@@ -60,7 +60,7 @@ exports[`Frontend.ResourceList.Slideshow Component renders correctly 1`] = `
         className="resource-slideshow__caption"
       >
         <header>
-          <h2
+          <h3
             className="resource-slideshow__title"
             dangerouslySetInnerHTML={
               Object {

--- a/client/src/frontend/components/resource-list/__tests__/__snapshots__/Thumbnails-test.js.snap
+++ b/client/src/frontend/components/resource-list/__tests__/__snapshots__/Thumbnails-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frontend.ResourceList.Thumbnails Component renders correctly 1`] = `
-<nav
+<div
   className="resource-thumbnail-list"
 >
   <ul>
@@ -112,5 +112,5 @@ exports[`Frontend.ResourceList.Thumbnails Component renders correctly 1`] = `
       </a>
     </li>
   </ul>
-</nav>
+</div>
 `;

--- a/client/src/frontend/components/resource-slide/Caption.js
+++ b/client/src/frontend/components/resource-slide/Caption.js
@@ -160,7 +160,7 @@ export default class ResourceListSlideCaption extends Component {
     return (
       <div className="resource-slideshow__caption">
         <header>
-          <h2
+          <h3
             className="resource-slideshow__title"
             dangerouslySetInnerHTML={{ __html: attr.titleFormatted }}
           />

--- a/client/src/frontend/components/resource-slide/__tests__/__snapshots__/Caption-test.js.snap
+++ b/client/src/frontend/components/resource-slide/__tests__/__snapshots__/Caption-test.js.snap
@@ -5,7 +5,7 @@ exports[`Frontend.ResourceList.Slide.Caption component renders correctly 1`] = `
   className="resource-slideshow__caption"
 >
   <header>
-    <h2
+    <h3
       className="resource-slideshow__title"
       dangerouslySetInnerHTML={
         Object {

--- a/client/src/frontend/components/resource/Card.js
+++ b/client/src/frontend/components/resource/Card.js
@@ -17,7 +17,12 @@ class ResourceCard extends Component {
     history: PropTypes.object.isRequired,
     resource: PropTypes.object,
     project: PropTypes.object.isRequired,
-    resourceCollection: PropTypes.object
+    resourceCollection: PropTypes.object,
+    itemHeadingLevel: PropTypes.oneOf([2, 3, 4, 5, 6])
+  };
+
+  static defaultProps = {
+    itemHeadingLevel: 4
   };
 
   constructor() {
@@ -25,6 +30,10 @@ class ResourceCard extends Component {
     this.state = {
       infoHover: false
     };
+  }
+
+  get titleTag() {
+    return `h${this.props.itemHeadingLevel}`;
   }
 
   getResourceType(type) {
@@ -170,11 +179,18 @@ class ResourceCard extends Component {
     const resource = this.props.resource;
     if (!resource) return null;
     const attr = resource.attributes;
+    const Title = props => (
+      <this.titleTag
+        className="resource-card__title"
+        dangerouslySetInnerHTML={{ __html: props.children }}
+      />
+    );
 
     const infoClass = classNames({
       "resource-card__info": true,
       "resource-card__info--hover": this.state.infoHover
     });
+
     return (
       <li className="resource-card">
         <Preview resource={resource}>
@@ -201,8 +217,8 @@ class ResourceCard extends Component {
         >
           {/* eslint-enable jsx-a11y/no-noninteractive-element-to-interactive-role */}
           <div>
-            <header className="resource-card__title">
-              <h4 dangerouslySetInnerHTML={{ __html: attr.titleFormatted }} />
+            <header>
+              <Title>{attr.titleFormatted}</Title>
             </header>
             <span className="resource-card__date">
               Uploaded{" "}

--- a/client/src/frontend/components/resource/Detail.js
+++ b/client/src/frontend/components/resource/Detail.js
@@ -65,7 +65,7 @@ export default class ResourceDetail extends Component {
                   dangerouslySetInnerHTML={{ __html: attr.captionFormatted }}
                 />
 
-                <h3 className="attribute-header">Full Description</h3>
+                <h2 className="attribute-header">Full Description</h2>
                 <div
                   dangerouslySetInnerHTML={this.createDescription(
                     attr.descriptionFormatted

--- a/client/src/frontend/components/resource/__tests__/__snapshots__/Card-test.js.snap
+++ b/client/src/frontend/components/resource/__tests__/__snapshots__/Card-test.js.snap
@@ -82,10 +82,9 @@ exports[`Frontend.Resource.Card component renders correctly 1`] = `
     tabIndex="0"
   >
     <div>
-      <header
-        className="resource-card__title"
-      >
+      <header>
         <h4
+          className="resource-card__title"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Image",

--- a/client/src/frontend/components/resource/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/resource/__tests__/__snapshots__/Detail-test.js.snap
@@ -107,6 +107,7 @@ exports[`Frontend.Resource.Detail component renders correctly 1`] = `
             </svg>
           </a>
           <nav
+            aria-label="Share"
             className="share-nav-primary"
           >
             <span
@@ -397,11 +398,11 @@ exports[`Frontend.Resource.Detail component renders correctly 1`] = `
               }
             }
           />
-          <h3
+          <h2
             className="attribute-header"
           >
             Full Description
-          </h3>
+          </h2>
           <div
             dangerouslySetInnerHTML={
               Object {
@@ -415,7 +416,7 @@ exports[`Frontend.Resource.Detail component renders correctly 1`] = `
             <div
               className="comment-editor"
             >
-              <h3
+              <h2
                 className="comment-editor__editor-label"
               >
                 <svg
@@ -436,7 +437,7 @@ exports[`Frontend.Resource.Detail component renders correctly 1`] = `
                 >
                   Add Comment
                 </span>
-              </h3>
+              </h2>
               <div
                 className="placeholder"
               >

--- a/client/src/frontend/components/utility/ShareBar.js
+++ b/client/src/frontend/components/utility/ShareBar.js
@@ -62,7 +62,7 @@ class ShareBar extends Component {
     const twitterWindowOptions = ["", "", "width=600,height=300"];
 
     return (
-      <nav className="share-nav-primary">
+      <nav className="share-nav-primary" aria-label="Share">
         {this.props.label && (
           <span className="share-nav-primary__label">{this.props.label}</span>
         )}

--- a/client/src/frontend/components/utility/__tests__/__snapshots__/Sharebar-test.js.snap
+++ b/client/src/frontend/components/utility/__tests__/__snapshots__/Sharebar-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Frontend.Utility.ShareBar component renders correctly 1`] = `
 <nav
+  aria-label="Share"
   className="share-nav-primary"
 >
   <span

--- a/client/src/frontend/containers/Contact/index.js
+++ b/client/src/frontend/containers/Contact/index.js
@@ -68,7 +68,7 @@ export class ContactContainer extends Component {
       <section>
         <div className="container">
           <form method="post" onSubmit={this.sendMessage}>
-            <h4 className="form-heading">Send a Message</h4>
+            <h1 className="form-heading">Send a Message</h1>
             <div className="row-1-p">
               <Form.Errorable
                 className="form-input"

--- a/client/src/frontend/containers/EventList/__tests__/__snapshots__/EventList-test.js.snap
+++ b/client/src/frontend/containers/EventList/__tests__/__snapshots__/EventList-test.js.snap
@@ -66,11 +66,11 @@ exports[`Frontend EventList Container renders correctly 1`] = `
           <div
             className="body"
           >
-            <h4
+            <h2
               className="title"
             >
               All Activity
-            </h4>
+            </h2>
           </div>
         </div>
       </header>
@@ -110,7 +110,7 @@ exports[`Frontend EventList Container renders correctly 1`] = `
                 >
                   Text Added
                 </div>
-                <h5
+                <h3
                   className="event-tile__title"
                   dangerouslySetInnerHTML={
                     Object {
@@ -160,7 +160,7 @@ exports[`Frontend EventList Container renders correctly 1`] = `
                 >
                   Text Added
                 </div>
-                <h5
+                <h3
                   className="event-tile__title"
                   dangerouslySetInnerHTML={
                     Object {
@@ -185,6 +185,7 @@ exports[`Frontend EventList Container renders correctly 1`] = `
           className="entity-section-wrapper__pagination"
         >
           <nav
+            aria-label="Pagination"
             className="list-pagination"
           >
             <ul
@@ -318,7 +319,12 @@ exports[`Frontend EventList Container renders correctly 1`] = `
     <div
       className="container"
     >
-      <nav
+      <h2
+        className="screen-reader-text"
+      >
+        Project Navigation
+      </h2>
+      <div
         className="button-nav button-nav--default"
       >
         <a
@@ -346,7 +352,7 @@ exports[`Frontend EventList Container renders correctly 1`] = `
             See All Projects
           </span>
         </a>
-      </nav>
+      </div>
     </div>
   </section>
 </div>

--- a/client/src/frontend/containers/Featured/__tests__/__snapshots__/Featured-test.js.snap
+++ b/client/src/frontend/containers/Featured/__tests__/__snapshots__/Featured-test.js.snap
@@ -8,6 +8,11 @@ exports[`Frontend Featured Container renders correctly 1`] = `
     }
   }
 >
+  <h1
+    className="screen-reader-text"
+  >
+    Featured Projects
+  </h1>
   <section
     className="bg-neutral05"
   >
@@ -36,11 +41,11 @@ exports[`Frontend Featured Container renders correctly 1`] = `
           <div
             className="body"
           >
-            <h4
+            <h2
               className="title"
             >
               Featured Projects
-            </h4>
+            </h2>
           </div>
         </div>
       </header>
@@ -136,7 +141,7 @@ exports[`Frontend Featured Container renders correctly 1`] = `
           Reset Search + Filters
         </button>
       </form>
-      <nav
+      <div
         className="project-list grid entity-section-wrapper__body"
       >
         <ul>
@@ -675,7 +680,7 @@ exports[`Frontend Featured Container renders correctly 1`] = `
             </a>
           </li>
         </ul>
-      </nav>
+      </div>
     </div>
   </section>
   <section
@@ -684,7 +689,12 @@ exports[`Frontend Featured Container renders correctly 1`] = `
     <div
       className="container"
     >
-      <nav
+      <h2
+        className="screen-reader-text"
+      >
+        Project Navigation
+      </h2>
+      <div
         className="button-nav button-nav--default"
       >
         <a
@@ -712,7 +722,7 @@ exports[`Frontend Featured Container renders correctly 1`] = `
             See All Projects
           </span>
         </a>
-      </nav>
+      </div>
     </div>
   </section>
 </div>

--- a/client/src/frontend/containers/Featured/index.js
+++ b/client/src/frontend/containers/Featured/index.js
@@ -81,13 +81,14 @@ export class FeaturedContainer extends Component {
         }}
       >
         <HeadContent title="Featured" appendTitle />
+        <h1 className="screen-reader-text">Featured Projects</h1>
         <section className="bg-neutral05">
           <div className="entity-section-wrapper container">
             <header className="entity-section-wrapper__heading section-heading">
               <div className="main">
                 <Utility.IconComposer size={56} icon="lamp64" />
                 <div className="body">
-                  <h4 className="title">{"Featured Projects"}</h4>
+                  <h2 className="title">{"Featured Projects"}</h2>
                 </div>
               </div>
             </header>

--- a/client/src/frontend/containers/Following/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/frontend/containers/Following/__tests__/__snapshots__/Following-test.js.snap
@@ -2,6 +2,11 @@
 
 exports[`Frontend Following Container renders correctly 1`] = `
 <div>
+  <h1
+    className="screen-reader-text"
+  >
+    Projects You’re Following
+  </h1>
   <section
     className="bg-neutral05"
   >
@@ -30,11 +35,11 @@ exports[`Frontend Following Container renders correctly 1`] = `
           <div
             className="body"
           >
-            <h4
+            <h2
               className="title"
             >
               Projects You’re Following
-            </h4>
+            </h2>
           </div>
         </div>
       </header>
@@ -162,7 +167,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
           Reset Search + Filters
         </button>
       </form>
-      <nav
+      <div
         className="project-list grid entity-section-wrapper__body"
       >
         <ul>
@@ -701,7 +706,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
             </a>
           </li>
         </ul>
-      </nav>
+      </div>
     </div>
   </section>
   <section>
@@ -730,15 +735,15 @@ exports[`Frontend Following Container renders correctly 1`] = `
           <div
             className="body"
           >
-            <h4
+            <h2
               className="title"
             >
               Featured Projects
-            </h4>
+            </h2>
           </div>
         </div>
       </header>
-      <nav
+      <div
         className="project-list grid entity-section-wrapper__body"
       >
         <ul>
@@ -1277,7 +1282,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
             </a>
           </li>
         </ul>
-      </nav>
+      </div>
     </div>
   </section>
   <section
@@ -1286,7 +1291,12 @@ exports[`Frontend Following Container renders correctly 1`] = `
     <div
       className="container"
     >
-      <nav
+      <h2
+        className="screen-reader-text"
+      >
+        Project Navigation
+      </h2>
+      <div
         className="button-nav button-nav--default"
       >
         <a
@@ -1314,7 +1324,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
             See All Projects
           </span>
         </a>
-      </nav>
+      </div>
     </div>
   </section>
 </div>

--- a/client/src/frontend/containers/Following/index.js
+++ b/client/src/frontend/containers/Following/index.js
@@ -129,7 +129,7 @@ export class FollowingContainer extends Component {
             <div className="main">
               <Utility.IconComposer size={56} icon="lamp64" />
               <div className="body">
-                <h4 className="title">{"Featured Projects"}</h4>
+                <h2 className="title">{"Featured Projects"}</h2>
               </div>
             </div>
             {this.renderFeaturedButton(featuredLimit)}
@@ -165,6 +165,7 @@ export class FollowingContainer extends Component {
       >
         <div>
           <HeadContent title="Following" appendTitle />
+          <h1 className="screen-reader-text">Projects You’re Following</h1>
           <ProjectList.Following
             followedProjects={this.props.followedProjects}
             authentication={this.props.authentication}

--- a/client/src/frontend/containers/Frontend/__tests__/__snapshots__/Frontend-test.js.snap
+++ b/client/src/frontend/containers/Frontend/__tests__/__snapshots__/Frontend-test.js.snap
@@ -2,13 +2,6 @@
 
 exports[`Frontend Frontend Container renders correctly 1`] = `
 <div>
-  <a
-    className="skip-to-main screen-reader-text"
-    href="#skip-to-main"
-    onClick={[Function]}
-  >
-    Skip to main content
-  </a>
   <div
     className="scroll-aware top pinned"
   >
@@ -16,6 +9,13 @@ exports[`Frontend Frontend Container renders correctly 1`] = `
       <header
         className="header-app"
       >
+        <a
+          className="skip-to-main screen-reader-text"
+          href="#skip-to-main"
+          onClick={[Function]}
+        >
+          Skip to main content
+        </a>
         <div
           className="header-container"
         >
@@ -59,6 +59,7 @@ exports[`Frontend Frontend Container renders correctly 1`] = `
             </figure>
           </a>
           <nav
+            aria-label="Primary Navigation"
             className="page-nav show-75"
           >
             <ul
@@ -303,6 +304,7 @@ exports[`Frontend Frontend Container renders correctly 1`] = `
               className="rel left"
             >
               <nav
+                aria-label="Footer Navigation"
                 className="text-nav"
               >
                 <ul

--- a/client/src/frontend/containers/Frontend/index.js
+++ b/client/src/frontend/containers/Frontend/index.js
@@ -85,7 +85,6 @@ export class FrontendContainer extends Component {
     return (
       <BodyClass className={"browse"}>
         <div>
-          <Utility.SkipLink />
           <Utility.ScrollToTop />
           <ScrollAware>
             <Layout.Header

--- a/client/src/frontend/containers/Home/Projects.js
+++ b/client/src/frontend/containers/Home/Projects.js
@@ -62,7 +62,7 @@ export class HomeProjectsContainer extends Component {
             <div className="main">
               <Utility.IconComposer size={56} icon="projects64" />
               <div className="body">
-                <h4 className="title">{"Our Projects"}</h4>
+                <h2 className="title">{"Our Projects"}</h2>
               </div>
             </div>
           </header>

--- a/client/src/frontend/containers/Home/__tests__/__snapshots__/Home-test.js.snap
+++ b/client/src/frontend/containers/Home/__tests__/__snapshots__/Home-test.js.snap
@@ -14,7 +14,12 @@ exports[`Frontend Home Container renders correctly 1`] = `
     <div
       className="container"
     >
-      <nav
+      <h2
+        className="screen-reader-text"
+      >
+        Project Navigation
+      </h2>
+      <div
         className="button-nav button-nav--default"
       >
         <a
@@ -42,7 +47,7 @@ exports[`Frontend Home Container renders correctly 1`] = `
             See All Projects
           </span>
         </a>
-      </nav>
+      </div>
     </div>
   </section>
 </div>
@@ -62,7 +67,12 @@ exports[`Frontend Home Container renders correctly with project collections pres
     <div
       className="container"
     >
-      <nav
+      <h2
+        className="screen-reader-text"
+      >
+        Project Navigation
+      </h2>
+      <div
         className="button-nav button-nav--default"
       >
         <a
@@ -90,7 +100,7 @@ exports[`Frontend Home Container renders correctly with project collections pres
             See All Projects
           </span>
         </a>
-      </nav>
+      </div>
     </div>
   </section>
 </div>

--- a/client/src/frontend/containers/ProjectCollectionDetail/__tests__/__snapshots__/ProjectCollectionDetail-test.js.snap
+++ b/client/src/frontend/containers/ProjectCollectionDetail/__tests__/__snapshots__/ProjectCollectionDetail-test.js.snap
@@ -34,6 +34,11 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
       />
     </div>
   </a>
+  <h1
+    className="screen-reader-text"
+  >
+    A Project Collection
+  </h1>
   <section
     className="bg-neutral05"
   >
@@ -62,11 +67,11 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
           <div
             className="body"
           >
-            <h4
+            <h2
               className="title"
             >
               A Project Collection
-            </h4>
+            </h2>
           </div>
         </div>
       </div>
@@ -174,7 +179,7 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
            projects
         </p>
       </div>
-      <nav
+      <div
         className="project-list grid entity-section-wrapper__body"
       >
         <ul>
@@ -545,11 +550,12 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
             </a>
           </li>
         </ul>
-      </nav>
+      </div>
       <div
         className="entity-section-wrapper__pagination"
       >
         <nav
+          aria-label="Pagination"
           className="list-pagination"
         >
           <ul
@@ -682,7 +688,12 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
     <div
       className="container"
     >
-      <nav
+      <h2
+        className="screen-reader-text"
+      >
+        Project Navigation
+      </h2>
+      <div
         className="button-nav button-nav--default"
       >
         <a
@@ -710,7 +721,7 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
             See Project Collections
           </span>
         </a>
-      </nav>
+      </div>
     </div>
   </section>
 </div>

--- a/client/src/frontend/containers/ProjectCollectionDetail/index.js
+++ b/client/src/frontend/containers/ProjectCollectionDetail/index.js
@@ -171,6 +171,9 @@ export class ProjectCollectionDetailContainer extends Component {
             this.props.projectCollection.attributes.descriptionPlaintext
           }
         />
+        <h1 className="screen-reader-text">
+          {this.props.projectCollection.attributes.title}
+        </h1>
         {this.renderProjects(this.props)}
         <Layout.ButtonNavigation
           showFollowing={false}

--- a/client/src/frontend/containers/ProjectCollections/__tests__/__snapshots__/ProjectCollections-test.js.snap
+++ b/client/src/frontend/containers/ProjectCollections/__tests__/__snapshots__/ProjectCollections-test.js.snap
@@ -40,6 +40,11 @@ exports[`Frontend ProjectCollections Container renders correctly 1`] = `
       />
     </div>
   </a>
+  <h1
+    className="screen-reader-text"
+  >
+    Project Collections
+  </h1>
   <section
     className="project-collection-summary bg-neutral05"
   >
@@ -70,11 +75,11 @@ exports[`Frontend ProjectCollections Container renders correctly 1`] = `
           <div
             className="body"
           >
-            <h4
+            <h2
               className="title"
             >
               A Project Collection
-            </h4>
+            </h2>
           </div>
         </div>
       </a>
@@ -119,11 +124,11 @@ exports[`Frontend ProjectCollections Container renders correctly 1`] = `
           <div
             className="body"
           >
-            <h4
+            <h2
               className="title"
             >
               A Project Collection
-            </h4>
+            </h2>
           </div>
         </div>
       </a>

--- a/client/src/frontend/containers/ProjectCollections/index.js
+++ b/client/src/frontend/containers/ProjectCollections/index.js
@@ -124,6 +124,7 @@ export class ProjectsCollectionsContainer extends Component {
           link={lh.link("frontendProjectsAll")}
           backText={"Back to projects"}
         />
+        <h1 className="screen-reader-text">Project Collections</h1>
         {this.renderProjectCollections()}
         {this.props.projectCollectionsMeta ? (
           <GlobalUtility.Pagination

--- a/client/src/frontend/containers/ProjectDetail/__tests__/__snapshots__/ProjectDetail-test.js.snap
+++ b/client/src/frontend/containers/ProjectDetail/__tests__/__snapshots__/ProjectDetail-test.js.snap
@@ -239,7 +239,12 @@ exports[`Frontend ProjectDetail Container renders correctly 1`] = `
       <div
         className="container"
       >
-        <nav
+        <h2
+          className="screen-reader-text"
+        >
+          Project Navigation
+        </h2>
+        <div
           className="button-nav button-nav--default"
         >
           <a
@@ -267,7 +272,7 @@ exports[`Frontend ProjectDetail Container renders correctly 1`] = `
               See All Projects
             </span>
           </a>
-        </nav>
+        </div>
       </div>
     </section>
   </div>

--- a/client/src/frontend/containers/ProjectResourceCollections/index.js
+++ b/client/src/frontend/containers/ProjectResourceCollections/index.js
@@ -93,6 +93,9 @@ class ProjectResourceCollectionsContainer extends Component {
           description={project.attributes.description}
           image={project.attributes.heroStyles.medium}
         />
+        <h1 className="screen-reader-text">
+          {`${project.attributes.titlePlaintext} Resource Collections`}
+        </h1>
         <section className="bg-neutral05">
           <Utility.BackLinkPrimary
             link={lh.link("frontendProject", project.attributes.slug)}
@@ -105,6 +108,7 @@ class ProjectResourceCollectionsContainer extends Component {
               <ResourceCollectionList.Grid
                 project={this.props.project}
                 resourceCollections={this.props.resourceCollections}
+                itemHeadingLevel={2}
               />
             )}
             {this.props.meta && (

--- a/client/src/frontend/containers/ProjectResources/__tests__/__snapshots__/ProjectResources-test.js.snap
+++ b/client/src/frontend/containers/ProjectResources/__tests__/__snapshots__/ProjectResources-test.js.snap
@@ -2,6 +2,11 @@
 
 exports[`Frontend ProjectResources Container renders correctly 1`] = `
 <div>
+  <h1
+    className="screen-reader-text"
+  >
+    Rowan Test Resources
+  </h1>
   <section
     className="bg-neutral05"
   >
@@ -223,7 +228,7 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
       <div
         className="entity-section-wrapper__body"
       >
-        <nav
+        <div
           className="resource-list"
         >
           <div
@@ -325,10 +330,9 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
                 tabIndex="0"
               >
                 <div>
-                  <header
-                    className="resource-card__title"
-                  >
-                    <h4
+                  <header>
+                    <h3
+                      className="resource-card__title"
                       dangerouslySetInnerHTML={
                         Object {
                           "__html": "Image",
@@ -411,6 +415,7 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
             </li>
           </ul>
           <nav
+            aria-label="Pagination"
             className="list-pagination"
           >
             <ul
@@ -534,7 +539,7 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
               </li>
             </ul>
           </nav>
-        </nav>
+        </div>
       </div>
     </div>
   </section>

--- a/client/src/frontend/containers/ProjectResources/index.js
+++ b/client/src/frontend/containers/ProjectResources/index.js
@@ -156,6 +156,9 @@ class ProjectResourcesContainer extends Component {
           description={project.attributes.description}
           image={project.attributes.heroStyles.medium}
         />
+        <h1 className="screen-reader-text">
+          {`${project.attributes.titlePlaintext} Resources`}
+        </h1>
         <section className="bg-neutral05">
           <Utility.BackLinkPrimary
             link={lh.link("frontendProject", project.attributes.slug)}
@@ -170,6 +173,7 @@ class ProjectResourcesContainer extends Component {
             paginationClickHandler={this.pageChangeHandlerCreator}
             filterChange={this.filterChange}
             initialFilterState={initialFilter}
+            itemHeadingLevel={3}
           />
         ) : null}
         <section className="bg-neutral05">

--- a/client/src/frontend/containers/Projects/index.js
+++ b/client/src/frontend/containers/Projects/index.js
@@ -141,7 +141,7 @@ export class ProjectsContainer extends Component {
             <div className="main">
               <Utility.IconComposer size={56} icon="projects64" />
               <div className="body">
-                <h4 className="title">{"All Projects"}</h4>
+                <h2 className="title">{"All Projects"}</h2>
               </div>
             </div>
           </header>
@@ -181,6 +181,7 @@ export class ProjectsContainer extends Component {
           overflowX: "hidden"
         }}
       >
+        <h1 className="screen-reader-text">All Projects</h1>
         {this.renderProjectLibrary()}
         <Layout.ButtonNavigation
           showProjectCollections

--- a/client/src/frontend/containers/ResourceCollectionDetail/__tests__/__snapshots__/ResourceCollectionDetail-test.js.snap
+++ b/client/src/frontend/containers/ResourceCollectionDetail/__tests__/__snapshots__/ResourceCollectionDetail-test.js.snap
@@ -64,11 +64,11 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
           <div
             className="body"
           >
-            <h2
+            <h1
               className="title"
             >
               Rowan
-            </h2>
+            </h1>
             <span
               className="date"
             >
@@ -85,6 +85,7 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
         className="collection-detail__utility"
       >
         <nav
+          aria-label="Share"
           className="share-nav-primary"
         >
           <span
@@ -127,6 +128,11 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
         </nav>
       </div>
     </div>
+    <h2
+      className="screen-reader-text"
+    >
+      Resource Slideshow
+    </h2>
     <div
       className="resource-slideshow"
     >
@@ -186,7 +192,7 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
             className="resource-slideshow__caption"
           >
             <header>
-              <h2
+              <h3
                 className="resource-slideshow__title"
                 dangerouslySetInnerHTML={
                   Object {
@@ -367,6 +373,11 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
     <div
       className="container flush-top"
     >
+      <h2
+        className="screen-reader-text"
+      >
+        Resource List
+      </h2>
       <div
         className="resource-total"
       >
@@ -561,7 +572,7 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
       <div
         className="entity-section-wrapper__body"
       >
-        <nav
+        <div
           className="resource-list"
         >
           <div
@@ -663,10 +674,9 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
                 tabIndex="0"
               >
                 <div>
-                  <header
-                    className="resource-card__title"
-                  >
-                    <h4
+                  <header>
+                    <h3
+                      className="resource-card__title"
                       dangerouslySetInnerHTML={
                         Object {
                           "__html": "Image",
@@ -749,6 +759,7 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
             </li>
           </ul>
           <nav
+            aria-label="Pagination"
             className="list-pagination"
           >
             <ul
@@ -872,7 +883,7 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
               </li>
             </ul>
           </nav>
-        </nav>
+        </div>
       </div>
     </div>
   </section>

--- a/client/src/frontend/containers/ResourceDetail/__tests__/__snapshots__/ResourceDetail-test.js.snap
+++ b/client/src/frontend/containers/ResourceDetail/__tests__/__snapshots__/ResourceDetail-test.js.snap
@@ -142,6 +142,7 @@ exports[`Frontend ResourceDetail Container renders correctly 1`] = `
               </svg>
             </a>
             <nav
+              aria-label="Share"
               className="share-nav-primary"
             >
               <span
@@ -432,11 +433,11 @@ exports[`Frontend ResourceDetail Container renders correctly 1`] = `
                 }
               }
             />
-            <h3
+            <h2
               className="attribute-header"
             >
               Full Description
-            </h3>
+            </h2>
             <div
               dangerouslySetInnerHTML={
                 Object {
@@ -450,7 +451,7 @@ exports[`Frontend ResourceDetail Container renders correctly 1`] = `
               <div
                 className="comment-editor"
               >
-                <h3
+                <h2
                   className="comment-editor__editor-label"
                 >
                   <svg
@@ -471,7 +472,7 @@ exports[`Frontend ResourceDetail Container renders correctly 1`] = `
                   >
                     Add Comment
                   </span>
-                </h3>
+                </h2>
                 <div
                   className="placeholder"
                 >

--- a/client/src/frontend/containers/Search/__tests__/__snapshots__/Search-test.js.snap
+++ b/client/src/frontend/containers/Search/__tests__/__snapshots__/Search-test.js.snap
@@ -2,12 +2,22 @@
 
 exports[`Frontend SearchContainer renders correctly 1`] = `
 <div>
+  <h1
+    className="screen-reader-text"
+  >
+    Search
+  </h1>
   <div
     className="search-form-frontend"
   >
     <div
       className="container"
     >
+      <h2
+        className="screen-reader-text"
+      >
+        Search Form
+      </h2>
       <form
         className="search-query"
         onSubmit={[Function]}

--- a/client/src/frontend/containers/Search/index.js
+++ b/client/src/frontend/containers/Search/index.js
@@ -41,8 +41,10 @@ class SearchContainer extends PureComponent {
 
     return (
       <div>
+        <h1 className="screen-reader-text">Search</h1>
         <div className="search-form-frontend">
           <div className="container">
+            <h2 className="screen-reader-text">Search Form</h2>
             <SearchQuery.Form
               initialState={{
                 keyword: "",
@@ -57,6 +59,7 @@ class SearchContainer extends PureComponent {
         {this.props.results ? (
           <div className="search-results-frontend">
             <div className="container">
+              <h2 className="screen-reader-text">Search Results</h2>
               <SearchResults.List
                 pagination={this.props.resultsMeta.pagination}
                 paginationClickHandler={this.props.setPage}

--- a/client/src/frontend/containers/Subscriptions/__tests__/__snapshots__/Subscriptions-test.js.snap
+++ b/client/src/frontend/containers/Subscriptions/__tests__/__snapshots__/Subscriptions-test.js.snap
@@ -13,7 +13,7 @@ exports[`Frontend Subscriptions Container renders correctly 1`] = `
       method="post"
       onSubmit={[Function]}
     >
-      <h2
+      <h1
         className="form-heading"
       >
         Notification Settings
@@ -22,15 +22,15 @@ exports[`Frontend Subscriptions Container renders correctly 1`] = `
         >
           Edit your email notifications and subscriptions.
         </span>
-      </h2>
+      </h1>
       <div
         className="subscriptions"
       >
-        <h3
+        <h2
           className="section-heading-secondary"
         >
           Project Activity
-        </h3>
+        </h2>
         <div
           className="form-group"
         >
@@ -118,11 +118,11 @@ exports[`Frontend Subscriptions Container renders correctly 1`] = `
             </label>
           </div>
         </div>
-        <h3
+        <h2
           className="section-heading-secondary"
         >
           Other Activity
-        </h3>
+        </h2>
         <div
           className="form-group"
         >

--- a/client/src/frontend/containers/Subscriptions/index.js
+++ b/client/src/frontend/containers/Subscriptions/index.js
@@ -100,12 +100,12 @@ export class SubscriptionsContainer extends Component {
               method="post"
               onSubmit={this.updateUser}
             >
-              <h2 className="form-heading">
+              <h1 className="form-heading">
                 Notification Settings
                 <span className="instructions">
                   Edit your email notifications and subscriptions.
                 </span>
-              </h2>
+              </h1>
               <Preferences.NotificationsForm
                 preferences={this.state.notificationPreferencesByKind}
                 changeHandler={this.handlePreferenceChange}

--- a/client/src/global/components/navigation/Static.js
+++ b/client/src/global/components/navigation/Static.js
@@ -128,7 +128,7 @@ export class NavigationStatic extends PureComponent {
   render() {
     return (
       <React.Fragment>
-        <nav className="page-nav show-75">
+        <nav className="page-nav show-75" aria-label="Primary Navigation">
           <ul style={this.props.style} className="links">
             {this.props.links.map((link, index) => {
               if (link.ability)

--- a/client/src/global/components/preferences/NotificationsForm.js
+++ b/client/src/global/components/preferences/NotificationsForm.js
@@ -17,7 +17,7 @@ export default class NotificationsForm extends Component {
 
     return (
       <div className="subscriptions">
-        <h3 className="section-heading-secondary">Project Activity</h3>
+        <h2 className="section-heading-secondary">Project Activity</h2>
         <div className="form-group">
           <div className="form-input">
             <span className="instructions">
@@ -30,7 +30,7 @@ export default class NotificationsForm extends Component {
             {this.renderDigestContent(preferences)}
           </Collapse>
         </div>
-        <h3 className="section-heading-secondary">Other Activity</h3>
+        <h2 className="section-heading-secondary">Other Activity</h2>
         <div className="form-group">
           {this.renderNotificationContent(preferences)}
         </div>

--- a/client/src/global/components/preferences/__tests__/__snapshots__/NotificationsForm-test.js.snap
+++ b/client/src/global/components/preferences/__tests__/__snapshots__/NotificationsForm-test.js.snap
@@ -4,11 +4,11 @@ exports[`Global.Preferences.NotificationsForm component renders correctly 1`] = 
 <div
   className="subscriptions"
 >
-  <h3
+  <h2
     className="section-heading-secondary"
   >
     Project Activity
-  </h3>
+  </h2>
   <div
     className="form-group"
   >
@@ -96,11 +96,11 @@ exports[`Global.Preferences.NotificationsForm component renders correctly 1`] = 
       </label>
     </div>
   </div>
-  <h3
+  <h2
     className="section-heading-secondary"
   >
     Other Activity
-  </h3>
+  </h2>
   <div
     className="form-group"
   >

--- a/client/src/global/components/search/results/Types/Generic/index.js
+++ b/client/src/global/components/search/results/Types/Generic/index.js
@@ -60,7 +60,7 @@ class SearchResultsTypeGeneric extends PureComponent {
             <div className="search-result__text-column-top">
               <div className="search-result__text-column-top-left">
                 {this.hasProp("parent") && (
-                  <h4
+                  <div
                     className="search-result__parent"
                     {...this.attributesFor("parent")}
                   >
@@ -68,7 +68,7 @@ class SearchResultsTypeGeneric extends PureComponent {
                       this.props.parentUrl,
                       this.valueFor("parent")
                     )}
-                  </h4>
+                  </div>
                 )}
                 {this.hasProp("title") &&
                   this.wrapWithLink(

--- a/client/src/global/components/utility/Pagination.js
+++ b/client/src/global/components/utility/Pagination.js
@@ -169,7 +169,7 @@ export default class UtilityPagination extends PureComponent {
     });
 
     return (
-      <nav className={wrapperClassNames}>
+      <nav className={wrapperClassNames} aria-label="Pagination">
         <ul className="list-pagination__columns">
           <li className="list-pagination__column">
             <ul>{this.previous(pagination)}</ul>

--- a/client/src/global/components/utility/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/client/src/global/components/utility/__tests__/__snapshots__/Pagination-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Global.Utility.Pagination component renders correctly 1`] = `
 <nav
+  aria-label="Pagination"
   className="list-pagination"
 >
   <ul
@@ -129,6 +130,7 @@ exports[`Global.Utility.Pagination component renders correctly 1`] = `
 
 exports[`Global.Utility.Pagination component renders correctly when compact style 1`] = `
 <nav
+  aria-label="Pagination"
   className="list-pagination list-pagination--compact"
 >
   <ul

--- a/client/src/global/containers/comment/Editor.js
+++ b/client/src/global/containers/comment/Editor.js
@@ -170,7 +170,7 @@ export class CommentEditor extends PureComponent {
     return (
       <div className="comment-editor">
         {this.props.label ? (
-          <h3 className="comment-editor__editor-label">
+          <h2 className="comment-editor__editor-label">
             <IconComposer
               icon="annotate32"
               size={44.91}
@@ -179,7 +179,7 @@ export class CommentEditor extends PureComponent {
             <span className="comment-editor__label-text">
               {this.props.label}
             </span>
-          </h3>
+          </h2>
         ) : null}
         <Authorize kind="unauthenticated">
           <div className="placeholder">

--- a/client/src/reader/components/Header/__tests__/__snapshots__/Header-test.js.snap
+++ b/client/src/reader/components/Header/__tests__/__snapshots__/Header-test.js.snap
@@ -5,6 +5,13 @@ exports[`Reader.Header Component renders correctly 1`] = `
   <header
     className="header-reader"
   >
+    <a
+      className="skip-to-main screen-reader-text"
+      href="#skip-to-main"
+      onClick={[Function]}
+    >
+      Skip to main content
+    </a>
     <nav
       className="container-banner"
     >
@@ -191,6 +198,13 @@ exports[`Reader.Header Component renders correctly when no TOC or metadata 1`] =
   <header
     className="header-reader"
   >
+    <a
+      className="skip-to-main screen-reader-text"
+      href="#skip-to-main"
+      onClick={[Function]}
+    >
+      Skip to main content
+    </a>
     <nav
       className="container-banner"
     >

--- a/client/src/reader/components/Header/index.js
+++ b/client/src/reader/components/Header/index.js
@@ -14,7 +14,7 @@ import Layout from "reader/components/layout";
 import memoize from "lodash/memoize";
 import classNames from "classnames";
 import isEmpty from "lodash/isEmpty";
-import IconComposer from "global/components/utility/IconComposer";
+import Utility from "global/components/utility";
 
 import Authorize from "hoc/authorize";
 import BlurOnLocationChange from "hoc/blur-on-location-change";
@@ -90,7 +90,7 @@ export default class Header extends Component {
         onClick={this.handleContentsButtonClick}
       >
         <span className="button-index__text">Contents</span>
-        <IconComposer
+        <Utility.IconComposer
           icon="disclosureDown24"
           size="default"
           iconClass="button-index__icon"
@@ -107,6 +107,7 @@ export default class Header extends Component {
     return (
       <BlurOnLocationChange location={this.props.location}>
         <header className="header-reader">
+          <Utility.SkipLink />
           <Layout.PreHeader />
           <nav className={containerClass}>
             <ReturnMenu.Button

--- a/client/src/reader/components/notation/resource-collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/reader/components/notation/resource-collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -30,11 +30,11 @@ exports[`Reader.Notation.Collection.Detail component renders correctly 1`] = `
           <div
             className="body"
           >
-            <h2
+            <h1
               className="title"
             >
               Rowan
-            </h2>
+            </h1>
             <span
               className="date"
             >
@@ -87,7 +87,7 @@ exports[`Reader.Notation.Collection.Detail component renders correctly 1`] = `
           className="resource-slideshow__caption"
         >
           <header>
-            <h2
+            <h3
               className="resource-slideshow__title"
               dangerouslySetInnerHTML={
                 Object {

--- a/client/src/reader/containers/Reader/__tests__/__snapshots__/Reader-test.js.snap
+++ b/client/src/reader/containers/Reader/__tests__/__snapshots__/Reader-test.js.snap
@@ -2,13 +2,6 @@
 
 exports[`Reader Reader Container renders correctly 1`] = `
 <div>
-  <a
-    className="skip-to-main screen-reader-text"
-    href="#skip-to-main"
-    onClick={[Function]}
-  >
-    Skip to main content
-  </a>
   <div
     className="scroll-aware top pinned"
   >
@@ -16,6 +9,13 @@ exports[`Reader Reader Container renders correctly 1`] = `
       <header
         className="header-reader"
       >
+        <a
+          className="skip-to-main screen-reader-text"
+          href="#skip-to-main"
+          onClick={[Function]}
+        >
+          Skip to main content
+        </a>
         <nav
           className="container-banner"
         >

--- a/client/src/reader/containers/Reader/index.js
+++ b/client/src/reader/containers/Reader/index.js
@@ -232,7 +232,6 @@ export class ReaderContainer extends Component {
     return (
       <BodyClass className={this.bodyClass}>
         <div>
-          <Utility.SkipLink />
           <ScrollAware>
             {/* Header inside scroll-aware HOC */}
             <Header

--- a/client/src/reader/containers/notation/__tests__/__snapshots__/Picker-test.js.snap
+++ b/client/src/reader/containers/notation/__tests__/__snapshots__/Picker-test.js.snap
@@ -172,7 +172,7 @@ exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
                 <div
                   className="entity-row__text entity-row__text--in-rows"
                 >
-                  <h4
+                  <h3
                     className="entity-row__title entity-row__title--in-rows"
                   >
                     <span
@@ -195,8 +195,8 @@ exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
                     >
                       View Image
                     </span>
-                  </h4>
-                  <h6
+                  </h3>
+                  <div
                     className="entity-row__meta entity-row__meta--in-rows"
                   >
                     <time
@@ -204,7 +204,7 @@ exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
                     >
                       Created April 24, 2017
                     </time>
-                  </h6>
+                  </div>
                 </div>
               </div>
             </a>
@@ -238,7 +238,7 @@ exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
                 <div
                   className="entity-row__text entity-row__text--in-rows"
                 >
-                  <h4
+                  <h3
                     className="entity-row__title entity-row__title--in-rows"
                   >
                     <span
@@ -261,8 +261,8 @@ exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
                     >
                       View Image
                     </span>
-                  </h4>
-                  <h6
+                  </h3>
+                  <div
                     className="entity-row__meta entity-row__meta--in-rows"
                   >
                     <time
@@ -270,7 +270,7 @@ exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
                     >
                       Created April 24, 2017
                     </time>
-                  </h6>
+                  </div>
                 </div>
               </div>
             </a>
@@ -280,6 +280,7 @@ exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
           className="entity-list__pagination"
         >
           <nav
+            aria-label="Pagination"
             className="list-pagination"
           >
             <ul

--- a/client/src/reader/containers/notation/resource-collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/reader/containers/notation/resource-collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -71,11 +71,11 @@ exports[`Reader Notation ResourceCollection Detail Container renders correctly 1
                   <div
                     className="body"
                   >
-                    <h2
+                    <h1
                       className="title"
                     >
                       Rowan
-                    </h2>
+                    </h1>
                     <span
                       className="date"
                     >
@@ -128,7 +128,7 @@ exports[`Reader Notation ResourceCollection Detail Container renders correctly 1
                   className="resource-slideshow__caption"
                 >
                   <header>
-                    <h2
+                    <h3
                       className="resource-slideshow__title"
                       dangerouslySetInnerHTML={
                         Object {

--- a/client/src/theme/styles/components/frontend/resource/_card.scss
+++ b/client/src/theme/styles/components/frontend/resource/_card.scss
@@ -162,17 +162,15 @@
   }
 
   &__title {
-    h4 {
-      @include templateHead;
-      margin: 0;
-      margin-bottom: 6px;
-      font-size: 16px;
-      font-weight: $regular;
-      color: $neutral75;
+    @include templateHead;
+    margin: 0;
+    margin-bottom: 6px;
+    font-size: 16px;
+    font-weight: $regular;
+    color: $neutral75;
 
-      @include respond($break85) {
-        font-size: 17px;
-      }
+    @include respond($break85) {
+      font-size: 17px;
     }
   }
 

--- a/client/src/theme/styles/components/global/forms/_section.scss
+++ b/client/src/theme/styles/components/global/forms/_section.scss
@@ -15,7 +15,7 @@
     padding-left: 24px;
     margin-top: 40px;
 
-    h2, span {
+    h2, h3, span {
       @include utilityPrimary;
       width: 100%;
       font-size: 14px;


### PR DESCRIPTION
This PR revises components and containers across the frontend and backend in order two accomplish two things:

1) Simplify use of ARIA landmarks
This PR reduces the number of `nav` tags in order to eliminate unnecessary screen reader noise. Many remaining `nav` tags have been labeled using the `aria-label` attribute to differentiate their functions. It also moves the "skip to main content" link into the header so that it is nested in a landmark.

2) Improve heading structure
Currently, most BE and FE routes have issues with heading structure, including missing `h1` tags, incorrectly-ordered or inconsistently-applied tags, or page structures that skip heading levels. This PR cleans up those issues with the goal of providing a predictable, consistent heading structure on all routes. This involves revising many tags to a different heading level, removing unnecessary tags (esp. in backend forms), and adding visually-hidden `h1` and `h2` tags to many routes for an improved screen reader experience. It also  creates props and logic to render heading levels conditionally when one component needs different tags in different contexts.

Resolves #2185
Resolves #2186