### PR TITLE
[B] Improve SR experience for project lists

### DIFF
--- a/client/src/backend/components/project-collection/__tests__/__snapshots__/AddButton-test.js.snap
+++ b/client/src/backend/components/project-collection/__tests__/__snapshots__/AddButton-test.js.snap
@@ -6,15 +6,15 @@ exports[`Backend.ProjectCollection.AddButton component renders correctly 1`] = `
     className="screen-reader-text"
     onClick={[Function]}
   >
-    add Rowan Test
+    Include Rowan Test
   </button>
-  <div
+  <button
     aria-hidden="true"
     className="add project-cover-button-wrapper"
     onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
-    role="presentation"
+    tabIndex={-1}
   >
     <div
       aria-hidden="true"
@@ -83,6 +83,6 @@ exports[`Backend.ProjectCollection.AddButton component renders correctly 1`] = `
         </span>
       </span>
     </div>
-  </div>
+  </button>
 </div>
 `;

--- a/client/src/backend/components/project-collection/__tests__/__snapshots__/ProjectCover-test.js.snap
+++ b/client/src/backend/components/project-collection/__tests__/__snapshots__/ProjectCover-test.js.snap
@@ -5,7 +5,7 @@ exports[`Backend.ProjectCollection.ProjectCover component renders correctly 1`] 
   className="cover"
 >
   <svg
-    aria-label="Default Project Thumbnail"
+    aria-label={null}
     className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
     height={134}
     viewBox="0 0 134 134"
@@ -89,7 +89,7 @@ exports[`Backend.ProjectCollection.ProjectCover component renders correctly 1`] 
     </g>
   </svg>
   <svg
-    aria-label="Default Project Thumbnail"
+    aria-label={null}
     className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
     height="100%"
     viewBox="0 0 48 48"
@@ -165,15 +165,15 @@ exports[`Backend.ProjectCollection.ProjectCover component renders correctly 1`] 
       className="screen-reader-text"
       onClick={[Function]}
     >
-      add Rowan Test
+      Include Rowan Test
     </button>
-    <div
+    <button
       aria-hidden="true"
       className="add project-cover-button-wrapper"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
-      role="presentation"
+      tabIndex={-1}
     >
       <div
         aria-hidden="true"
@@ -242,7 +242,7 @@ exports[`Backend.ProjectCollection.ProjectCover component renders correctly 1`] 
           </span>
         </span>
       </div>
-    </div>
+    </button>
   </div>
 </figure>
 `;

--- a/client/src/backend/containers/project-collection/ManageProjects.js
+++ b/client/src/backend/containers/project-collection/ManageProjects.js
@@ -13,6 +13,7 @@ import EntitiesList, {
   ProjectRow
 } from "backend/components/list/EntitiesList";
 import withFilteredLists, { projectFilters } from "hoc/with-filtered-lists";
+import withScreenReaderStatus from "hoc/with-screen-reader-status";
 import IconComposer from "global/components/utility/IconComposer";
 
 const { request } = entityStoreActions;
@@ -67,6 +68,16 @@ class ProjectCollectionManageProjectsImplementation extends PureComponent {
     );
   }
 
+  projectAddMessage(project) {
+    const title = project.attributes.title;
+    return `You have added ${title} to the collection.`;
+  }
+
+  projectRemoveMessage(project) {
+    const title = project.attributes.title;
+    return `You have removed ${title} from the collection.`;
+  }
+
   filtersChanged(prevProps) {
     return (
       prevProps.entitiesListSearchParams !== this.props.entitiesListSearchParams
@@ -116,6 +127,8 @@ class ProjectCollectionManageProjectsImplementation extends PureComponent {
   };
 
   handleProjectAdd = project => {
+    this.props.setScreenReaderStatus(this.projectAddMessage(project));
+
     const projects = this.projectsForProjectCollection(
       this.props.projectCollection
     );
@@ -125,6 +138,8 @@ class ProjectCollectionManageProjectsImplementation extends PureComponent {
   };
 
   handleProjectRemove = project => {
+    this.props.setScreenReaderStatus(this.projectRemoveMessage(project));
+
     const projects = this.projectsForProjectCollection(
       this.props.projectCollection
     );
@@ -226,7 +241,7 @@ class ProjectCollectionManageProjectsImplementation extends PureComponent {
 }
 
 export const ProjectCollectionManageProjects = withFilteredLists(
-  ProjectCollectionManageProjectsImplementation,
+  withScreenReaderStatus(ProjectCollectionManageProjectsImplementation),
   {
     projects: projectFilters()
   }

--- a/client/src/backend/containers/project-collection/__tests__/__snapshots__/ManageProjects-test.js.snap
+++ b/client/src/backend/containers/project-collection/__tests__/__snapshots__/ManageProjects-test.js.snap
@@ -2,6 +2,12 @@
 
 exports[`Backend.ProjectCollection.ManageProjects container renders correctly 1`] = `
 Array [
+  <div
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
   <header
     className="drawer-header"
   >
@@ -314,7 +320,7 @@ Array [
                 className="cover"
               >
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                   height={134}
                   viewBox="0 0 134 134"
@@ -398,7 +404,7 @@ Array [
                   </g>
                 </svg>
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                   height="100%"
                   viewBox="0 0 48 48"
@@ -474,15 +480,15 @@ Array [
                     className="screen-reader-text"
                     onClick={[Function]}
                   >
-                    Follow Rowan Test
+                    Exclude Rowan Test
                   </button>
-                  <div
+                  <button
                     aria-hidden="true"
                     className="remove project-cover-button-wrapper"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
-                    role="presentation"
+                    tabIndex={-1}
                   >
                     <div
                       aria-hidden="true"
@@ -551,7 +557,7 @@ Array [
                         </span>
                       </span>
                     </div>
-                  </div>
+                  </button>
                 </div>
               </figure>
             </div>
@@ -603,7 +609,7 @@ Array [
                 className="cover"
               >
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                   height={134}
                   viewBox="0 0 134 134"
@@ -687,7 +693,7 @@ Array [
                   </g>
                 </svg>
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                   height="100%"
                   viewBox="0 0 48 48"
@@ -763,15 +769,15 @@ Array [
                     className="screen-reader-text"
                     onClick={[Function]}
                   >
-                    Follow Rowan Test
+                    Exclude Rowan Test
                   </button>
-                  <div
+                  <button
                     aria-hidden="true"
                     className="remove project-cover-button-wrapper"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
-                    role="presentation"
+                    tabIndex={-1}
                   >
                     <div
                       aria-hidden="true"
@@ -840,7 +846,7 @@ Array [
                         </span>
                       </span>
                     </div>
-                  </div>
+                  </button>
                 </div>
               </figure>
             </div>

--- a/client/src/frontend/components/project-collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/project-collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -145,7 +145,9 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
       className="project-list grid entity-section-wrapper__body"
     >
       <ul>
-        <li>
+        <li
+          className="project-list__item--pos-rel"
+        >
           <a
             href="/projects/slug-1"
             onClick={[Function]}
@@ -154,7 +156,7 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
               className="cover"
             >
               <svg
-                aria-label="Default Project Thumbnail"
+                aria-label={null}
                 className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                 height={134}
                 viewBox="0 0 134 134"
@@ -238,7 +240,7 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
                 </g>
               </svg>
               <svg
-                aria-label="Default Project Thumbnail"
+                aria-label={null}
                 className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                 height="100%"
                 viewBox="0 0 48 48"
@@ -327,8 +329,16 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
               </h3>
             </div>
           </a>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
         </li>
-        <li>
+        <li
+          className="project-list__item--pos-rel"
+        >
           <a
             href="/projects/slug-2"
             onClick={[Function]}
@@ -337,7 +347,7 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
               className="cover"
             >
               <svg
-                aria-label="Default Project Thumbnail"
+                aria-label={null}
                 className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                 height={134}
                 viewBox="0 0 134 134"
@@ -421,7 +431,7 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
                 </g>
               </svg>
               <svg
-                aria-label="Default Project Thumbnail"
+                aria-label={null}
                 className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                 height="100%"
                 viewBox="0 0 48 48"
@@ -510,6 +520,12 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
               </h3>
             </div>
           </a>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
         </li>
       </ul>
     </div>

--- a/client/src/frontend/components/project-collection/__tests__/__snapshots__/Summary-test.js.snap
+++ b/client/src/frontend/components/project-collection/__tests__/__snapshots__/Summary-test.js.snap
@@ -43,7 +43,9 @@ exports[`Frontend.ProjectCollection.Placeholder component renders correctly 1`] 
       className="project-list grid entity-section-wrapper__body"
     >
       <ul>
-        <li>
+        <li
+          className="project-list__item--pos-rel"
+        >
           <a
             href="/projects/slug-1"
             onClick={[Function]}
@@ -52,7 +54,7 @@ exports[`Frontend.ProjectCollection.Placeholder component renders correctly 1`] 
               className="cover"
             >
               <svg
-                aria-label="Default Project Thumbnail"
+                aria-label={null}
                 className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                 height={134}
                 viewBox="0 0 134 134"
@@ -136,7 +138,7 @@ exports[`Frontend.ProjectCollection.Placeholder component renders correctly 1`] 
                 </g>
               </svg>
               <svg
-                aria-label="Default Project Thumbnail"
+                aria-label={null}
                 className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                 height="100%"
                 viewBox="0 0 48 48"
@@ -225,6 +227,12 @@ exports[`Frontend.ProjectCollection.Placeholder component renders correctly 1`] 
               </h3>
             </div>
           </a>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
         </li>
       </ul>
     </div>

--- a/client/src/frontend/components/project-list/Grid.js
+++ b/client/src/frontend/components/project-list/Grid.js
@@ -120,7 +120,7 @@ export default class ProjectListGrid extends Component {
           >
             {projects.map(project => {
               return (
-                <li key={project.id}>
+                <li key={project.id} className="project-list__item--pos-rel">
                   <GridItem
                     authenticated={this.props.authenticated}
                     favorites={this.props.favorites}

--- a/client/src/frontend/components/project-list/GridItem.js
+++ b/client/src/frontend/components/project-list/GridItem.js
@@ -30,7 +30,7 @@ export default class ProjectGridItem extends Component {
     const attr = project.attributes;
     if (attr.publicationDate && !this.props.hideDate) {
       return (
-        <div className="date">
+        <div className="date" aria-hidden>
           <FormattedDate
             prefix="Published"
             format="MMMM, YYYY"
@@ -44,7 +44,11 @@ export default class ProjectGridItem extends Component {
 
   renderProjectDesc(project) {
     if (this.props.hideDesc || !project.attributes.subtitle) return null;
-    return <p className="description">{project.attributes.subtitle}</p>;
+    return (
+      <p className="description" aria-hidden>
+        {project.attributes.subtitle}
+      </p>
+    );
   }
 
   renderProjectStatusMarker(project) {
@@ -52,7 +56,11 @@ export default class ProjectGridItem extends Component {
     let marker = null;
 
     if (project.attributes.draft) {
-      marker = <div className="block-label">{"Draft"}</div>;
+      marker = (
+        <div className="block-label" aria-hidden>
+          {"Draft"}
+        </div>
+      );
     }
 
     return marker;
@@ -62,7 +70,7 @@ export default class ProjectGridItem extends Component {
     const creators = project.relationships.creators;
     if (!creators || creators.length === 0) return null;
     return (
-      <div className="relations-list">
+      <div className="relations-list" aria-hidden>
         <span>
           {creators.map(maker => maker.attributes.fullName).join(", ")}
         </span>
@@ -77,7 +85,7 @@ export default class ProjectGridItem extends Component {
       alert: project.attributes.recentlyUpdated
     });
     return (
-      <div className={classes}>
+      <div className={classes} aria-hidden>
         <FormattedDate
           prefix="Updated"
           format="MMMM, YYYY"
@@ -117,18 +125,20 @@ export default class ProjectGridItem extends Component {
     });
 
     return (
-      <Link to={lh.link("frontendProject", project.attributes.slug)}>
-        <figure className={figureClass}>
-          <GlobalProject.Avatar project={project} />
-          <Project.Follow
-            project={project}
-            authenticated={this.props.authenticated}
-            favorites={this.props.favorites}
-            dispatch={this.props.dispatch}
-          />
-        </figure>
-        {projectMeta}
-      </Link>
+      <React.Fragment>
+        <Link to={lh.link("frontendProject", project.attributes.slug)}>
+          <figure className={figureClass}>
+            <GlobalProject.Avatar project={project} />
+          </figure>
+          {projectMeta}
+        </Link>
+        <Project.Follow
+          project={project}
+          authenticated={this.props.authenticated}
+          favorites={this.props.favorites}
+          dispatch={this.props.dispatch}
+        />
+      </React.Fragment>
     );
   }
 }

--- a/client/src/frontend/components/project-list/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/frontend/components/project-list/__tests__/__snapshots__/Following-test.js.snap
@@ -165,7 +165,9 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
       className="project-list grid entity-section-wrapper__body"
     >
       <ul>
-        <li>
+        <li
+          className="project-list__item--pos-rel"
+        >
           <a
             href="/projects/slug-1"
             onClick={[Function]}
@@ -174,7 +176,7 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
               className="cover"
             >
               <svg
-                aria-label="Default Project Thumbnail"
+                aria-label={null}
                 className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                 height={134}
                 viewBox="0 0 134 134"
@@ -258,7 +260,7 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
                 </g>
               </svg>
               <svg
-                aria-label="Default Project Thumbnail"
+                aria-label={null}
                 className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                 height="100%"
                 viewBox="0 0 48 48"
@@ -347,8 +349,16 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
               </h3>
             </div>
           </a>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
         </li>
-        <li>
+        <li
+          className="project-list__item--pos-rel"
+        >
           <a
             href="/projects/slug-2"
             onClick={[Function]}
@@ -357,7 +367,7 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
               className="cover"
             >
               <svg
-                aria-label="Default Project Thumbnail"
+                aria-label={null}
                 className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                 height={134}
                 viewBox="0 0 134 134"
@@ -441,7 +451,7 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
                 </g>
               </svg>
               <svg
-                aria-label="Default Project Thumbnail"
+                aria-label={null}
                 className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                 height="100%"
                 viewBox="0 0 48 48"
@@ -530,6 +540,12 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
               </h3>
             </div>
           </a>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
         </li>
       </ul>
     </div>

--- a/client/src/frontend/components/project-list/__tests__/__snapshots__/Grid-test.js.snap
+++ b/client/src/frontend/components/project-list/__tests__/__snapshots__/Grid-test.js.snap
@@ -5,7 +5,9 @@ exports[`Frontend.ProjectList.Grid component renders correctly 1`] = `
   className="project-list grid entity-section-wrapper__body"
 >
   <ul>
-    <li>
+    <li
+      className="project-list__item--pos-rel"
+    >
       <a
         href="/projects/slug-1"
         onClick={[Function]}
@@ -14,7 +16,7 @@ exports[`Frontend.ProjectList.Grid component renders correctly 1`] = `
           className="cover"
         >
           <svg
-            aria-label="Default Project Thumbnail"
+            aria-label={null}
             className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
             height={134}
             viewBox="0 0 134 134"
@@ -98,7 +100,7 @@ exports[`Frontend.ProjectList.Grid component renders correctly 1`] = `
             </g>
           </svg>
           <svg
-            aria-label="Default Project Thumbnail"
+            aria-label={null}
             className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
             height="100%"
             viewBox="0 0 48 48"
@@ -169,90 +171,6 @@ exports[`Frontend.ProjectList.Grid component renders correctly 1`] = `
               </g>
             </g>
           </svg>
-          <div>
-            <button
-              className="screen-reader-text"
-              onClick={[Function]}
-            >
-              add Rowan Test
-            </button>
-            <div
-              aria-hidden="true"
-              className="add project-cover-button-wrapper"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              role="presentation"
-            >
-              <div
-                aria-hidden="true"
-                className="project-cover-button"
-              >
-                <div
-                  className="icons"
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="manicon-svg minus svg-icon--MinusUnique"
-                    fill="currentColor"
-                    height={28}
-                    viewBox="0 0 32 32"
-                    width={28}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <rect
-                      height="2"
-                      width="14"
-                      x="9"
-                      y="15"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    className="manicon-svg check svg-icon--CheckUnique"
-                    fill="currentColor"
-                    height={28}
-                    viewBox="0 0 32 32"
-                    width={28}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <polygon
-                      points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
-                    />
-                  </svg>
-                  <svg
-                    aria-hidden="true"
-                    className="manicon-svg plus svg-icon--PlusUnique"
-                    fill="currentColor"
-                    height={28}
-                    viewBox="0 0 32 32"
-                    width={28}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <rect
-                      height="2"
-                      width="14"
-                      x="9"
-                      y="15"
-                    />
-                    <rect
-                      height="14"
-                      width="2"
-                      x="15"
-                      y="9"
-                    />
-                  </svg>
-                </div>
-                <span>
-                  <span
-                    className="action-text"
-                  >
-                    Follow
-                  </span>
-                </span>
-              </div>
-            </div>
-          </div>
         </figure>
         <div
           className="meta"
@@ -271,6 +189,96 @@ exports[`Frontend.ProjectList.Grid component renders correctly 1`] = `
           </h3>
         </div>
       </a>
+      <div
+        aria-atomic={true}
+        aria-live="polite"
+        className="screen-reader-text"
+        role="status"
+      />
+      <div>
+        <button
+          className="screen-reader-text"
+          onClick={[Function]}
+        >
+          Follow Rowan Test
+        </button>
+        <button
+          aria-hidden="true"
+          className="add project-cover-button-wrapper"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          tabIndex={-1}
+        >
+          <div
+            aria-hidden="true"
+            className="project-cover-button"
+          >
+            <div
+              className="icons"
+            >
+              <svg
+                aria-hidden="true"
+                className="manicon-svg minus svg-icon--MinusUnique"
+                fill="currentColor"
+                height={28}
+                viewBox="0 0 32 32"
+                width={28}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="2"
+                  width="14"
+                  x="9"
+                  y="15"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                className="manicon-svg check svg-icon--CheckUnique"
+                fill="currentColor"
+                height={28}
+                viewBox="0 0 32 32"
+                width={28}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <polygon
+                  points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                className="manicon-svg plus svg-icon--PlusUnique"
+                fill="currentColor"
+                height={28}
+                viewBox="0 0 32 32"
+                width={28}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="2"
+                  width="14"
+                  x="9"
+                  y="15"
+                />
+                <rect
+                  height="14"
+                  width="2"
+                  x="15"
+                  y="9"
+                />
+              </svg>
+            </div>
+            <span>
+              <span
+                className="action-text"
+              >
+                Follow
+              </span>
+            </span>
+          </div>
+        </button>
+      </div>
     </li>
   </ul>
 </div>

--- a/client/src/frontend/components/project-list/__tests__/__snapshots__/GridItem-test.js.snap
+++ b/client/src/frontend/components/project-list/__tests__/__snapshots__/GridItem-test.js.snap
@@ -1,274 +1,283 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frontend.Project.Thumbnail component renders correctly 1`] = `
-<a
-  href="/projects/slug-1"
-  onClick={[Function]}
->
-  <figure
-    className="cover"
+Array [
+  <a
+    href="/projects/slug-1"
+    onClick={[Function]}
   >
-    <svg
-      aria-label="Default Project Thumbnail"
-      className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
-      height={134}
-      viewBox="0 0 134 134"
-      width={134}
-      xmlns="http://www.w3.org/2000/svg"
+    <figure
+      className="cover"
     >
-      <g
-        fill="none"
-        fillRule="evenodd"
+      <svg
+        aria-label={null}
+        className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
+        height={134}
+        viewBox="0 0 134 134"
+        width={134}
+        xmlns="http://www.w3.org/2000/svg"
       >
         <g
-          className="project-thumb-placeholder__frame"
-          strokeWidth="1.5"
-          transform="translate(2 2)"
-        >
-          <polyline
-            points="124 6 124 124 6 124"
-          />
-          <polyline
-            points="130 12 130 130 12 130"
-          />
-          <polygon
-            points="0 118 118 118 118 0 0 0"
-          />
-        </g>
-        <polygon
-          className="project-thumb-placeholder__tile"
-          points="0 102 102 102 102 0 0 0"
-          transform="translate(10 10)"
-        />
-        <g
-          className="project-thumb-placeholder__illustration"
-          transform="translate(34 32)"
+          fill="none"
+          fillRule="evenodd"
         >
           <g
-            transform="translate(47.557 2.968)"
+            className="project-thumb-placeholder__frame"
+            strokeWidth="1.5"
+            transform="translate(2 2)"
           >
             <polyline
-              className="project-thumb-placeholder__illustration"
-              points=".271 7.606 .271 50.893 3.747 57.089 7.221 50.893 7.221 7.606"
-              strokeWidth="1.5"
+              points="124 6 124 124 6 124"
             />
-            <path
-              d="M7.22166456 50.8926203L.271601266 50.8926203M.27135443 3.82883544L.27135443 2.02693671C.27135443.936746835 1.1558481.0522531646 2.24603797.0522531646L5.24673418.0522531646C6.33774684.0522531646 7.22141772.936746835 7.22141772 2.02693671L7.22141772 3.82883544"
-              strokeWidth="1.5"
+            <polyline
+              points="130 12 130 130 12 130"
             />
             <polygon
-              points=".272 7.606 7.222 7.606 7.222 3.829 .272 3.829"
-              strokeWidth="1.5"
-            />
-            <path
-              d="M3.74655063,11.5277975 L3.74655063,46.9708987"
-              strokeWidth="1.5"
-            />
-            <polygon
-              points="2.183 54.3 3.747 57.089 5.311 54.3"
+              points="0 118 118 118 118 0 0 0"
             />
           </g>
-          <g
-            strokeWidth="1.5"
-            transform="translate(0 26)"
-          >
-            <polygon
-              points="34.054 .598 .703 .598 .703 26.635 17.859 26.635 17.859 34.057 24.336 26.635 34.054 26.635"
-            />
-            <path
-              d="M28.3519304 7.9074557L6.30870253 7.9074557M28.3519304 18.7725759L6.30870253 18.7725759M28.3519304 13.3399747L6.30870253 13.3399747"
-            />
-          </g>
-          <g
-            strokeWidth="1.5"
-          >
-            <path
-              d="M27.3882848 11.8128038C27.3882848 14.7707152 24.9898671 17.1691329 22.0319557 17.1691329 19.0740443 17.1691329 16.6756266 14.7707152 16.6756266 11.8128038 16.6756266 8.85489241 19.0740443 6.45647468 22.0319557 6.45647468 24.9898671 6.45647468 27.3882848 8.85489241 27.3882848 11.8128038zM27.3882848 12.0765886L34.9537911 4.51108228C36.3196139 3.14608228 38.6546772 4.11285443 38.6546772 6.04475316M8.54099982 6.88421582L14.7943291.639221519C16.1601519-.726601266 18.4952152.240993671 18.4952152 2.17206962M11.4153165 12.3338734L12.5877848 11.8393797C13.52 11.4469114 14.5706962 11.4469114 15.5029114 11.8393797L16.6753797 12.3338734"
-            />
-            <path
-              d="M11.4153165,11.8128038 C11.4153165,14.7707152 9.01689873,17.1691329 6.05898734,17.1691329 C3.10107595,17.1691329 0.702658228,14.7707152 0.702658228,11.8128038 C0.702658228,8.85489241 3.10107595,6.45647468 6.05898734,6.45647468 C9.01689873,6.45647468 11.4153165,8.85489241 11.4153165,11.8128038 Z"
-            />
-          </g>
-        </g>
-      </g>
-    </svg>
-    <svg
-      aria-label="Default Project Thumbnail"
-      className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
-      height="100%"
-      viewBox="0 0 48 48"
-      width="100%"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fill="none"
-        fillRule="evenodd"
-      >
-        <polygon
-          className="project-thumb-placeholder__tile"
-          fill="#CBF7E6"
-          points="0 42 42 42 42 0 0 0"
-        />
-        <g
-          className="project-thumb-placeholder__illustration"
-          transform="translate(9 8)"
-        >
-          <g
-            transform="translate(20.683 2.244)"
-          >
-            <polygon
-              points=".161 2.954 .161 21.013 1.612 23.598 3.06 21.013 3.06 2.954"
-            />
-            <path
-              d="M3.06081501,21.012797 L0.161633021,21.012797"
-            />
-            <path
-              d="M0.162011257,2.95560225 L3.06119325,2.95560225 L3.06119325,1.53299812 C3.06119325,0.980713374 2.613478,0.532998124 2.06119325,0.532998124 L1.16201126,0.532998124 C0.609726507,0.532998124 0.162011257,0.980713374 0.162011257,1.53299812 L0.162011257,2.95560225 Z"
-              strokeLinejoin="round"
-            />
-          </g>
-          <g
-            transform="translate(.195 11.463)"
-          >
-            <polygon
-              points="14.898 .419 .985 .419 .985 11.282 8.141 11.282 8.141 14.378 10.844 11.282 14.898 11.282"
-            />
-            <path
-              d="M12.5237854 3.46905816L3.32696735 3.46905816M12.5237854 8.00165403L3.32696735 8.00165403M12.5237854 5.73507242L3.32696735 5.73507242"
-            />
-          </g>
-          <g
-            transform="translate(.195 .195)"
-          >
-            <path
-              d="M11.8853223 5.12585966C11.8853223 6.3608015 10.8848871 7.36123677 9.64994522 7.36123677 8.41689456 7.36123677 7.41645929 6.3608015 7.41645929 5.12585966 7.41645929 3.89091782 8.41689456 2.89048255 9.64994522 2.89048255 10.8848871 2.89048255 11.8853223 3.89091782 11.8853223 5.12585966zM11.8853223 5.23573734L15.0417051 2.0793546C15.6109508 1.51010882 16.5849096 1.91293058 16.5849096 2.71857411M3.99814784 3.09718874L6.63067317.464663415C7.20181013-.106473546 8.17576886.2982394 8.17576886 1.10388293"
-            />
-            <path
-              d="M5.22155347 5.12585966C5.22155347 6.3608015 4.2211182 7.36123677 2.98617636 7.36123677 1.7531257 7.36123677.752690432 6.3608015.752690432 5.12585966.752690432 3.89091782 1.7531257 2.89048255 2.98617636 2.89048255 4.2211182 2.89048255 5.22155347 3.89091782 5.22155347 5.12585966zM5.22155347 5.34334559L5.71136961 5.13720675C6.09906191 4.97267392 6.53781614 4.97267392 6.92739962 5.13720675L7.41532458 5.34334559"
-            />
-          </g>
-        </g>
-        <g
-          className="project-thumb-placeholder__frame"
-          stroke="#828282"
-        >
-          <polyline
-            points="48 6 48 48 6 48"
-          />
-          <polyline
-            points="45 3 45 45 3 45"
-          />
           <polygon
-            points="0 42 42 42 42 0 0 0"
+            className="project-thumb-placeholder__tile"
+            points="0 102 102 102 102 0 0 0"
+            transform="translate(10 10)"
           />
-        </g>
-      </g>
-    </svg>
-    <div>
-      <button
-        className="screen-reader-text"
-        onClick={[Function]}
-      >
-        add Rowan Test
-      </button>
-      <div
-        aria-hidden="true"
-        className="add project-cover-button-wrapper"
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        role="presentation"
-      >
-        <div
-          aria-hidden="true"
-          className="project-cover-button"
-        >
-          <div
-            className="icons"
+          <g
+            className="project-thumb-placeholder__illustration"
+            transform="translate(34 32)"
           >
-            <svg
-              aria-hidden="true"
-              className="manicon-svg minus svg-icon--MinusUnique"
-              fill="currentColor"
-              height={28}
-              viewBox="0 0 32 32"
-              width={28}
-              xmlns="http://www.w3.org/2000/svg"
+            <g
+              transform="translate(47.557 2.968)"
             >
-              <rect
-                height="2"
-                width="14"
-                x="9"
-                y="15"
+              <polyline
+                className="project-thumb-placeholder__illustration"
+                points=".271 7.606 .271 50.893 3.747 57.089 7.221 50.893 7.221 7.606"
+                strokeWidth="1.5"
               />
-            </svg>
-            <svg
-              aria-hidden="true"
-              className="manicon-svg check svg-icon--CheckUnique"
-              fill="currentColor"
-              height={28}
-              viewBox="0 0 32 32"
-              width={28}
-              xmlns="http://www.w3.org/2000/svg"
+              <path
+                d="M7.22166456 50.8926203L.271601266 50.8926203M.27135443 3.82883544L.27135443 2.02693671C.27135443.936746835 1.1558481.0522531646 2.24603797.0522531646L5.24673418.0522531646C6.33774684.0522531646 7.22141772.936746835 7.22141772 2.02693671L7.22141772 3.82883544"
+                strokeWidth="1.5"
+              />
+              <polygon
+                points=".272 7.606 7.222 7.606 7.222 3.829 .272 3.829"
+                strokeWidth="1.5"
+              />
+              <path
+                d="M3.74655063,11.5277975 L3.74655063,46.9708987"
+                strokeWidth="1.5"
+              />
+              <polygon
+                points="2.183 54.3 3.747 57.089 5.311 54.3"
+              />
+            </g>
+            <g
+              strokeWidth="1.5"
+              transform="translate(0 26)"
             >
               <polygon
-                points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                points="34.054 .598 .703 .598 .703 26.635 17.859 26.635 17.859 34.057 24.336 26.635 34.054 26.635"
               />
-            </svg>
-            <svg
-              aria-hidden="true"
-              className="manicon-svg plus svg-icon--PlusUnique"
-              fill="currentColor"
-              height={28}
-              viewBox="0 0 32 32"
-              width={28}
-              xmlns="http://www.w3.org/2000/svg"
+              <path
+                d="M28.3519304 7.9074557L6.30870253 7.9074557M28.3519304 18.7725759L6.30870253 18.7725759M28.3519304 13.3399747L6.30870253 13.3399747"
+              />
+            </g>
+            <g
+              strokeWidth="1.5"
             >
-              <rect
-                height="2"
-                width="14"
-                x="9"
-                y="15"
+              <path
+                d="M27.3882848 11.8128038C27.3882848 14.7707152 24.9898671 17.1691329 22.0319557 17.1691329 19.0740443 17.1691329 16.6756266 14.7707152 16.6756266 11.8128038 16.6756266 8.85489241 19.0740443 6.45647468 22.0319557 6.45647468 24.9898671 6.45647468 27.3882848 8.85489241 27.3882848 11.8128038zM27.3882848 12.0765886L34.9537911 4.51108228C36.3196139 3.14608228 38.6546772 4.11285443 38.6546772 6.04475316M8.54099982 6.88421582L14.7943291.639221519C16.1601519-.726601266 18.4952152.240993671 18.4952152 2.17206962M11.4153165 12.3338734L12.5877848 11.8393797C13.52 11.4469114 14.5706962 11.4469114 15.5029114 11.8393797L16.6753797 12.3338734"
               />
-              <rect
-                height="14"
-                width="2"
-                x="15"
-                y="9"
+              <path
+                d="M11.4153165,11.8128038 C11.4153165,14.7707152 9.01689873,17.1691329 6.05898734,17.1691329 C3.10107595,17.1691329 0.702658228,14.7707152 0.702658228,11.8128038 C0.702658228,8.85489241 3.10107595,6.45647468 6.05898734,6.45647468 C9.01689873,6.45647468 11.4153165,8.85489241 11.4153165,11.8128038 Z"
               />
-            </svg>
-          </div>
-          <span>
-            <span
-              className="action-text"
+            </g>
+          </g>
+        </g>
+      </svg>
+      <svg
+        aria-label={null}
+        className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
+        height="100%"
+        viewBox="0 0 48 48"
+        width="100%"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+        >
+          <polygon
+            className="project-thumb-placeholder__tile"
+            fill="#CBF7E6"
+            points="0 42 42 42 42 0 0 0"
+          />
+          <g
+            className="project-thumb-placeholder__illustration"
+            transform="translate(9 8)"
+          >
+            <g
+              transform="translate(20.683 2.244)"
             >
-              Follow
-            </span>
-          </span>
-        </div>
-      </div>
-    </div>
-  </figure>
-  <div
-    className="meta"
-  >
-    <h3
-      className="name"
+              <polygon
+                points=".161 2.954 .161 21.013 1.612 23.598 3.06 21.013 3.06 2.954"
+              />
+              <path
+                d="M3.06081501,21.012797 L0.161633021,21.012797"
+              />
+              <path
+                d="M0.162011257,2.95560225 L3.06119325,2.95560225 L3.06119325,1.53299812 C3.06119325,0.980713374 2.613478,0.532998124 2.06119325,0.532998124 L1.16201126,0.532998124 C0.609726507,0.532998124 0.162011257,0.980713374 0.162011257,1.53299812 L0.162011257,2.95560225 Z"
+                strokeLinejoin="round"
+              />
+            </g>
+            <g
+              transform="translate(.195 11.463)"
+            >
+              <polygon
+                points="14.898 .419 .985 .419 .985 11.282 8.141 11.282 8.141 14.378 10.844 11.282 14.898 11.282"
+              />
+              <path
+                d="M12.5237854 3.46905816L3.32696735 3.46905816M12.5237854 8.00165403L3.32696735 8.00165403M12.5237854 5.73507242L3.32696735 5.73507242"
+              />
+            </g>
+            <g
+              transform="translate(.195 .195)"
+            >
+              <path
+                d="M11.8853223 5.12585966C11.8853223 6.3608015 10.8848871 7.36123677 9.64994522 7.36123677 8.41689456 7.36123677 7.41645929 6.3608015 7.41645929 5.12585966 7.41645929 3.89091782 8.41689456 2.89048255 9.64994522 2.89048255 10.8848871 2.89048255 11.8853223 3.89091782 11.8853223 5.12585966zM11.8853223 5.23573734L15.0417051 2.0793546C15.6109508 1.51010882 16.5849096 1.91293058 16.5849096 2.71857411M3.99814784 3.09718874L6.63067317.464663415C7.20181013-.106473546 8.17576886.2982394 8.17576886 1.10388293"
+              />
+              <path
+                d="M5.22155347 5.12585966C5.22155347 6.3608015 4.2211182 7.36123677 2.98617636 7.36123677 1.7531257 7.36123677.752690432 6.3608015.752690432 5.12585966.752690432 3.89091782 1.7531257 2.89048255 2.98617636 2.89048255 4.2211182 2.89048255 5.22155347 3.89091782 5.22155347 5.12585966zM5.22155347 5.34334559L5.71136961 5.13720675C6.09906191 4.97267392 6.53781614 4.97267392 6.92739962 5.13720675L7.41532458 5.34334559"
+              />
+            </g>
+          </g>
+          <g
+            className="project-thumb-placeholder__frame"
+            stroke="#828282"
+          >
+            <polyline
+              points="48 6 48 48 6 48"
+            />
+            <polyline
+              points="45 3 45 45 3 45"
+            />
+            <polygon
+              points="0 42 42 42 42 0 0 0"
+            />
+          </g>
+        </g>
+      </svg>
+    </figure>
+    <div
+      className="meta"
     >
-      <span
-        className="title-text"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "Rowan Test",
+      <h3
+        className="name"
+      >
+        <span
+          className="title-text"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Rowan Test",
+            }
           }
-        }
-      />
-    </h3>
-    <p
-      className="description"
+        />
+      </h3>
+      <p
+        aria-hidden={true}
+        className="description"
+      >
+        World's Greatest Dog
+      </p>
+    </div>
+  </a>,
+  <div
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
+  <div>
+    <button
+      className="screen-reader-text"
+      onClick={[Function]}
     >
-      World's Greatest Dog
-    </p>
-  </div>
-</a>
+      Follow Rowan Test
+    </button>
+    <button
+      aria-hidden="true"
+      className="add project-cover-button-wrapper"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      tabIndex={-1}
+    >
+      <div
+        aria-hidden="true"
+        className="project-cover-button"
+      >
+        <div
+          className="icons"
+        >
+          <svg
+            aria-hidden="true"
+            className="manicon-svg minus svg-icon--MinusUnique"
+            fill="currentColor"
+            height={28}
+            viewBox="0 0 32 32"
+            width={28}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="2"
+              width="14"
+              x="9"
+              y="15"
+            />
+          </svg>
+          <svg
+            aria-hidden="true"
+            className="manicon-svg check svg-icon--CheckUnique"
+            fill="currentColor"
+            height={28}
+            viewBox="0 0 32 32"
+            width={28}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polygon
+              points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+            />
+          </svg>
+          <svg
+            aria-hidden="true"
+            className="manicon-svg plus svg-icon--PlusUnique"
+            fill="currentColor"
+            height={28}
+            viewBox="0 0 32 32"
+            width={28}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="2"
+              width="14"
+              x="9"
+              y="15"
+            />
+            <rect
+              height="14"
+              width="2"
+              x="15"
+              y="9"
+            />
+          </svg>
+        </div>
+        <span>
+          <span
+            className="action-text"
+          >
+            Follow
+          </span>
+        </span>
+      </div>
+    </button>
+  </div>,
+]
 `;

--- a/client/src/frontend/components/project/Follow.js
+++ b/client/src/frontend/components/project/Follow.js
@@ -4,7 +4,9 @@ import get from "lodash/get";
 import { currentUserActions } from "actions";
 import Project from "global/components/project";
 
-export default class ProjectFollow extends Component {
+import withScreenReaderStatus from "hoc/with-screen-reader-status";
+
+class ProjectFollow extends Component {
   static displayName = "Project.Follow";
 
   static propTypes = {
@@ -14,6 +16,14 @@ export default class ProjectFollow extends Component {
     project: PropTypes.object
   };
 
+  get followMessage() {
+    return "You are now following this project";
+  }
+
+  get unfollowMessage() {
+    return "You are no longer following this project.";
+  }
+
   getFollowed(props) {
     return get(props.favorites, props.project.id);
   }
@@ -21,12 +31,14 @@ export default class ProjectFollow extends Component {
   handleFollow = () => {
     const { id, type } = this.props.project;
     this.props.dispatch(currentUserActions.follow({ id, type }));
+    this.props.setScreenReaderStatus(this.followMessage);
   };
 
   handleUnfollow = followed => {
     this.props.dispatch(
       currentUserActions.unfollow(this.props.project.id, followed.id)
     );
+    this.props.setScreenReaderStatus(this.unfollowMessage);
   };
 
   render() {
@@ -45,3 +57,5 @@ export default class ProjectFollow extends Component {
     );
   }
 }
+
+export default withScreenReaderStatus(ProjectFollow);

--- a/client/src/frontend/components/project/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/project/__tests__/__snapshots__/Detail-test.js.snap
@@ -54,7 +54,7 @@ exports[`Frontend.Project.Detail component renders correctly 1`] = `
             className="project-hero__figure project-hero__figure--constrained"
           >
             <svg
-              aria-label="Default Project Thumbnail"
+              aria-label={null}
               className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
               height={134}
               viewBox="0 0 134 134"
@@ -138,7 +138,7 @@ exports[`Frontend.Project.Detail component renders correctly 1`] = `
               </g>
             </svg>
             <svg
-              aria-label="Default Project Thumbnail"
+              aria-label={null}
               className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
               height="100%"
               viewBox="0 0 48 48"
@@ -329,7 +329,7 @@ exports[`Frontend.Project.Detail component renders correctly when hideActivity i
             className="project-hero__figure project-hero__figure--constrained"
           >
             <svg
-              aria-label="Default Project Thumbnail"
+              aria-label={null}
               className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
               height={134}
               viewBox="0 0 134 134"
@@ -413,7 +413,7 @@ exports[`Frontend.Project.Detail component renders correctly when hideActivity i
               </g>
             </svg>
             <svg
-              aria-label="Default Project Thumbnail"
+              aria-label={null}
               className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
               height="100%"
               viewBox="0 0 48 48"

--- a/client/src/frontend/components/project/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/frontend/components/project/__tests__/__snapshots__/Following-test.js.snap
@@ -1,88 +1,96 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frontend.Project.Follow component renders correctly 1`] = `
-<div>
-  <button
-    className="screen-reader-text"
-    onClick={[Function]}
-  >
-    add Rowan Test
-  </button>
+Array [
   <div
-    aria-hidden="true"
-    className="add project-cover-button-wrapper"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    role="presentation"
-  >
-    <div
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
+  <div>
+    <button
+      className="screen-reader-text"
+      onClick={[Function]}
+    >
+      Follow Rowan Test
+    </button>
+    <button
       aria-hidden="true"
-      className="project-cover-button"
+      className="add project-cover-button-wrapper"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      tabIndex={-1}
     >
       <div
-        className="icons"
+        aria-hidden="true"
+        className="project-cover-button"
       >
-        <svg
-          aria-hidden="true"
-          className="manicon-svg minus svg-icon--MinusUnique"
-          fill="currentColor"
-          height={28}
-          viewBox="0 0 32 32"
-          width={28}
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          className="icons"
         >
-          <rect
-            height="2"
-            width="14"
-            x="9"
-            y="15"
-          />
-        </svg>
-        <svg
-          aria-hidden="true"
-          className="manicon-svg check svg-icon--CheckUnique"
-          fill="currentColor"
-          height={28}
-          viewBox="0 0 32 32"
-          width={28}
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <polygon
-            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
-          />
-        </svg>
-        <svg
-          aria-hidden="true"
-          className="manicon-svg plus svg-icon--PlusUnique"
-          fill="currentColor"
-          height={28}
-          viewBox="0 0 32 32"
-          width={28}
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect
-            height="2"
-            width="14"
-            x="9"
-            y="15"
-          />
-          <rect
-            height="14"
-            width="2"
-            x="15"
-            y="9"
-          />
-        </svg>
-      </div>
-      <span>
-        <span
-          className="action-text"
-        >
-          Follow
+          <svg
+            aria-hidden="true"
+            className="manicon-svg minus svg-icon--MinusUnique"
+            fill="currentColor"
+            height={28}
+            viewBox="0 0 32 32"
+            width={28}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="2"
+              width="14"
+              x="9"
+              y="15"
+            />
+          </svg>
+          <svg
+            aria-hidden="true"
+            className="manicon-svg check svg-icon--CheckUnique"
+            fill="currentColor"
+            height={28}
+            viewBox="0 0 32 32"
+            width={28}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polygon
+              points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+            />
+          </svg>
+          <svg
+            aria-hidden="true"
+            className="manicon-svg plus svg-icon--PlusUnique"
+            fill="currentColor"
+            height={28}
+            viewBox="0 0 32 32"
+            width={28}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="2"
+              width="14"
+              x="9"
+              y="15"
+            />
+            <rect
+              height="14"
+              width="2"
+              x="15"
+              y="9"
+            />
+          </svg>
+        </div>
+        <span>
+          <span
+            className="action-text"
+          >
+            Follow
+          </span>
         </span>
-      </span>
-    </div>
-  </div>
-</div>
+      </div>
+    </button>
+  </div>,
+]
 `;

--- a/client/src/frontend/components/project/__tests__/__snapshots__/Hero-test.js.snap
+++ b/client/src/frontend/components/project/__tests__/__snapshots__/Hero-test.js.snap
@@ -93,7 +93,7 @@ exports[`Frontend.Project.Hero component renders correctly 1`] = `
           className="project-hero__figure project-hero__figure--constrained"
         >
           <svg
-            aria-label="Default Project Thumbnail"
+            aria-label={null}
             className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
             height={134}
             viewBox="0 0 134 134"
@@ -177,7 +177,7 @@ exports[`Frontend.Project.Hero component renders correctly 1`] = `
             </g>
           </svg>
           <svg
-            aria-label="Default Project Thumbnail"
+            aria-label={null}
             className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
             height="100%"
             viewBox="0 0 48 48"
@@ -364,7 +364,7 @@ exports[`Frontend.Project.Hero component renders correctly when object-fit is un
           className="project-hero__figure project-hero__figure--constrained"
         >
           <svg
-            aria-label="Default Project Thumbnail"
+            aria-label={null}
             className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
             height={134}
             viewBox="0 0 134 134"
@@ -448,7 +448,7 @@ exports[`Frontend.Project.Hero component renders correctly when object-fit is un
             </g>
           </svg>
           <svg
-            aria-label="Default Project Thumbnail"
+            aria-label={null}
             className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
             height="100%"
             viewBox="0 0 48 48"

--- a/client/src/frontend/containers/Featured/__tests__/__snapshots__/Featured-test.js.snap
+++ b/client/src/frontend/containers/Featured/__tests__/__snapshots__/Featured-test.js.snap
@@ -145,7 +145,9 @@ exports[`Frontend Featured Container renders correctly 1`] = `
         className="project-list grid entity-section-wrapper__body"
       >
         <ul>
-          <li>
+          <li
+            className="project-list__item--pos-rel"
+          >
             <a
               href="/projects/slug-1"
               onClick={[Function]}
@@ -154,7 +156,7 @@ exports[`Frontend Featured Container renders correctly 1`] = `
                 className="cover"
               >
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                   height={134}
                   viewBox="0 0 134 134"
@@ -238,7 +240,7 @@ exports[`Frontend Featured Container renders correctly 1`] = `
                   </g>
                 </svg>
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                   height="100%"
                   viewBox="0 0 48 48"
@@ -309,90 +311,6 @@ exports[`Frontend Featured Container renders correctly 1`] = `
                     </g>
                   </g>
                 </svg>
-                <div>
-                  <button
-                    className="screen-reader-text"
-                    onClick={[Function]}
-                  >
-                    add Rowan Test
-                  </button>
-                  <div
-                    aria-hidden="true"
-                    className="add project-cover-button-wrapper"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="presentation"
-                  >
-                    <div
-                      aria-hidden="true"
-                      className="project-cover-button"
-                    >
-                      <div
-                        className="icons"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg minus svg-icon--MinusUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <rect
-                            height="2"
-                            width="14"
-                            x="9"
-                            y="15"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg check svg-icon--CheckUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <polygon
-                            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg plus svg-icon--PlusUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <rect
-                            height="2"
-                            width="14"
-                            x="9"
-                            y="15"
-                          />
-                          <rect
-                            height="14"
-                            width="2"
-                            x="15"
-                            y="9"
-                          />
-                        </svg>
-                      </div>
-                      <span>
-                        <span
-                          className="action-text"
-                        >
-                          Follow
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </div>
               </figure>
               <div
                 className="meta"
@@ -411,8 +329,100 @@ exports[`Frontend Featured Container renders correctly 1`] = `
                 </h3>
               </div>
             </a>
+            <div
+              aria-atomic={true}
+              aria-live="polite"
+              className="screen-reader-text"
+              role="status"
+            />
+            <div>
+              <button
+                className="screen-reader-text"
+                onClick={[Function]}
+              >
+                Follow Rowan Test
+              </button>
+              <button
+                aria-hidden="true"
+                className="add project-cover-button-wrapper"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                tabIndex={-1}
+              >
+                <div
+                  aria-hidden="true"
+                  className="project-cover-button"
+                >
+                  <div
+                    className="icons"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg minus svg-icon--MinusUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        height="2"
+                        width="14"
+                        x="9"
+                        y="15"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg check svg-icon--CheckUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <polygon
+                        points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg plus svg-icon--PlusUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        height="2"
+                        width="14"
+                        x="9"
+                        y="15"
+                      />
+                      <rect
+                        height="14"
+                        width="2"
+                        x="15"
+                        y="9"
+                      />
+                    </svg>
+                  </div>
+                  <span>
+                    <span
+                      className="action-text"
+                    >
+                      Follow
+                    </span>
+                  </span>
+                </div>
+              </button>
+            </div>
           </li>
-          <li>
+          <li
+            className="project-list__item--pos-rel"
+          >
             <a
               href="/projects/slug-2"
               onClick={[Function]}
@@ -421,7 +431,7 @@ exports[`Frontend Featured Container renders correctly 1`] = `
                 className="cover"
               >
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                   height={134}
                   viewBox="0 0 134 134"
@@ -505,7 +515,7 @@ exports[`Frontend Featured Container renders correctly 1`] = `
                   </g>
                 </svg>
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                   height="100%"
                   viewBox="0 0 48 48"
@@ -576,90 +586,6 @@ exports[`Frontend Featured Container renders correctly 1`] = `
                     </g>
                   </g>
                 </svg>
-                <div>
-                  <button
-                    className="screen-reader-text"
-                    onClick={[Function]}
-                  >
-                    add Rowan Test
-                  </button>
-                  <div
-                    aria-hidden="true"
-                    className="add project-cover-button-wrapper"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="presentation"
-                  >
-                    <div
-                      aria-hidden="true"
-                      className="project-cover-button"
-                    >
-                      <div
-                        className="icons"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg minus svg-icon--MinusUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <rect
-                            height="2"
-                            width="14"
-                            x="9"
-                            y="15"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg check svg-icon--CheckUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <polygon
-                            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg plus svg-icon--PlusUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <rect
-                            height="2"
-                            width="14"
-                            x="9"
-                            y="15"
-                          />
-                          <rect
-                            height="14"
-                            width="2"
-                            x="15"
-                            y="9"
-                          />
-                        </svg>
-                      </div>
-                      <span>
-                        <span
-                          className="action-text"
-                        >
-                          Follow
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </div>
               </figure>
               <div
                 className="meta"
@@ -678,6 +604,96 @@ exports[`Frontend Featured Container renders correctly 1`] = `
                 </h3>
               </div>
             </a>
+            <div
+              aria-atomic={true}
+              aria-live="polite"
+              className="screen-reader-text"
+              role="status"
+            />
+            <div>
+              <button
+                className="screen-reader-text"
+                onClick={[Function]}
+              >
+                Follow Rowan Test
+              </button>
+              <button
+                aria-hidden="true"
+                className="add project-cover-button-wrapper"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                tabIndex={-1}
+              >
+                <div
+                  aria-hidden="true"
+                  className="project-cover-button"
+                >
+                  <div
+                    className="icons"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg minus svg-icon--MinusUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        height="2"
+                        width="14"
+                        x="9"
+                        y="15"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg check svg-icon--CheckUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <polygon
+                        points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg plus svg-icon--PlusUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        height="2"
+                        width="14"
+                        x="9"
+                        y="15"
+                      />
+                      <rect
+                        height="14"
+                        width="2"
+                        x="15"
+                        y="9"
+                      />
+                    </svg>
+                  </div>
+                  <span>
+                    <span
+                      className="action-text"
+                    >
+                      Follow
+                    </span>
+                  </span>
+                </div>
+              </button>
+            </div>
           </li>
         </ul>
       </div>

--- a/client/src/frontend/containers/Following/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/frontend/containers/Following/__tests__/__snapshots__/Following-test.js.snap
@@ -171,7 +171,9 @@ exports[`Frontend Following Container renders correctly 1`] = `
         className="project-list grid entity-section-wrapper__body"
       >
         <ul>
-          <li>
+          <li
+            className="project-list__item--pos-rel"
+          >
             <a
               href="/projects/slug-3"
               onClick={[Function]}
@@ -180,7 +182,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
                 className="cover"
               >
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                   height={134}
                   viewBox="0 0 134 134"
@@ -264,7 +266,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
                   </g>
                 </svg>
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                   height="100%"
                   viewBox="0 0 48 48"
@@ -335,90 +337,6 @@ exports[`Frontend Following Container renders correctly 1`] = `
                     </g>
                   </g>
                 </svg>
-                <div>
-                  <button
-                    className="screen-reader-text"
-                    onClick={[Function]}
-                  >
-                    add Rowan Test
-                  </button>
-                  <div
-                    aria-hidden="true"
-                    className="add project-cover-button-wrapper"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="presentation"
-                  >
-                    <div
-                      aria-hidden="true"
-                      className="project-cover-button"
-                    >
-                      <div
-                        className="icons"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg minus svg-icon--MinusUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <rect
-                            height="2"
-                            width="14"
-                            x="9"
-                            y="15"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg check svg-icon--CheckUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <polygon
-                            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg plus svg-icon--PlusUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <rect
-                            height="2"
-                            width="14"
-                            x="9"
-                            y="15"
-                          />
-                          <rect
-                            height="14"
-                            width="2"
-                            x="15"
-                            y="9"
-                          />
-                        </svg>
-                      </div>
-                      <span>
-                        <span
-                          className="action-text"
-                        >
-                          Follow
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </div>
               </figure>
               <div
                 className="meta"
@@ -437,8 +355,100 @@ exports[`Frontend Following Container renders correctly 1`] = `
                 </h3>
               </div>
             </a>
+            <div
+              aria-atomic={true}
+              aria-live="polite"
+              className="screen-reader-text"
+              role="status"
+            />
+            <div>
+              <button
+                className="screen-reader-text"
+                onClick={[Function]}
+              >
+                Follow Rowan Test
+              </button>
+              <button
+                aria-hidden="true"
+                className="add project-cover-button-wrapper"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                tabIndex={-1}
+              >
+                <div
+                  aria-hidden="true"
+                  className="project-cover-button"
+                >
+                  <div
+                    className="icons"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg minus svg-icon--MinusUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        height="2"
+                        width="14"
+                        x="9"
+                        y="15"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg check svg-icon--CheckUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <polygon
+                        points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg plus svg-icon--PlusUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        height="2"
+                        width="14"
+                        x="9"
+                        y="15"
+                      />
+                      <rect
+                        height="14"
+                        width="2"
+                        x="15"
+                        y="9"
+                      />
+                    </svg>
+                  </div>
+                  <span>
+                    <span
+                      className="action-text"
+                    >
+                      Follow
+                    </span>
+                  </span>
+                </div>
+              </button>
+            </div>
           </li>
-          <li>
+          <li
+            className="project-list__item--pos-rel"
+          >
             <a
               href="/projects/slug-4"
               onClick={[Function]}
@@ -447,7 +457,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
                 className="cover"
               >
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                   height={134}
                   viewBox="0 0 134 134"
@@ -531,7 +541,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
                   </g>
                 </svg>
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                   height="100%"
                   viewBox="0 0 48 48"
@@ -602,90 +612,6 @@ exports[`Frontend Following Container renders correctly 1`] = `
                     </g>
                   </g>
                 </svg>
-                <div>
-                  <button
-                    className="screen-reader-text"
-                    onClick={[Function]}
-                  >
-                    add Rowan Test
-                  </button>
-                  <div
-                    aria-hidden="true"
-                    className="add project-cover-button-wrapper"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="presentation"
-                  >
-                    <div
-                      aria-hidden="true"
-                      className="project-cover-button"
-                    >
-                      <div
-                        className="icons"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg minus svg-icon--MinusUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <rect
-                            height="2"
-                            width="14"
-                            x="9"
-                            y="15"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg check svg-icon--CheckUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <polygon
-                            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg plus svg-icon--PlusUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <rect
-                            height="2"
-                            width="14"
-                            x="9"
-                            y="15"
-                          />
-                          <rect
-                            height="14"
-                            width="2"
-                            x="15"
-                            y="9"
-                          />
-                        </svg>
-                      </div>
-                      <span>
-                        <span
-                          className="action-text"
-                        >
-                          Follow
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </div>
               </figure>
               <div
                 className="meta"
@@ -704,6 +630,96 @@ exports[`Frontend Following Container renders correctly 1`] = `
                 </h3>
               </div>
             </a>
+            <div
+              aria-atomic={true}
+              aria-live="polite"
+              className="screen-reader-text"
+              role="status"
+            />
+            <div>
+              <button
+                className="screen-reader-text"
+                onClick={[Function]}
+              >
+                Follow Rowan Test
+              </button>
+              <button
+                aria-hidden="true"
+                className="add project-cover-button-wrapper"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                tabIndex={-1}
+              >
+                <div
+                  aria-hidden="true"
+                  className="project-cover-button"
+                >
+                  <div
+                    className="icons"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg minus svg-icon--MinusUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        height="2"
+                        width="14"
+                        x="9"
+                        y="15"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg check svg-icon--CheckUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <polygon
+                        points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg plus svg-icon--PlusUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        height="2"
+                        width="14"
+                        x="9"
+                        y="15"
+                      />
+                      <rect
+                        height="14"
+                        width="2"
+                        x="15"
+                        y="9"
+                      />
+                    </svg>
+                  </div>
+                  <span>
+                    <span
+                      className="action-text"
+                    >
+                      Follow
+                    </span>
+                  </span>
+                </div>
+              </button>
+            </div>
           </li>
         </ul>
       </div>
@@ -747,7 +763,9 @@ exports[`Frontend Following Container renders correctly 1`] = `
         className="project-list grid entity-section-wrapper__body"
       >
         <ul>
-          <li>
+          <li
+            className="project-list__item--pos-rel"
+          >
             <a
               href="/projects/slug-1"
               onClick={[Function]}
@@ -756,7 +774,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
                 className="cover"
               >
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                   height={134}
                   viewBox="0 0 134 134"
@@ -840,7 +858,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
                   </g>
                 </svg>
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                   height="100%"
                   viewBox="0 0 48 48"
@@ -911,90 +929,6 @@ exports[`Frontend Following Container renders correctly 1`] = `
                     </g>
                   </g>
                 </svg>
-                <div>
-                  <button
-                    className="screen-reader-text"
-                    onClick={[Function]}
-                  >
-                    add Rowan Test
-                  </button>
-                  <div
-                    aria-hidden="true"
-                    className="add project-cover-button-wrapper"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="presentation"
-                  >
-                    <div
-                      aria-hidden="true"
-                      className="project-cover-button"
-                    >
-                      <div
-                        className="icons"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg minus svg-icon--MinusUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <rect
-                            height="2"
-                            width="14"
-                            x="9"
-                            y="15"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg check svg-icon--CheckUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <polygon
-                            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg plus svg-icon--PlusUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <rect
-                            height="2"
-                            width="14"
-                            x="9"
-                            y="15"
-                          />
-                          <rect
-                            height="14"
-                            width="2"
-                            x="15"
-                            y="9"
-                          />
-                        </svg>
-                      </div>
-                      <span>
-                        <span
-                          className="action-text"
-                        >
-                          Follow
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </div>
               </figure>
               <div
                 className="meta"
@@ -1013,8 +947,100 @@ exports[`Frontend Following Container renders correctly 1`] = `
                 </h3>
               </div>
             </a>
+            <div
+              aria-atomic={true}
+              aria-live="polite"
+              className="screen-reader-text"
+              role="status"
+            />
+            <div>
+              <button
+                className="screen-reader-text"
+                onClick={[Function]}
+              >
+                Follow Rowan Test
+              </button>
+              <button
+                aria-hidden="true"
+                className="add project-cover-button-wrapper"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                tabIndex={-1}
+              >
+                <div
+                  aria-hidden="true"
+                  className="project-cover-button"
+                >
+                  <div
+                    className="icons"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg minus svg-icon--MinusUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        height="2"
+                        width="14"
+                        x="9"
+                        y="15"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg check svg-icon--CheckUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <polygon
+                        points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg plus svg-icon--PlusUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        height="2"
+                        width="14"
+                        x="9"
+                        y="15"
+                      />
+                      <rect
+                        height="14"
+                        width="2"
+                        x="15"
+                        y="9"
+                      />
+                    </svg>
+                  </div>
+                  <span>
+                    <span
+                      className="action-text"
+                    >
+                      Follow
+                    </span>
+                  </span>
+                </div>
+              </button>
+            </div>
           </li>
-          <li>
+          <li
+            className="project-list__item--pos-rel"
+          >
             <a
               href="/projects/slug-2"
               onClick={[Function]}
@@ -1023,7 +1049,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
                 className="cover"
               >
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                   height={134}
                   viewBox="0 0 134 134"
@@ -1107,7 +1133,7 @@ exports[`Frontend Following Container renders correctly 1`] = `
                   </g>
                 </svg>
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                   height="100%"
                   viewBox="0 0 48 48"
@@ -1178,90 +1204,6 @@ exports[`Frontend Following Container renders correctly 1`] = `
                     </g>
                   </g>
                 </svg>
-                <div>
-                  <button
-                    className="screen-reader-text"
-                    onClick={[Function]}
-                  >
-                    add Rowan Test
-                  </button>
-                  <div
-                    aria-hidden="true"
-                    className="add project-cover-button-wrapper"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    role="presentation"
-                  >
-                    <div
-                      aria-hidden="true"
-                      className="project-cover-button"
-                    >
-                      <div
-                        className="icons"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg minus svg-icon--MinusUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <rect
-                            height="2"
-                            width="14"
-                            x="9"
-                            y="15"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg check svg-icon--CheckUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <polygon
-                            points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          className="manicon-svg plus svg-icon--PlusUnique"
-                          fill="currentColor"
-                          height={28}
-                          viewBox="0 0 32 32"
-                          width={28}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <rect
-                            height="2"
-                            width="14"
-                            x="9"
-                            y="15"
-                          />
-                          <rect
-                            height="14"
-                            width="2"
-                            x="15"
-                            y="9"
-                          />
-                        </svg>
-                      </div>
-                      <span>
-                        <span
-                          className="action-text"
-                        >
-                          Follow
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </div>
               </figure>
               <div
                 className="meta"
@@ -1280,6 +1222,96 @@ exports[`Frontend Following Container renders correctly 1`] = `
                 </h3>
               </div>
             </a>
+            <div
+              aria-atomic={true}
+              aria-live="polite"
+              className="screen-reader-text"
+              role="status"
+            />
+            <div>
+              <button
+                className="screen-reader-text"
+                onClick={[Function]}
+              >
+                Follow Rowan Test
+              </button>
+              <button
+                aria-hidden="true"
+                className="add project-cover-button-wrapper"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                tabIndex={-1}
+              >
+                <div
+                  aria-hidden="true"
+                  className="project-cover-button"
+                >
+                  <div
+                    className="icons"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg minus svg-icon--MinusUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        height="2"
+                        width="14"
+                        x="9"
+                        y="15"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg check svg-icon--CheckUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <polygon
+                        points="14.314 23.462 7.317 16.909 8.684 15.449 14.118 20.538 23.225 9.368 24.775 10.632 14.314 23.462"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      className="manicon-svg plus svg-icon--PlusUnique"
+                      fill="currentColor"
+                      height={28}
+                      viewBox="0 0 32 32"
+                      width={28}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <rect
+                        height="2"
+                        width="14"
+                        x="9"
+                        y="15"
+                      />
+                      <rect
+                        height="14"
+                        width="2"
+                        x="15"
+                        y="9"
+                      />
+                    </svg>
+                  </div>
+                  <span>
+                    <span
+                      className="action-text"
+                    >
+                      Follow
+                    </span>
+                  </span>
+                </div>
+              </button>
+            </div>
           </li>
         </ul>
       </div>

--- a/client/src/frontend/containers/ProjectCollectionDetail/__tests__/__snapshots__/ProjectCollectionDetail-test.js.snap
+++ b/client/src/frontend/containers/ProjectCollectionDetail/__tests__/__snapshots__/ProjectCollectionDetail-test.js.snap
@@ -183,7 +183,9 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
         className="project-list grid entity-section-wrapper__body"
       >
         <ul>
-          <li>
+          <li
+            className="project-list__item--pos-rel"
+          >
             <a
               href="/projects/slug-1"
               onClick={[Function]}
@@ -192,7 +194,7 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
                 className="cover"
               >
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                   height={134}
                   viewBox="0 0 134 134"
@@ -276,7 +278,7 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
                   </g>
                 </svg>
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                   height="100%"
                   viewBox="0 0 48 48"
@@ -365,8 +367,16 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
                 </h3>
               </div>
             </a>
+            <div
+              aria-atomic={true}
+              aria-live="polite"
+              className="screen-reader-text"
+              role="status"
+            />
           </li>
-          <li>
+          <li
+            className="project-list__item--pos-rel"
+          >
             <a
               href="/projects/slug-2"
               onClick={[Function]}
@@ -375,7 +385,7 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
                 className="cover"
               >
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                   height={134}
                   viewBox="0 0 134 134"
@@ -459,7 +469,7 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
                   </g>
                 </svg>
                 <svg
-                  aria-label="Default Project Thumbnail"
+                  aria-label={null}
                   className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                   height="100%"
                   viewBox="0 0 48 48"
@@ -548,6 +558,12 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
                 </h3>
               </div>
             </a>
+            <div
+              aria-atomic={true}
+              aria-live="polite"
+              className="screen-reader-text"
+              role="status"
+            />
           </li>
         </ul>
       </div>

--- a/client/src/frontend/containers/ProjectDetail/__tests__/__snapshots__/ProjectDetail-test.js.snap
+++ b/client/src/frontend/containers/ProjectDetail/__tests__/__snapshots__/ProjectDetail-test.js.snap
@@ -57,7 +57,7 @@ exports[`Frontend ProjectDetail Container renders correctly 1`] = `
               className="project-hero__figure project-hero__figure--constrained"
             >
               <svg
-                aria-label="Default Project Thumbnail"
+                aria-label={null}
                 className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
                 height={134}
                 viewBox="0 0 134 134"
@@ -141,7 +141,7 @@ exports[`Frontend ProjectDetail Container renders correctly 1`] = `
                 </g>
               </svg>
               <svg
-                aria-label="Default Project Thumbnail"
+                aria-label={null}
                 className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
                 height="100%"
                 viewBox="0 0 48 48"

--- a/client/src/global/components/project/Avatar.js
+++ b/client/src/global/components/project/Avatar.js
@@ -16,9 +16,7 @@ export default class ProjectAvatar extends Component {
       meta.width >= meta.height
         ? project.attributes.avatarStyles.smallSquare
         : project.attributes.avatarStyles.small;
-    return (
-      <img src={imageStyle} alt={`View ${project.attributes.titlePlaintext}`} />
-    );
+    return <img src={imageStyle} alt="" />;
   }
 
   renderPlaceholderImage(project) {
@@ -28,6 +26,7 @@ export default class ProjectAvatar extends Component {
         <UniqueIcons.ProjectPlaceholderUnique
           mode="responsive"
           color={project.attributes.avatarColor}
+          ariaLabel={false}
         />
       </React.Fragment>
     );

--- a/client/src/global/components/project/CoverButton.js
+++ b/client/src/global/components/project/CoverButton.js
@@ -82,13 +82,14 @@ export default class CoverButton extends Component {
   };
 
   screenReaderButtonText() {
+    const { addText, removeText, project } = this.props;
     switch (this.state.view) {
       case "add":
       case "add-active":
-        return "add " + this.props.project.attributes.titlePlaintext;
+        return `${addText} ${project.attributes.titlePlaintext}`;
       case "remove":
       case "remove-active":
-        return "Follow " + this.props.project.attributes.titlePlaintext;
+        return `${removeText} ${project.attributes.titlePlaintext}`;
       default:
         return null;
     }
@@ -157,13 +158,13 @@ export default class CoverButton extends Component {
         <button className="screen-reader-text" onClick={this.toggleFollow}>
           {this.screenReaderButtonText()}
         </button>
-        <div
+        <button
           onClick={this.handleClick}
           onMouseEnter={this.activate}
           onMouseLeave={this.deactivate}
           className={wrapperClasses}
-          role="presentation"
           aria-hidden="true"
+          tabIndex={-1}
         >
           <div className="project-cover-button" aria-hidden="true">
             <div className="icons">
@@ -191,7 +192,7 @@ export default class CoverButton extends Component {
               {this.renderButton(this.state.view)}
             </ReactCSSTransitionGroup>
           </div>
-        </div>
+        </button>
       </div>
     );
   }

--- a/client/src/hoc/with-screen-reader-status/index.js
+++ b/client/src/hoc/with-screen-reader-status/index.js
@@ -1,0 +1,66 @@
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
+import hoistStatics from "hoist-non-react-statics";
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || "Component";
+}
+
+export default function withScreenReaderStatus(WrappedComponent) {
+  const displayName = `WithScreenReaderStatus('${getDisplayName(
+    WrappedComponent
+  )})`;
+
+  class WithScreenReaderStatus extends PureComponent {
+    static WrappedComponent = WrappedComponent;
+
+    static displayName = displayName;
+
+    constructor(props) {
+      super(props);
+      this.state = { message: null };
+    }
+
+    get childProps() {
+      return {
+        setScreenReaderStatus: this.setStatus
+      }
+    }
+
+    setStatus = message => {
+      // temporarily update state with new message
+      this.setState({ message: message });
+
+      // remove message
+      setTimeout(() => {
+        this.setState({ message: null })
+      }, 1000);
+    }
+
+    renderLiveRegion() {
+      return (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic
+          className="screen-reader-text"
+        >
+          {this.state.message}
+        </div>
+      );
+    }
+
+    render() {
+      const props = Object.assign({}, this.props, this.childProps);
+
+      return (
+        <React.Fragment>
+          {this.renderLiveRegion()}
+          {React.createElement(WrappedComponent, props)}
+        </React.Fragment>
+      );
+    }
+  }
+
+  return hoistStatics(WithScreenReaderStatus, WrappedComponent);
+}

--- a/client/src/theme/styles/components/global/_buttons.scss
+++ b/client/src/theme/styles/components/global/_buttons.scss
@@ -650,25 +650,48 @@
 }
 
 .project-cover-button-wrapper {
+  @include buttonUnstyled;
   position: absolute;
-  top: 10.526%;
+  top: 10px;
   left: -15px;
   width: 28px;
   height: 28px;
 
   @include respond($break75) {
+    top: 15px;
     width: 30px;
     height: 30px;
   }
 
+  .project-list__item--pos-rel & {
+    // aligned to <li> to separate button from anchor
+    top: 25px;
+    left: 0;
+
+    @include respond($break75) {
+      top: calc(2.105vw + 15px);
+      left: calc(2.105vw - 15px);
+    }
+
+    @include respond($break120) {
+      top: 40px;
+      left: 10px;
+    }
+  }
+
   &.active {
     width: 100%;
+  }
+
+  &:focus {
+    outline-width: 0;
   }
 }
 
 .project-cover-button {
   @include templateHead;
   position: absolute;
+  top: 0;
   left: 0;
   display: block;
   max-width: 100%;

--- a/client/src/theme/styles/components/global/_project-list.scss
+++ b/client/src/theme/styles/components/global/_project-list.scss
@@ -32,6 +32,10 @@
     }
   }
 
+  &__item--pos-rel {
+    position: relative;
+  }
+
   // Optional grid-style layout for larger viewports
   &.grid {
     a, .item-wrapper {


### PR DESCRIPTION
This PR makes a handful of changes to improve the accessibility of project lists on the FE and BE, with a particular emphasis on improving the experience for users accessing Manifold with a screen reader:

* Hides most content within each project link (cover alt-text, metadata, publication status, etc) to make SR readout less verbose
* Un-nests "Follow" button from anchor that wraps each project
* Improves SR text for "Follow" button ("Include" in PC manual collections)
* Adds live region that provides a notification to screen readers when a project is followed/unfollowed (included/excluded in PC manual collections)

Resolves #2188