### PR TITLE
[B] Improve SR experience for search forms

### DIFF
--- a/client/src/backend/components/list/EntitiesList/List/Search.js
+++ b/client/src/backend/components/list/EntitiesList/List/Search.js
@@ -5,7 +5,6 @@ import labelId from "helpers/labelId";
 import { Collapse } from "react-collapse";
 import classNames from "classnames";
 import has from "lodash/has";
-
 import isPlainObject from "lodash/isPlainObject";
 
 export default class ListEntitiesListSearch extends PureComponent {
@@ -31,6 +30,7 @@ export default class ListEntitiesListSearch extends PureComponent {
       open: false,
       keyword: ""
     };
+    this.searchInput = React.createRef();
   }
 
   componentDidUpdate(prevProps) {
@@ -146,6 +146,9 @@ export default class ListEntitiesListSearch extends PureComponent {
     event.preventDefault();
     this.setState({ keyword: "" });
     this.props.onReset();
+
+    // focus on search field
+    this.searchInput.current.focus();
   };
 
   classNameWithStyle(className) {
@@ -179,6 +182,7 @@ export default class ListEntitiesListSearch extends PureComponent {
                   Enter Search Criteria
                 </label>
                 <input
+                  ref={this.searchInput}
                   className={`${baseClass}__keyword-input`}
                   id={label}
                   value={this.state.keyword}
@@ -197,6 +201,8 @@ export default class ListEntitiesListSearch extends PureComponent {
                 <button
                   onClick={this.toggleOptions}
                   className={`${baseClass}__text-button ${baseClass}__text-button--foregrounded`}
+                  aria-haspopup
+                  aria-expanded={this.state.open}
                 >
                   Options
                 </button>

--- a/client/src/backend/components/list/EntitiesList/List/TextTitle.js
+++ b/client/src/backend/components/list/EntitiesList/List/TextTitle.js
@@ -38,6 +38,16 @@ export default class ListEntitiesListTextTitle extends PureComponent {
     return this.props.titleLink;
   }
 
+  get ariaAttributes() {
+    if (!this.props.count) return null;
+
+    return {
+      role: "status",
+      "aria-live": "polite",
+      "aria-atomic": true
+    };
+  }
+
   link(child) {
     if (!this.titleLink) return child;
     return <Link to={this.titleLink}>{child}</Link>;
@@ -45,7 +55,10 @@ export default class ListEntitiesListTextTitle extends PureComponent {
 
   render() {
     return (
-      <h2 className="entity-list__title-block entity-list__title">
+      <h2
+        className="entity-list__title-block entity-list__title"
+        {...this.ariaAttributes}
+      >
         {this.link(
           <React.Fragment>
             {this.titleIcon && (

--- a/client/src/backend/containers/dashboards/__tests__/__snapshots__/Admin-test.js.snap
+++ b/client/src/backend/containers/dashboards/__tests__/__snapshots__/Admin-test.js.snap
@@ -1,38 +1,720 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Backend Dashboards Admin Container renders correctly 1`] = `
-<div>
-  <h1
+Array [
+  <div
+    aria-atomic={true}
+    aria-live="polite"
     className="screen-reader-text"
-  >
-    Dashboard
-  </h1>
-  <section>
-    <div
-      className="container"
+    role="status"
+  />,
+  <div>
+    <h1
+      className="screen-reader-text"
     >
-      <section
-        className="backend-dashboard"
+      Dashboard
+    </h1>
+    <section>
+      <div
+        className="container"
       >
-        <div
-          className="left"
+        <section
+          className="backend-dashboard"
         >
           <div
-            className="dashboard-panel"
+            className="left"
           >
             <div
-              className="panel"
+              className="dashboard-panel"
             >
               <div
-                className="entity-list"
-                id="entities-list1"
+                className="panel"
               >
-                <h2
-                  className="entity-list__title-block entity-list__title"
+                <div
+                  className="entity-list"
+                  id="entities-list1"
                 >
-                  <a
-                    href="/backend/projects"
-                    onClick={[Function]}
+                  <h2
+                    aria-atomic={true}
+                    aria-live="polite"
+                    className="entity-list__title-block entity-list__title"
+                    role="status"
+                  >
+                    <a
+                      href="/backend/projects"
+                      onClick={[Function]}
+                    >
+                      <figure
+                        className="entity-list__title-icon"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="manicon-svg svg-icon--BEProject64"
+                          fill="currentColor"
+                          height={null}
+                          viewBox="0 0 64 64"
+                          width={null}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M9.103,24.948 L32.045,34.722 L54.984,24.948 L32.045,15.174 L9.103,24.948 Z M32.045,36.896 L4,24.948 L32.045,13 L60.086,24.948 L32.045,36.896 Z M60.009,32.175 L60.009,30 L32.01,41.94 L4,30.021 L4,32.194 L32.011,44.113 L60.009,32.175 Z M60.009,39.175 L60.009,37 L32.01,48.94 L4,37.02 L4,39.194 L32.011,51.113 L60.009,39.175 Z"
+                            fillRule="evenodd"
+                          />
+                        </svg>
+                      </figure>
+                      2 Projects
+                    </a>
+                  </h2>
+                  <div
+                    className="entity-list__contents-wrapper"
+                  >
+                    <div
+                      className="entity-list__search entity-list-search"
+                    >
+                      <form
+                        onSubmit={[Function]}
+                      >
+                        <div
+                          className="entity-list-search__keyword-row"
+                        >
+                          <button
+                            className="entity-list-search__search-button"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="manicon-svg manicon-magnify svg-icon--search16"
+                              fill="currentColor"
+                              height={null}
+                              viewBox="0 0 16 16"
+                              width={null}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
+                              />
+                            </svg>
+                            <span
+                              className="screen-reader-text"
+                            >
+                              Search
+                            </span>
+                          </button>
+                          <div
+                            className="entity-list-search__keyword-input-wrapper"
+                          >
+                            <label
+                              className="screen-reader-text"
+                              htmlFor="list-search-1"
+                            >
+                              Enter Search Criteria
+                            </label>
+                            <input
+                              className="entity-list-search__keyword-input"
+                              id="list-search-1"
+                              onChange={[Function]}
+                              placeholder="Search..."
+                              type="text"
+                              value=""
+                            />
+                          </div>
+                          <button
+                            className="entity-list-search__text-button"
+                            onClick={[Function]}
+                          >
+                            Reset
+                          </button>
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
+                            onClick={[Function]}
+                          >
+                            Options
+                          </button>
+                        </div>
+                      </form>
+                      <div
+                        className="ReactCollapse--collapse"
+                        style={
+                          Object {
+                            "height": 0,
+                            "overflow": "hidden",
+                          }
+                        }
+                      >
+                        <div
+                          className="ReactCollapse--content"
+                        >
+                          <div>
+                            <div
+                              className="entity-list-search__options entity-list-search__options--vertical"
+                            >
+                              <div
+                                className="entity-list-search__option entity-list-search__option--vertical"
+                              >
+                                <div
+                                  className="entity-list-search__option-inner"
+                                >
+                                  <span
+                                    className="entity-list-search__options-label "
+                                  >
+                                    Filter Results:
+                                  </span>
+                                  <div
+                                    className="entity-list-search__select-wrapper"
+                                  >
+                                    <select
+                                      id="list-search-1"
+                                      onChange={[Function]}
+                                      value=""
+                                    >
+                                      <option
+                                        value=""
+                                      >
+                                        All projects
+                                      </option>
+                                      <option
+                                        value="true"
+                                      >
+                                        Only draft projects
+                                      </option>
+                                      <option
+                                        value="false"
+                                      >
+                                        Only published projects
+                                      </option>
+                                    </select>
+                                    <svg
+                                      aria-hidden={true}
+                                      className="manicon-svg svg-icon--disclosureDown24"
+                                      fill="currentColor"
+                                      height={null}
+                                      viewBox="0 0 24 24"
+                                      width={null}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <polygon
+                                        points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                                      />
+                                    </svg>
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                className="entity-list-search__option entity-list-search__option--vertical"
+                              >
+                                <div
+                                  className="entity-list-search__option-inner"
+                                >
+                                  <span
+                                    className="entity-list-search__options-label entity-list-search__options-label--empty"
+                                  >
+                                     
+                                  </span>
+                                  <div
+                                    className="entity-list-search__select-wrapper"
+                                  >
+                                    <select
+                                      id="list-search-1"
+                                      onChange={[Function]}
+                                      value=""
+                                    >
+                                      <option
+                                        value=""
+                                      >
+                                        Created by anyone
+                                      </option>
+                                      <option
+                                        value="true"
+                                      >
+                                        Created by me
+                                      </option>
+                                    </select>
+                                    <svg
+                                      aria-hidden={true}
+                                      className="manicon-svg svg-icon--disclosureDown24"
+                                      fill="currentColor"
+                                      height={null}
+                                      viewBox="0 0 24 24"
+                                      width={null}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <polygon
+                                        points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                                      />
+                                    </svg>
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                className="entity-list-search__option entity-list-search__option--vertical"
+                              >
+                                <div
+                                  className="entity-list-search__option-inner"
+                                >
+                                  <span
+                                    className="entity-list-search__options-label"
+                                  >
+                                    Order Results:
+                                  </span>
+                                  <div
+                                    className="entity-list-search__select-wrapper"
+                                  >
+                                    <select
+                                      id="list-search-1"
+                                      onChange={[Function]}
+                                      value="updated_at DESC"
+                                    >
+                                      <option
+                                        value="updated_at ASC"
+                                      >
+                                        Most recently updated
+                                      </option>
+                                      <option
+                                        value="sort_title ASC"
+                                      >
+                                        Alphabetical by title
+                                      </option>
+                                      <option
+                                        value="created_at DESC"
+                                      >
+                                        Newest projects first
+                                      </option>
+                                      <option
+                                        value="created_at ASC"
+                                      >
+                                        Oldest projects first
+                                      </option>
+                                    </select>
+                                    <svg
+                                      aria-hidden={true}
+                                      className="manicon-svg svg-icon--disclosureDown24"
+                                      fill="currentColor"
+                                      height={null}
+                                      viewBox="0 0 24 24"
+                                      width={null}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <polygon
+                                        points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                                      />
+                                    </svg>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="entity-list__header"
+                    >
+                      <div
+                        className="entity-list__button-set"
+                      />
+                    </div>
+                    <ul
+                      className="entity-list__list entity-list__list--rows"
+                    >
+                      <li
+                        className="entity-row entity-list__entity"
+                      >
+                        <a
+                          aria-describedby="undefined1-describedby"
+                          className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
+                          href="/backend/projects/1"
+                          onClick={[Function]}
+                        >
+                          <div
+                            className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
+                          >
+                            <div
+                              className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
+                            >
+                              <svg
+                                aria-label="Default Project Thumbnail"
+                                className="project-thumb-placeholder project-thumb-placeholder--all project-thumb-placeholder--primary"
+                                height="100%"
+                                viewBox="0 0 48 48"
+                                width="100%"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                >
+                                  <polygon
+                                    className="project-thumb-placeholder__tile"
+                                    fill="#CBF7E6"
+                                    points="0 42 42 42 42 0 0 0"
+                                  />
+                                  <g
+                                    className="project-thumb-placeholder__illustration"
+                                    transform="translate(9 8)"
+                                  >
+                                    <g
+                                      transform="translate(20.683 2.244)"
+                                    >
+                                      <polygon
+                                        points=".161 2.954 .161 21.013 1.612 23.598 3.06 21.013 3.06 2.954"
+                                      />
+                                      <path
+                                        d="M3.06081501,21.012797 L0.161633021,21.012797"
+                                      />
+                                      <path
+                                        d="M0.162011257,2.95560225 L3.06119325,2.95560225 L3.06119325,1.53299812 C3.06119325,0.980713374 2.613478,0.532998124 2.06119325,0.532998124 L1.16201126,0.532998124 C0.609726507,0.532998124 0.162011257,0.980713374 0.162011257,1.53299812 L0.162011257,2.95560225 Z"
+                                        strokeLinejoin="round"
+                                      />
+                                    </g>
+                                    <g
+                                      transform="translate(.195 11.463)"
+                                    >
+                                      <polygon
+                                        points="14.898 .419 .985 .419 .985 11.282 8.141 11.282 8.141 14.378 10.844 11.282 14.898 11.282"
+                                      />
+                                      <path
+                                        d="M12.5237854 3.46905816L3.32696735 3.46905816M12.5237854 8.00165403L3.32696735 8.00165403M12.5237854 5.73507242L3.32696735 5.73507242"
+                                      />
+                                    </g>
+                                    <g
+                                      transform="translate(.195 .195)"
+                                    >
+                                      <path
+                                        d="M11.8853223 5.12585966C11.8853223 6.3608015 10.8848871 7.36123677 9.64994522 7.36123677 8.41689456 7.36123677 7.41645929 6.3608015 7.41645929 5.12585966 7.41645929 3.89091782 8.41689456 2.89048255 9.64994522 2.89048255 10.8848871 2.89048255 11.8853223 3.89091782 11.8853223 5.12585966zM11.8853223 5.23573734L15.0417051 2.0793546C15.6109508 1.51010882 16.5849096 1.91293058 16.5849096 2.71857411M3.99814784 3.09718874L6.63067317.464663415C7.20181013-.106473546 8.17576886.2982394 8.17576886 1.10388293"
+                                      />
+                                      <path
+                                        d="M5.22155347 5.12585966C5.22155347 6.3608015 4.2211182 7.36123677 2.98617636 7.36123677 1.7531257 7.36123677.752690432 6.3608015.752690432 5.12585966.752690432 3.89091782 1.7531257 2.89048255 2.98617636 2.89048255 4.2211182 2.89048255 5.22155347 3.89091782 5.22155347 5.12585966zM5.22155347 5.34334559L5.71136961 5.13720675C6.09906191 4.97267392 6.53781614 4.97267392 6.92739962 5.13720675L7.41532458 5.34334559"
+                                      />
+                                    </g>
+                                  </g>
+                                  <g
+                                    className="project-thumb-placeholder__frame"
+                                    stroke="#828282"
+                                  >
+                                    <polyline
+                                      points="48 6 48 48 6 48"
+                                    />
+                                    <polyline
+                                      points="45 3 45 45 3 45"
+                                    />
+                                    <polygon
+                                      points="0 42 42 42 42 0 0 0"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                            </div>
+                            <div
+                              className="entity-row__text entity-row__text--in-rows"
+                            >
+                              <h3
+                                className="entity-row__title entity-row__title--in-rows"
+                              >
+                                <span
+                                  className="entity-row__title-inner"
+                                >
+                                  <span
+                                    dangerouslySetInnerHTML={
+                                      Object {
+                                        "__html": "Rowan Test",
+                                      }
+                                    }
+                                  />
+                                </span>
+                                <span
+                                  className="aria-describedby"
+                                  id="undefined1-describedby"
+                                >
+                                  View Rowan Test
+                                </span>
+                              </h3>
+                              <h4
+                                className="entity-row__subtitle entity-row__subtitle--in-rows"
+                              >
+                                World's Greatest Dog
+                              </h4>
+                              <div
+                                className="entity-row__meta entity-row__meta--in-rows"
+                              />
+                            </div>
+                          </div>
+                        </a>
+                      </li>
+                      <li
+                        className="entity-row entity-list__entity"
+                      >
+                        <a
+                          aria-describedby="undefined1-describedby"
+                          className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
+                          href="/backend/projects/2"
+                          onClick={[Function]}
+                        >
+                          <div
+                            className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
+                          >
+                            <div
+                              className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
+                            >
+                              <svg
+                                aria-label="Default Project Thumbnail"
+                                className="project-thumb-placeholder project-thumb-placeholder--all project-thumb-placeholder--primary"
+                                height="100%"
+                                viewBox="0 0 48 48"
+                                width="100%"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                >
+                                  <polygon
+                                    className="project-thumb-placeholder__tile"
+                                    fill="#CBF7E6"
+                                    points="0 42 42 42 42 0 0 0"
+                                  />
+                                  <g
+                                    className="project-thumb-placeholder__illustration"
+                                    transform="translate(9 8)"
+                                  >
+                                    <g
+                                      transform="translate(20.683 2.244)"
+                                    >
+                                      <polygon
+                                        points=".161 2.954 .161 21.013 1.612 23.598 3.06 21.013 3.06 2.954"
+                                      />
+                                      <path
+                                        d="M3.06081501,21.012797 L0.161633021,21.012797"
+                                      />
+                                      <path
+                                        d="M0.162011257,2.95560225 L3.06119325,2.95560225 L3.06119325,1.53299812 C3.06119325,0.980713374 2.613478,0.532998124 2.06119325,0.532998124 L1.16201126,0.532998124 C0.609726507,0.532998124 0.162011257,0.980713374 0.162011257,1.53299812 L0.162011257,2.95560225 Z"
+                                        strokeLinejoin="round"
+                                      />
+                                    </g>
+                                    <g
+                                      transform="translate(.195 11.463)"
+                                    >
+                                      <polygon
+                                        points="14.898 .419 .985 .419 .985 11.282 8.141 11.282 8.141 14.378 10.844 11.282 14.898 11.282"
+                                      />
+                                      <path
+                                        d="M12.5237854 3.46905816L3.32696735 3.46905816M12.5237854 8.00165403L3.32696735 8.00165403M12.5237854 5.73507242L3.32696735 5.73507242"
+                                      />
+                                    </g>
+                                    <g
+                                      transform="translate(.195 .195)"
+                                    >
+                                      <path
+                                        d="M11.8853223 5.12585966C11.8853223 6.3608015 10.8848871 7.36123677 9.64994522 7.36123677 8.41689456 7.36123677 7.41645929 6.3608015 7.41645929 5.12585966 7.41645929 3.89091782 8.41689456 2.89048255 9.64994522 2.89048255 10.8848871 2.89048255 11.8853223 3.89091782 11.8853223 5.12585966zM11.8853223 5.23573734L15.0417051 2.0793546C15.6109508 1.51010882 16.5849096 1.91293058 16.5849096 2.71857411M3.99814784 3.09718874L6.63067317.464663415C7.20181013-.106473546 8.17576886.2982394 8.17576886 1.10388293"
+                                      />
+                                      <path
+                                        d="M5.22155347 5.12585966C5.22155347 6.3608015 4.2211182 7.36123677 2.98617636 7.36123677 1.7531257 7.36123677.752690432 6.3608015.752690432 5.12585966.752690432 3.89091782 1.7531257 2.89048255 2.98617636 2.89048255 4.2211182 2.89048255 5.22155347 3.89091782 5.22155347 5.12585966zM5.22155347 5.34334559L5.71136961 5.13720675C6.09906191 4.97267392 6.53781614 4.97267392 6.92739962 5.13720675L7.41532458 5.34334559"
+                                      />
+                                    </g>
+                                  </g>
+                                  <g
+                                    className="project-thumb-placeholder__frame"
+                                    stroke="#828282"
+                                  >
+                                    <polyline
+                                      points="48 6 48 48 6 48"
+                                    />
+                                    <polyline
+                                      points="45 3 45 45 3 45"
+                                    />
+                                    <polygon
+                                      points="0 42 42 42 42 0 0 0"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                            </div>
+                            <div
+                              className="entity-row__text entity-row__text--in-rows"
+                            >
+                              <h3
+                                className="entity-row__title entity-row__title--in-rows"
+                              >
+                                <span
+                                  className="entity-row__title-inner"
+                                >
+                                  <span
+                                    dangerouslySetInnerHTML={
+                                      Object {
+                                        "__html": "Rowan Test",
+                                      }
+                                    }
+                                  />
+                                </span>
+                                <span
+                                  className="aria-describedby"
+                                  id="undefined1-describedby"
+                                >
+                                  View Rowan Test
+                                </span>
+                              </h3>
+                              <h4
+                                className="entity-row__subtitle entity-row__subtitle--in-rows"
+                              >
+                                World's Greatest Dog
+                              </h4>
+                              <div
+                                className="entity-row__meta entity-row__meta--in-rows"
+                              />
+                            </div>
+                          </div>
+                        </a>
+                      </li>
+                    </ul>
+                    <div
+                      className="entity-list__pagination"
+                    >
+                      <nav
+                        aria-label="Pagination"
+                        className="list-pagination"
+                      >
+                        <ul
+                          className="list-pagination__columns"
+                        >
+                          <li
+                            className="list-pagination__column"
+                          >
+                            <ul>
+                              <li
+                                className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
+                              >
+                                <a
+                                  disabled={true}
+                                  href="#entities-list1"
+                                  onClick={[Function]}
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="manicon-svg svg-icon--arrowLongLeft16"
+                                    fill="currentColor"
+                                    height={null}
+                                    viewBox="0 0 24 16"
+                                    width={null}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                                      transform="rotate(180 12 8)"
+                                    />
+                                  </svg>
+                                  <span
+                                    className="list-pagination__icon-label"
+                                  >
+                                    PREV
+                                  </span>
+                                </a>
+                              </li>
+                            </ul>
+                          </li>
+                          <li
+                            className="list-pagination__column-middle"
+                          >
+                            <ul
+                              className="list-pagination__pages"
+                            >
+                              <li
+                                className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
+                              >
+                                <a
+                                  href="#entities-list1"
+                                  onClick={[Function]}
+                                >
+                                  <span
+                                    aria-hidden="true"
+                                  >
+                                    1
+                                  </span>
+                                  <span
+                                    className="screen-reader-text"
+                                  >
+                                    Go to page: 
+                                    1
+                                  </span>
+                                </a>
+                              </li>
+                              <li
+                                className="list-pagination__page list-pagination__page--ordinal"
+                              >
+                                <a
+                                  href="#entities-list1"
+                                  onClick={[Function]}
+                                >
+                                  <span
+                                    aria-hidden="true"
+                                  >
+                                    2
+                                  </span>
+                                  <span
+                                    className="screen-reader-text"
+                                  >
+                                    Go to page: 
+                                    2
+                                  </span>
+                                </a>
+                              </li>
+                            </ul>
+                          </li>
+                          <li
+                            className="list-pagination__column"
+                          >
+                            <ul>
+                              <li
+                                className="list-pagination__page list-pagination__page--next"
+                              >
+                                <a
+                                  href="#entities-list1"
+                                  onClick={[Function]}
+                                >
+                                  <span
+                                    className="list-pagination__icon-label"
+                                  >
+                                    NEXT
+                                  </span>
+                                  <svg
+                                    aria-hidden={true}
+                                    className="manicon-svg svg-icon--arrowLongRight16"
+                                    fill="currentColor"
+                                    height={null}
+                                    viewBox="0 0 24 16"
+                                    width={null}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                                    />
+                                  </svg>
+                                </a>
+                              </li>
+                            </ul>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="right"
+          >
+            <div
+              className="dashboard-panel"
+            >
+              <div
+                className="panel"
+              >
+                <div
+                  className="entity-list"
+                  id="entities-list1"
+                >
+                  <h2
+                    className="entity-list__title-block entity-list__title"
                   >
                     <figure
                       className="entity-list__title-icon"
@@ -52,781 +734,112 @@ exports[`Backend Dashboards Admin Container renders correctly 1`] = `
                         />
                       </svg>
                     </figure>
-                    2 Projects
-                  </a>
-                </h2>
-                <div
-                  className="entity-list__contents-wrapper"
-                >
+                    Recently Updated
+                  </h2>
                   <div
-                    className="entity-list__search entity-list-search"
-                  >
-                    <form
-                      onSubmit={[Function]}
-                    >
-                      <div
-                        className="entity-list-search__keyword-row"
-                      >
-                        <button
-                          className="entity-list-search__search-button"
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="manicon-svg manicon-magnify svg-icon--search16"
-                            fill="currentColor"
-                            height={null}
-                            viewBox="0 0 16 16"
-                            width={null}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
-                            />
-                          </svg>
-                          <span
-                            className="screen-reader-text"
-                          >
-                            Search
-                          </span>
-                        </button>
-                        <div
-                          className="entity-list-search__keyword-input-wrapper"
-                        >
-                          <label
-                            className="screen-reader-text"
-                            htmlFor="list-search-1"
-                          >
-                            Enter Search Criteria
-                          </label>
-                          <input
-                            className="entity-list-search__keyword-input"
-                            id="list-search-1"
-                            onChange={[Function]}
-                            placeholder="Search..."
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                        <button
-                          className="entity-list-search__text-button"
-                          onClick={[Function]}
-                        >
-                          Reset
-                        </button>
-                        <button
-                          className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
-                          onClick={[Function]}
-                        >
-                          Options
-                        </button>
-                      </div>
-                    </form>
-                    <div
-                      className="ReactCollapse--collapse"
-                      style={
-                        Object {
-                          "height": 0,
-                          "overflow": "hidden",
-                        }
-                      }
-                    >
-                      <div
-                        className="ReactCollapse--content"
-                      >
-                        <div>
-                          <div
-                            className="entity-list-search__options entity-list-search__options--vertical"
-                          >
-                            <div
-                              className="entity-list-search__option entity-list-search__option--vertical"
-                            >
-                              <div
-                                className="entity-list-search__option-inner"
-                              >
-                                <span
-                                  className="entity-list-search__options-label "
-                                >
-                                  Filter Results:
-                                </span>
-                                <div
-                                  className="entity-list-search__select-wrapper"
-                                >
-                                  <select
-                                    id="list-search-1"
-                                    onChange={[Function]}
-                                    value=""
-                                  >
-                                    <option
-                                      value=""
-                                    >
-                                      All projects
-                                    </option>
-                                    <option
-                                      value="true"
-                                    >
-                                      Only draft projects
-                                    </option>
-                                    <option
-                                      value="false"
-                                    >
-                                      Only published projects
-                                    </option>
-                                  </select>
-                                  <svg
-                                    aria-hidden={true}
-                                    className="manicon-svg svg-icon--disclosureDown24"
-                                    fill="currentColor"
-                                    height={null}
-                                    viewBox="0 0 24 24"
-                                    width={null}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <polygon
-                                      points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
-                                    />
-                                  </svg>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              className="entity-list-search__option entity-list-search__option--vertical"
-                            >
-                              <div
-                                className="entity-list-search__option-inner"
-                              >
-                                <span
-                                  className="entity-list-search__options-label entity-list-search__options-label--empty"
-                                >
-                                   
-                                </span>
-                                <div
-                                  className="entity-list-search__select-wrapper"
-                                >
-                                  <select
-                                    id="list-search-1"
-                                    onChange={[Function]}
-                                    value=""
-                                  >
-                                    <option
-                                      value=""
-                                    >
-                                      Created by anyone
-                                    </option>
-                                    <option
-                                      value="true"
-                                    >
-                                      Created by me
-                                    </option>
-                                  </select>
-                                  <svg
-                                    aria-hidden={true}
-                                    className="manicon-svg svg-icon--disclosureDown24"
-                                    fill="currentColor"
-                                    height={null}
-                                    viewBox="0 0 24 24"
-                                    width={null}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <polygon
-                                      points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
-                                    />
-                                  </svg>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              className="entity-list-search__option entity-list-search__option--vertical"
-                            >
-                              <div
-                                className="entity-list-search__option-inner"
-                              >
-                                <span
-                                  className="entity-list-search__options-label"
-                                >
-                                  Order Results:
-                                </span>
-                                <div
-                                  className="entity-list-search__select-wrapper"
-                                >
-                                  <select
-                                    id="list-search-1"
-                                    onChange={[Function]}
-                                    value="updated_at DESC"
-                                  >
-                                    <option
-                                      value="updated_at ASC"
-                                    >
-                                      Most recently updated
-                                    </option>
-                                    <option
-                                      value="sort_title ASC"
-                                    >
-                                      Alphabetical by title
-                                    </option>
-                                    <option
-                                      value="created_at DESC"
-                                    >
-                                      Newest projects first
-                                    </option>
-                                    <option
-                                      value="created_at ASC"
-                                    >
-                                      Oldest projects first
-                                    </option>
-                                  </select>
-                                  <svg
-                                    aria-hidden={true}
-                                    className="manicon-svg svg-icon--disclosureDown24"
-                                    fill="currentColor"
-                                    height={null}
-                                    viewBox="0 0 24 24"
-                                    width={null}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <polygon
-                                      points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
-                                    />
-                                  </svg>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="entity-list__header"
+                    className="entity-list__contents-wrapper"
                   >
                     <div
-                      className="entity-list__button-set"
+                      className="entity-list__header"
                     />
-                  </div>
-                  <ul
-                    className="entity-list__list entity-list__list--rows"
-                  >
-                    <li
-                      className="entity-row entity-list__entity"
+                    <ul
+                      className="entity-list__list entity-list__list--rows"
                     >
-                      <a
-                        aria-describedby="undefined1-describedby"
-                        className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
-                        href="/backend/projects/1"
-                        onClick={[Function]}
+                      <li
+                        className="entity-row entity-list__entity"
                       >
-                        <div
-                          className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
+                        <a
+                          aria-describedby="undefined1-describedby"
+                          className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
+                          href="/backend/projects/3"
+                          onClick={[Function]}
                         >
                           <div
-                            className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
+                            className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
                           >
-                            <svg
-                              aria-label="Default Project Thumbnail"
-                              className="project-thumb-placeholder project-thumb-placeholder--all project-thumb-placeholder--primary"
-                              height="100%"
-                              viewBox="0 0 48 48"
-                              width="100%"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <polygon
-                                  className="project-thumb-placeholder__tile"
-                                  fill="#CBF7E6"
-                                  points="0 42 42 42 42 0 0 0"
-                                />
-                                <g
-                                  className="project-thumb-placeholder__illustration"
-                                  transform="translate(9 8)"
-                                >
-                                  <g
-                                    transform="translate(20.683 2.244)"
-                                  >
-                                    <polygon
-                                      points=".161 2.954 .161 21.013 1.612 23.598 3.06 21.013 3.06 2.954"
-                                    />
-                                    <path
-                                      d="M3.06081501,21.012797 L0.161633021,21.012797"
-                                    />
-                                    <path
-                                      d="M0.162011257,2.95560225 L3.06119325,2.95560225 L3.06119325,1.53299812 C3.06119325,0.980713374 2.613478,0.532998124 2.06119325,0.532998124 L1.16201126,0.532998124 C0.609726507,0.532998124 0.162011257,0.980713374 0.162011257,1.53299812 L0.162011257,2.95560225 Z"
-                                      strokeLinejoin="round"
-                                    />
-                                  </g>
-                                  <g
-                                    transform="translate(.195 11.463)"
-                                  >
-                                    <polygon
-                                      points="14.898 .419 .985 .419 .985 11.282 8.141 11.282 8.141 14.378 10.844 11.282 14.898 11.282"
-                                    />
-                                    <path
-                                      d="M12.5237854 3.46905816L3.32696735 3.46905816M12.5237854 8.00165403L3.32696735 8.00165403M12.5237854 5.73507242L3.32696735 5.73507242"
-                                    />
-                                  </g>
-                                  <g
-                                    transform="translate(.195 .195)"
-                                  >
-                                    <path
-                                      d="M11.8853223 5.12585966C11.8853223 6.3608015 10.8848871 7.36123677 9.64994522 7.36123677 8.41689456 7.36123677 7.41645929 6.3608015 7.41645929 5.12585966 7.41645929 3.89091782 8.41689456 2.89048255 9.64994522 2.89048255 10.8848871 2.89048255 11.8853223 3.89091782 11.8853223 5.12585966zM11.8853223 5.23573734L15.0417051 2.0793546C15.6109508 1.51010882 16.5849096 1.91293058 16.5849096 2.71857411M3.99814784 3.09718874L6.63067317.464663415C7.20181013-.106473546 8.17576886.2982394 8.17576886 1.10388293"
-                                    />
-                                    <path
-                                      d="M5.22155347 5.12585966C5.22155347 6.3608015 4.2211182 7.36123677 2.98617636 7.36123677 1.7531257 7.36123677.752690432 6.3608015.752690432 5.12585966.752690432 3.89091782 1.7531257 2.89048255 2.98617636 2.89048255 4.2211182 2.89048255 5.22155347 3.89091782 5.22155347 5.12585966zM5.22155347 5.34334559L5.71136961 5.13720675C6.09906191 4.97267392 6.53781614 4.97267392 6.92739962 5.13720675L7.41532458 5.34334559"
-                                    />
-                                  </g>
-                                </g>
-                                <g
-                                  className="project-thumb-placeholder__frame"
-                                  stroke="#828282"
-                                >
-                                  <polyline
-                                    points="48 6 48 48 6 48"
-                                  />
-                                  <polyline
-                                    points="45 3 45 45 3 45"
-                                  />
-                                  <polygon
-                                    points="0 42 42 42 42 0 0 0"
-                                  />
-                                </g>
-                              </g>
-                            </svg>
-                          </div>
-                          <div
-                            className="entity-row__text entity-row__text--in-rows"
-                          >
-                            <h3
-                              className="entity-row__title entity-row__title--in-rows"
-                            >
-                              <span
-                                className="entity-row__title-inner"
-                              >
-                                <span
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "Rowan Test",
-                                    }
-                                  }
-                                />
-                              </span>
-                              <span
-                                className="aria-describedby"
-                                id="undefined1-describedby"
-                              >
-                                View Rowan Test
-                              </span>
-                            </h3>
-                            <h4
-                              className="entity-row__subtitle entity-row__subtitle--in-rows"
-                            >
-                              World's Greatest Dog
-                            </h4>
                             <div
-                              className="entity-row__meta entity-row__meta--in-rows"
-                            />
-                          </div>
-                        </div>
-                      </a>
-                    </li>
-                    <li
-                      className="entity-row entity-list__entity"
-                    >
-                      <a
-                        aria-describedby="undefined1-describedby"
-                        className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
-                        href="/backend/projects/2"
-                        onClick={[Function]}
-                      >
-                        <div
-                          className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
-                        >
-                          <div
-                            className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
-                          >
-                            <svg
-                              aria-label="Default Project Thumbnail"
-                              className="project-thumb-placeholder project-thumb-placeholder--all project-thumb-placeholder--primary"
-                              height="100%"
-                              viewBox="0 0 48 48"
-                              width="100%"
-                              xmlns="http://www.w3.org/2000/svg"
+                              className="entity-row__text entity-row__text--in-rows"
                             >
-                              <g
-                                fill="none"
-                                fillRule="evenodd"
-                              >
-                                <polygon
-                                  className="project-thumb-placeholder__tile"
-                                  fill="#CBF7E6"
-                                  points="0 42 42 42 42 0 0 0"
-                                />
-                                <g
-                                  className="project-thumb-placeholder__illustration"
-                                  transform="translate(9 8)"
-                                >
-                                  <g
-                                    transform="translate(20.683 2.244)"
-                                  >
-                                    <polygon
-                                      points=".161 2.954 .161 21.013 1.612 23.598 3.06 21.013 3.06 2.954"
-                                    />
-                                    <path
-                                      d="M3.06081501,21.012797 L0.161633021,21.012797"
-                                    />
-                                    <path
-                                      d="M0.162011257,2.95560225 L3.06119325,2.95560225 L3.06119325,1.53299812 C3.06119325,0.980713374 2.613478,0.532998124 2.06119325,0.532998124 L1.16201126,0.532998124 C0.609726507,0.532998124 0.162011257,0.980713374 0.162011257,1.53299812 L0.162011257,2.95560225 Z"
-                                      strokeLinejoin="round"
-                                    />
-                                  </g>
-                                  <g
-                                    transform="translate(.195 11.463)"
-                                  >
-                                    <polygon
-                                      points="14.898 .419 .985 .419 .985 11.282 8.141 11.282 8.141 14.378 10.844 11.282 14.898 11.282"
-                                    />
-                                    <path
-                                      d="M12.5237854 3.46905816L3.32696735 3.46905816M12.5237854 8.00165403L3.32696735 8.00165403M12.5237854 5.73507242L3.32696735 5.73507242"
-                                    />
-                                  </g>
-                                  <g
-                                    transform="translate(.195 .195)"
-                                  >
-                                    <path
-                                      d="M11.8853223 5.12585966C11.8853223 6.3608015 10.8848871 7.36123677 9.64994522 7.36123677 8.41689456 7.36123677 7.41645929 6.3608015 7.41645929 5.12585966 7.41645929 3.89091782 8.41689456 2.89048255 9.64994522 2.89048255 10.8848871 2.89048255 11.8853223 3.89091782 11.8853223 5.12585966zM11.8853223 5.23573734L15.0417051 2.0793546C15.6109508 1.51010882 16.5849096 1.91293058 16.5849096 2.71857411M3.99814784 3.09718874L6.63067317.464663415C7.20181013-.106473546 8.17576886.2982394 8.17576886 1.10388293"
-                                    />
-                                    <path
-                                      d="M5.22155347 5.12585966C5.22155347 6.3608015 4.2211182 7.36123677 2.98617636 7.36123677 1.7531257 7.36123677.752690432 6.3608015.752690432 5.12585966.752690432 3.89091782 1.7531257 2.89048255 2.98617636 2.89048255 4.2211182 2.89048255 5.22155347 3.89091782 5.22155347 5.12585966zM5.22155347 5.34334559L5.71136961 5.13720675C6.09906191 4.97267392 6.53781614 4.97267392 6.92739962 5.13720675L7.41532458 5.34334559"
-                                    />
-                                  </g>
-                                </g>
-                                <g
-                                  className="project-thumb-placeholder__frame"
-                                  stroke="#828282"
-                                >
-                                  <polyline
-                                    points="48 6 48 48 6 48"
-                                  />
-                                  <polyline
-                                    points="45 3 45 45 3 45"
-                                  />
-                                  <polygon
-                                    points="0 42 42 42 42 0 0 0"
-                                  />
-                                </g>
-                              </g>
-                            </svg>
-                          </div>
-                          <div
-                            className="entity-row__text entity-row__text--in-rows"
-                          >
-                            <h3
-                              className="entity-row__title entity-row__title--in-rows"
-                            >
-                              <span
-                                className="entity-row__title-inner"
+                              <h3
+                                className="entity-row__title entity-row__title--in-rows"
                               >
                                 <span
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "Rowan Test",
+                                  className="entity-row__title-inner"
+                                >
+                                  <span
+                                    dangerouslySetInnerHTML={
+                                      Object {
+                                        "__html": "Rowan Test",
+                                      }
                                     }
-                                  }
-                                />
-                              </span>
-                              <span
-                                className="aria-describedby"
-                                id="undefined1-describedby"
-                              >
-                                View Rowan Test
-                              </span>
-                            </h3>
-                            <h4
-                              className="entity-row__subtitle entity-row__subtitle--in-rows"
-                            >
-                              World's Greatest Dog
-                            </h4>
-                            <div
-                              className="entity-row__meta entity-row__meta--in-rows"
-                            />
+                                  />
+                                </span>
+                                <span
+                                  className="aria-describedby"
+                                  id="undefined1-describedby"
+                                >
+                                  View Rowan Test
+                                </span>
+                              </h3>
+                              <div
+                                className="entity-row__meta entity-row__meta--in-rows"
+                              />
+                            </div>
                           </div>
-                        </div>
-                      </a>
-                    </li>
-                  </ul>
-                  <div
-                    className="entity-list__pagination"
-                  >
-                    <nav
-                      aria-label="Pagination"
-                      className="list-pagination"
-                    >
-                      <ul
-                        className="list-pagination__columns"
+                        </a>
+                      </li>
+                      <li
+                        className="entity-row entity-list__entity"
                       >
-                        <li
-                          className="list-pagination__column"
+                        <a
+                          aria-describedby="undefined1-describedby"
+                          className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
+                          href="/backend/projects/4"
+                          onClick={[Function]}
                         >
-                          <ul>
-                            <li
-                              className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
-                            >
-                              <a
-                                disabled={true}
-                                href="#entities-list1"
-                                onClick={[Function]}
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  className="manicon-svg svg-icon--arrowLongLeft16"
-                                  fill="currentColor"
-                                  height={null}
-                                  viewBox="0 0 24 16"
-                                  width={null}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                                    transform="rotate(180 12 8)"
-                                  />
-                                </svg>
-                                <span
-                                  className="list-pagination__icon-label"
-                                >
-                                  PREV
-                                </span>
-                              </a>
-                            </li>
-                          </ul>
-                        </li>
-                        <li
-                          className="list-pagination__column-middle"
-                        >
-                          <ul
-                            className="list-pagination__pages"
+                          <div
+                            className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
                           >
-                            <li
-                              className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
+                            <div
+                              className="entity-row__text entity-row__text--in-rows"
                             >
-                              <a
-                                href="#entities-list1"
-                                onClick={[Function]}
+                              <h3
+                                className="entity-row__title entity-row__title--in-rows"
                               >
                                 <span
-                                  aria-hidden="true"
+                                  className="entity-row__title-inner"
                                 >
-                                  1
-                                </span>
-                                <span
-                                  className="screen-reader-text"
-                                >
-                                  Go to page: 
-                                  1
-                                </span>
-                              </a>
-                            </li>
-                            <li
-                              className="list-pagination__page list-pagination__page--ordinal"
-                            >
-                              <a
-                                href="#entities-list1"
-                                onClick={[Function]}
-                              >
-                                <span
-                                  aria-hidden="true"
-                                >
-                                  2
-                                </span>
-                                <span
-                                  className="screen-reader-text"
-                                >
-                                  Go to page: 
-                                  2
-                                </span>
-                              </a>
-                            </li>
-                          </ul>
-                        </li>
-                        <li
-                          className="list-pagination__column"
-                        >
-                          <ul>
-                            <li
-                              className="list-pagination__page list-pagination__page--next"
-                            >
-                              <a
-                                href="#entities-list1"
-                                onClick={[Function]}
-                              >
-                                <span
-                                  className="list-pagination__icon-label"
-                                >
-                                  NEXT
-                                </span>
-                                <svg
-                                  aria-hidden={true}
-                                  className="manicon-svg svg-icon--arrowLongRight16"
-                                  fill="currentColor"
-                                  height={null}
-                                  viewBox="0 0 24 16"
-                                  width={null}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                                  <span
+                                    dangerouslySetInnerHTML={
+                                      Object {
+                                        "__html": "Rowan Test",
+                                      }
+                                    }
                                   />
-                                </svg>
-                              </a>
-                            </li>
-                          </ul>
-                        </li>
-                      </ul>
-                    </nav>
+                                </span>
+                                <span
+                                  className="aria-describedby"
+                                  id="undefined1-describedby"
+                                >
+                                  View Rowan Test
+                                </span>
+                              </h3>
+                              <div
+                                className="entity-row__meta entity-row__meta--in-rows"
+                              />
+                            </div>
+                          </div>
+                        </a>
+                      </li>
+                    </ul>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="right"
-        >
-          <div
-            className="dashboard-panel"
-          >
-            <div
-              className="panel"
-            >
-              <div
-                className="entity-list"
-                id="entities-list1"
-              >
-                <h2
-                  className="entity-list__title-block entity-list__title"
-                >
-                  <figure
-                    className="entity-list__title-icon"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--BEProject64"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 64 64"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M9.103,24.948 L32.045,34.722 L54.984,24.948 L32.045,15.174 L9.103,24.948 Z M32.045,36.896 L4,24.948 L32.045,13 L60.086,24.948 L32.045,36.896 Z M60.009,32.175 L60.009,30 L32.01,41.94 L4,30.021 L4,32.194 L32.011,44.113 L60.009,32.175 Z M60.009,39.175 L60.009,37 L32.01,48.94 L4,37.02 L4,39.194 L32.011,51.113 L60.009,39.175 Z"
-                        fillRule="evenodd"
-                      />
-                    </svg>
-                  </figure>
-                  Recently Updated
-                </h2>
-                <div
-                  className="entity-list__contents-wrapper"
-                >
-                  <div
-                    className="entity-list__header"
-                  />
-                  <ul
-                    className="entity-list__list entity-list__list--rows"
-                  >
-                    <li
-                      className="entity-row entity-list__entity"
-                    >
-                      <a
-                        aria-describedby="undefined1-describedby"
-                        className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
-                        href="/backend/projects/3"
-                        onClick={[Function]}
-                      >
-                        <div
-                          className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
-                        >
-                          <div
-                            className="entity-row__text entity-row__text--in-rows"
-                          >
-                            <h3
-                              className="entity-row__title entity-row__title--in-rows"
-                            >
-                              <span
-                                className="entity-row__title-inner"
-                              >
-                                <span
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "Rowan Test",
-                                    }
-                                  }
-                                />
-                              </span>
-                              <span
-                                className="aria-describedby"
-                                id="undefined1-describedby"
-                              >
-                                View Rowan Test
-                              </span>
-                            </h3>
-                            <div
-                              className="entity-row__meta entity-row__meta--in-rows"
-                            />
-                          </div>
-                        </div>
-                      </a>
-                    </li>
-                    <li
-                      className="entity-row entity-list__entity"
-                    >
-                      <a
-                        aria-describedby="undefined1-describedby"
-                        className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
-                        href="/backend/projects/4"
-                        onClick={[Function]}
-                      >
-                        <div
-                          className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
-                        >
-                          <div
-                            className="entity-row__text entity-row__text--in-rows"
-                          >
-                            <h3
-                              className="entity-row__title entity-row__title--in-rows"
-                            >
-                              <span
-                                className="entity-row__title-inner"
-                              >
-                                <span
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "Rowan Test",
-                                    }
-                                  }
-                                />
-                              </span>
-                              <span
-                                className="aria-describedby"
-                                id="undefined1-describedby"
-                              >
-                                View Rowan Test
-                              </span>
-                            </h3>
-                            <div
-                              className="entity-row__meta entity-row__meta--in-rows"
-                            />
-                          </div>
-                        </div>
-                      </a>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-    </div>
-  </section>
-</div>
+        </section>
+      </div>
+    </section>
+  </div>,
+]
 `;

--- a/client/src/backend/containers/makers/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/containers/makers/__tests__/__snapshots__/List-test.js.snap
@@ -2,6 +2,12 @@
 
 exports[`Backend People Makers List Container renders correctly 1`] = `
 Array [
+  <div
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
   <span />,
   <div
     className="entity-list"
@@ -87,6 +93,8 @@ Array [
               Reset
             </button>
             <button
+              aria-expanded={false}
+              aria-haspopup={true}
               className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
               onClick={[Function]}
             >
@@ -171,6 +179,7 @@ Array [
           className="entity-list__count"
         >
           <p
+            aria-hidden={true}
             className="list-total"
           >
             Showing 
@@ -183,6 +192,14 @@ Array [
             </span>
              makers: 
           </p>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          >
+            2 makers. Showing results 1 through 1.
+          </div>
         </div>
       </div>
       <ul

--- a/client/src/backend/containers/project-collection/ManageProjects.js
+++ b/client/src/backend/containers/project-collection/ManageProjects.js
@@ -166,10 +166,21 @@ class ProjectCollectionManageProjectsImplementation extends PureComponent {
     const total = projectsMeta.pagination.totalCount || 0;
 
     return (
-      <p className="list-total">
-        You have added <span>{added}</span> of <span>{total}</span> available
-        projects
-      </p>
+      <React.Fragment>
+        <p className="list-total" aria-hidden>
+          You have added <span>{added}</span> of <span>{total}</span> available
+          projects
+        </p>
+        {/* Better readout for screen readers */}
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic
+          className="screen-reader-text"
+        >
+          {`You have added ${added} of ${total} available projects.`}
+        </div>
+      </React.Fragment>
     );
   }
 

--- a/client/src/backend/containers/project-collection/__tests__/__snapshots__/ManageProjects-test.js.snap
+++ b/client/src/backend/containers/project-collection/__tests__/__snapshots__/ManageProjects-test.js.snap
@@ -2,6 +2,12 @@
 
 exports[`Backend.ProjectCollection.ManageProjects container renders correctly 1`] = `
 Array [
+  <div
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
   <header
     className="drawer-header"
   >
@@ -96,6 +102,8 @@ Array [
               Reset
             </button>
             <button
+              aria-expanded={false}
+              aria-haspopup={true}
               className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
               onClick={[Function]}
             >
@@ -284,6 +292,7 @@ Array [
           className="entity-list__count"
         >
           <p
+            aria-hidden={true}
             className="list-total"
           >
             You have added 
@@ -296,6 +305,14 @@ Array [
             </span>
              available projects
           </p>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          >
+            You have added 0 of 2 available projects.
+          </div>
         </div>
       </div>
       <ul

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Collections-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Collections-test.js.snap
@@ -3,6 +3,12 @@
 exports[`Backend Project Collections Container renders correctly 1`] = `
 <section>
   <div
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />
+  <div
     className="entity-list"
     id="entities-list1"
   >
@@ -87,6 +93,8 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
               Reset
             </button>
             <button
+              aria-expanded={false}
+              aria-haspopup={true}
               className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
               onClick={[Function]}
             >
@@ -329,6 +337,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
           className="entity-list__count"
         >
           <p
+            aria-hidden={true}
             className="list-total"
           >
             Showing 
@@ -341,6 +350,14 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
             </span>
              resources: 
           </p>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          >
+            2 resources. Showing results 1 through 1.
+          </div>
         </div>
       </div>
       <div

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Events-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Events-test.js.snap
@@ -1,178 +1,188 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Backend Project Events Container renders correctly 1`] = `
-<section>
+Array [
   <div
-    className="entity-list"
-    id="entities-list1"
-  >
-    <h2
-      className="entity-list__title-block entity-list__title"
-    >
-      <figure
-        className="entity-list__title-icon"
-      >
-        <svg
-          aria-hidden={true}
-          className="manicon-svg svg-icon--BENews64"
-          fill="currentColor"
-          height={null}
-          viewBox="0 0 64 64"
-          width={null}
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M39.2643465,35.96065 C39.2643465,32.7727533 36.686535,30.1850285 33.5025,30.1728 L19.8809382,30.1727926 C16.693065,30.1850285 14.1152535,32.7727533 14.1152535,35.96065 C14.1152535,39.1485467 16.693065,41.7362715 19.8771,41.7485 L33.500506,41.7485 C36.6875291,41.7352734 39.2643465,39.147932 39.2643465,35.96065 Z M33.5063382,43.7484927 L19.8732617,43.7484927 C15.5838238,43.7320287 12.1152535,40.2501196 12.1152535,35.96065 C12.1152535,31.6711805 15.5838238,28.1892713 19.8771,28.1728 L33.5063382,28.1728074 C37.7957762,28.1892713 41.2643465,31.6711805 41.2643465,35.96065 C41.2643465,40.2501196 37.7957762,43.7320287 33.5063382,43.7484927 Z M4.05719996,30.1728 L4.05719996,28.1728 L43.9642,28.1728 L43.9642,30.1728 L4.05719996,30.1728 Z M55.4516752,36.7622384 C52.1544239,32.8465026 47.6524924,30.1753035 43.6628931,30.1668978 L43.6653582,28.1669001 C47.6513075,28.1683277 52.1512822,25.5008902 55.4516752,21.5832616 L59.9428,16.2515027 L59.9428,42.0939973 L55.4516752,36.7622384 Z M56.9814315,35.4738883 L57.9428,36.6152027 L57.9428,21.7302973 L56.9812826,22.8717885 C54.5951477,25.7041754 51.6260066,27.9542521 48.5521534,29.1707722 C51.6273936,30.3909571 54.5971615,32.642387 56.9814315,35.4738883 Z"
-          />
-        </svg>
-      </figure>
-      Activity
-    </h2>
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
+  <section>
     <div
-      className="entity-list__contents-wrapper"
+      className="entity-list"
+      id="entities-list1"
     >
-      <div
-        className="entity-list__search entity-list-search"
+      <h2
+        className="entity-list__title-block entity-list__title"
       >
-        <form
-          onSubmit={[Function]}
+        <figure
+          className="entity-list__title-icon"
         >
-          <div
-            className="entity-list-search__keyword-row"
+          <svg
+            aria-hidden={true}
+            className="manicon-svg svg-icon--BENews64"
+            fill="currentColor"
+            height={null}
+            viewBox="0 0 64 64"
+            width={null}
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <button
-              className="entity-list-search__search-button"
-            >
-              <svg
-                aria-hidden={true}
-                className="manicon-svg manicon-magnify svg-icon--search16"
-                fill="currentColor"
-                height={null}
-                viewBox="0 0 16 16"
-                width={null}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
-                />
-              </svg>
-              <span
-                className="screen-reader-text"
-              >
-                Search
-              </span>
-            </button>
-            <div
-              className="entity-list-search__keyword-input-wrapper"
-            >
-              <label
-                className="screen-reader-text"
-                htmlFor="list-search-1"
-              >
-                Enter Search Criteria
-              </label>
-              <input
-                className="entity-list-search__keyword-input"
-                id="list-search-1"
-                onChange={[Function]}
-                placeholder="Search..."
-                type="text"
-                value=""
-              />
-            </div>
-            <button
-              className="entity-list-search__text-button"
-              onClick={[Function]}
-            >
-              Reset
-            </button>
-            <button
-              className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
-              onClick={[Function]}
-            >
-              Options
-            </button>
-          </div>
-        </form>
+            <path
+              d="M39.2643465,35.96065 C39.2643465,32.7727533 36.686535,30.1850285 33.5025,30.1728 L19.8809382,30.1727926 C16.693065,30.1850285 14.1152535,32.7727533 14.1152535,35.96065 C14.1152535,39.1485467 16.693065,41.7362715 19.8771,41.7485 L33.500506,41.7485 C36.6875291,41.7352734 39.2643465,39.147932 39.2643465,35.96065 Z M33.5063382,43.7484927 L19.8732617,43.7484927 C15.5838238,43.7320287 12.1152535,40.2501196 12.1152535,35.96065 C12.1152535,31.6711805 15.5838238,28.1892713 19.8771,28.1728 L33.5063382,28.1728074 C37.7957762,28.1892713 41.2643465,31.6711805 41.2643465,35.96065 C41.2643465,40.2501196 37.7957762,43.7320287 33.5063382,43.7484927 Z M4.05719996,30.1728 L4.05719996,28.1728 L43.9642,28.1728 L43.9642,30.1728 L4.05719996,30.1728 Z M55.4516752,36.7622384 C52.1544239,32.8465026 47.6524924,30.1753035 43.6628931,30.1668978 L43.6653582,28.1669001 C47.6513075,28.1683277 52.1512822,25.5008902 55.4516752,21.5832616 L59.9428,16.2515027 L59.9428,42.0939973 L55.4516752,36.7622384 Z M56.9814315,35.4738883 L57.9428,36.6152027 L57.9428,21.7302973 L56.9812826,22.8717885 C54.5951477,25.7041754 51.6260066,27.9542521 48.5521534,29.1707722 C51.6273936,30.3909571 54.5971615,32.642387 56.9814315,35.4738883 Z"
+            />
+          </svg>
+        </figure>
+        Activity
+      </h2>
+      <div
+        className="entity-list__contents-wrapper"
+      >
         <div
-          className="ReactCollapse--collapse"
-          style={
-            Object {
-              "height": 0,
-              "overflow": "hidden",
-            }
-          }
+          className="entity-list__search entity-list-search"
         >
-          <div
-            className="ReactCollapse--content"
+          <form
+            onSubmit={[Function]}
           >
-            <div>
-              <div
-                className="entity-list-search__options entity-list-search__options--horizontal"
+            <div
+              className="entity-list-search__keyword-row"
+            >
+              <button
+                className="entity-list-search__search-button"
               >
+                <svg
+                  aria-hidden={true}
+                  className="manicon-svg manicon-magnify svg-icon--search16"
+                  fill="currentColor"
+                  height={null}
+                  viewBox="0 0 16 16"
+                  width={null}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
+                  />
+                </svg>
+                <span
+                  className="screen-reader-text"
+                >
+                  Search
+                </span>
+              </button>
+              <div
+                className="entity-list-search__keyword-input-wrapper"
+              >
+                <label
+                  className="screen-reader-text"
+                  htmlFor="list-search-1"
+                >
+                  Enter Search Criteria
+                </label>
+                <input
+                  className="entity-list-search__keyword-input"
+                  id="list-search-1"
+                  onChange={[Function]}
+                  placeholder="Search..."
+                  type="text"
+                  value=""
+                />
+              </div>
+              <button
+                className="entity-list-search__text-button"
+                onClick={[Function]}
+              >
+                Reset
+              </button>
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
+                onClick={[Function]}
+              >
+                Options
+              </button>
+            </div>
+          </form>
+          <div
+            className="ReactCollapse--collapse"
+            style={
+              Object {
+                "height": 0,
+                "overflow": "hidden",
+              }
+            }
+          >
+            <div
+              className="ReactCollapse--content"
+            >
+              <div>
                 <div
-                  className="entity-list-search__option entity-list-search__option--horizontal"
+                  className="entity-list-search__options entity-list-search__options--horizontal"
                 >
                   <div
-                    className="entity-list-search__option-inner"
+                    className="entity-list-search__option entity-list-search__option--horizontal"
                   >
-                    <span
-                      className="entity-list-search__options-label "
-                    >
-                      Filter Results:
-                    </span>
                     <div
-                      className="entity-list-search__select-wrapper"
+                      className="entity-list-search__option-inner"
                     >
-                      <select
-                        id="list-search-1"
-                        onChange={[Function]}
-                        value=""
+                      <span
+                        className="entity-list-search__options-label "
                       >
-                        <option
-                          value="project_created"
-                        >
-                          Type is "Project Created"
-                        </option>
-                        <option
-                          value="text_added"
-                        >
-                          Type is "Text Added"
-                        </option>
-                        <option
-                          value="text_annotated"
-                        >
-                          Type is "Text Annotated"
-                        </option>
-                        <option
-                          value="resource_added"
-                        >
-                          Type is "Resource Added"
-                        </option>
-                        <option
-                          value="comment_created"
-                        >
-                          Type is "Comment Created"
-                        </option>
-                        <option
-                          value="tweet"
-                        >
-                          Type is "Tweet"
-                        </option>
-                      </select>
-                      <svg
-                        aria-hidden={true}
-                        className="manicon-svg svg-icon--disclosureDown24"
-                        fill="currentColor"
-                        height={null}
-                        viewBox="0 0 24 24"
-                        width={null}
-                        xmlns="http://www.w3.org/2000/svg"
+                        Filter Results:
+                      </span>
+                      <div
+                        className="entity-list-search__select-wrapper"
                       >
-                        <polygon
-                          points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
-                        />
-                      </svg>
+                        <select
+                          id="list-search-1"
+                          onChange={[Function]}
+                          value=""
+                        >
+                          <option
+                            value="project_created"
+                          >
+                            Type is "Project Created"
+                          </option>
+                          <option
+                            value="text_added"
+                          >
+                            Type is "Text Added"
+                          </option>
+                          <option
+                            value="text_annotated"
+                          >
+                            Type is "Text Annotated"
+                          </option>
+                          <option
+                            value="resource_added"
+                          >
+                            Type is "Resource Added"
+                          </option>
+                          <option
+                            value="comment_created"
+                          >
+                            Type is "Comment Created"
+                          </option>
+                          <option
+                            value="tweet"
+                          >
+                            Type is "Tweet"
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="manicon-svg svg-icon--disclosureDown24"
+                          fill="currentColor"
+                          height={null}
+                          viewBox="0 0 24 24"
+                          width={null}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                          />
+                        </svg>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -180,322 +190,331 @@ exports[`Backend Project Events Container renders correctly 1`] = `
             </div>
           </div>
         </div>
-      </div>
-      <div
-        className="entity-list__header"
-      >
         <div
-          className="entity-list__count"
+          className="entity-list__header"
         >
-          <p
-            className="list-total"
+          <div
+            className="entity-list__count"
           >
-            Showing 
-            <span>
-              1-1
-            </span>
-             of 
-            <span>
-              2
-            </span>
-             events: 
-          </p>
+            <p
+              aria-hidden={true}
+              className="list-total"
+            >
+              Showing 
+              <span>
+                1-1
+              </span>
+               of 
+              <span>
+                2
+              </span>
+               events: 
+            </p>
+            <div
+              aria-atomic={true}
+              aria-live="polite"
+              className="screen-reader-text"
+              role="status"
+            >
+              2 events. Showing results 1 through 1.
+            </div>
+          </div>
+        </div>
+        <ul
+          className="entity-list__list entity-list__list--tiles"
+        >
+          <li
+            className="event-entity-row"
+          >
+            <div
+              className="event-entity-row__inner"
+            >
+              <div
+                className="event-tile"
+                onClick={[Function]}
+                role="link"
+              >
+                <div
+                  className="event-tile__inner"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="manicon-svg event-tile__icon svg-icon--activityText64"
+                    fill="currentColor"
+                    height={48}
+                    viewBox="0 0 64 64"
+                    width={48}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M63,32 C63,49.121 49.12,63 32,63 C14.879,63 1,49.121 1,32 C1,14.879 14.879,1 32,1 C49.12,1 63,14.879 63,32 M22.5634,39.0022 L34.5634,39.0022 L34.5634,37.0022 L22.5634,37.0022 L22.5634,39.0022 Z M22.5634,35.0022 L37.5634,35.0022 L37.5634,33.0022 L22.5634,33.0022 L22.5634,35.0022 Z M22.5634,31.0022 L34.5634,31.0022 L34.5634,29.0022 L22.5634,29.0022 L22.5634,31.0022 Z M22.5634,27.0022 L37.5634,27.0022 L37.5634,25.0022 L22.5634,25.0022 L22.5634,27.0022 Z M42.5635,51.002 C39.2545,51.002 36.5635,48.311 36.5635,45.002 C36.5635,41.693 39.2545,39.002 42.5635,39.002 C45.8725,39.002 48.5635,41.693 48.5635,45.002 C48.5635,48.311 45.8725,51.002 42.5635,51.002 L42.5635,51.002 Z M19.5635,47.002 L19.5635,14.002 L35.4245,14.002 C35.4665,14.002 35.5115,14.06 35.5385,14.14 L35.4065,14.261 L35.5635,14.432 L35.5635,22.002 L42.4245,22.002 C42.4815,22.002 42.5635,22.088 42.5635,22.224 L42.5635,37.002 C38.1525,37.002 34.5635,40.591 34.5635,45.002 C34.5635,45.693 34.6615,46.361 34.8275,47.002 L19.5635,47.002 Z M37.5635,16.61 L40.6775,20.002 L37.5635,20.002 L37.5635,16.61 Z M44.5635,37.266 L44.5635,22.224 C44.5635,21.637 44.3385,21.106 43.9795,20.707 L44.0125,20.677 L37.4445,13.523 C37.1595,12.643 36.3675,12.002 35.4245,12.002 L17.5635,12.002 L17.5635,49.002 L35.5635,49.002 L35.5635,48.866 C36.9285,51.329 39.5535,53.002 42.5635,53.002 C46.9745,53.002 50.5635,49.413 50.5635,45.002 C50.5635,41.282 48.0075,38.157 44.5635,37.266 L44.5635,37.266 Z M43.5635,41.002 L41.5635,41.002 L41.5635,44.002 L38.5635,44.002 L38.5635,46.002 L41.5635,46.002 L41.5635,49.002 L43.5635,49.002 L43.5635,46.002 L46.5635,46.002 L46.5635,44.002 L43.5635,44.002 L43.5635,41.002 Z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                  <div
+                    className="event-tile__header"
+                  >
+                    Text Added
+                  </div>
+                  <h3
+                    className="event-tile__title"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "New Text",
+                      }
+                    }
+                  />
+                  <span
+                    className="event-tile__footer"
+                  >
+                    <time
+                      dateTime="2017-04-24"
+                    >
+                      April 24th, 2017
+                    </time>
+                  </span>
+                </div>
+              </div>
+              <div
+                className="utility-button"
+                data-id="destroy"
+                onClick={[Function]}
+                role="button"
+                tabIndex="0"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="manicon-svg utility-button__icon utility-button__icon--notice svg-icon--delete32"
+                  fill="currentColor"
+                  height={26}
+                  viewBox="0 0 32 32"
+                  width={26}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M22.5006476,10.9603607 L23.4993524,11.0112392 L22.8010808,24.6917831 C22.8222428,25.6607758 22.05432,26.4636781 21.074,26.4858 L10.9146542,26.4856713 C9.94567997,26.4636781 9.17775722,25.6607758 9.19944755,24.7281393 L8.50064755,11.0112392 L9.49935241,10.9603607 L10.1986808,24.713617 C10.1895701,25.1307915 10.5201792,25.4764602 10.926,25.4858 L21.0626542,25.4859288 C21.4798208,25.4764602 21.8104299,25.1307915 21.8018476,24.6772608 L22.5006476,10.9603607 Z M5.99999997,11.4266 L5.99999997,10.4266 L26,10.4266 L26,11.4266 L5.99999997,11.4266 Z M12.75,10.9266 L11.75,10.9266 L11.7501673,6.81953297 C11.732004,6.11756111 12.2857775,5.53349733 13.0014,5.51409997 L19.0122785,5.5142871 C19.7142225,5.53349733 20.267996,6.11756111 20.25,6.80659997 L20.25,10.9266 L19.25,10.9266 L19.2501673,6.79366698 C19.2540602,6.64321292 19.1353696,6.51803017 18.9986,6.51409997 L13.0150785,6.51391283 C12.8646304,6.51803017 12.7459398,6.64321292 12.75,6.80659997 L12.75,10.9266 Z M13.5,14.7217 L14.5,14.7217 L14.5,22.25 L13.5,22.25 L13.5,14.7217 Z M17.5,14.7217 L18.5,14.7217 L18.5,22.25 L17.5,22.25 L17.5,14.7217 Z"
+                  />
+                </svg>
+                <span
+                  className="screen-reader-text"
+                >
+                  Delete Event
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            className="event-entity-row"
+          >
+            <div
+              className="event-entity-row__inner"
+            >
+              <div
+                className="event-tile"
+                onClick={[Function]}
+                role="link"
+              >
+                <div
+                  className="event-tile__inner"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="manicon-svg event-tile__icon svg-icon--activityText64"
+                    fill="currentColor"
+                    height={48}
+                    viewBox="0 0 64 64"
+                    width={48}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M63,32 C63,49.121 49.12,63 32,63 C14.879,63 1,49.121 1,32 C1,14.879 14.879,1 32,1 C49.12,1 63,14.879 63,32 M22.5634,39.0022 L34.5634,39.0022 L34.5634,37.0022 L22.5634,37.0022 L22.5634,39.0022 Z M22.5634,35.0022 L37.5634,35.0022 L37.5634,33.0022 L22.5634,33.0022 L22.5634,35.0022 Z M22.5634,31.0022 L34.5634,31.0022 L34.5634,29.0022 L22.5634,29.0022 L22.5634,31.0022 Z M22.5634,27.0022 L37.5634,27.0022 L37.5634,25.0022 L22.5634,25.0022 L22.5634,27.0022 Z M42.5635,51.002 C39.2545,51.002 36.5635,48.311 36.5635,45.002 C36.5635,41.693 39.2545,39.002 42.5635,39.002 C45.8725,39.002 48.5635,41.693 48.5635,45.002 C48.5635,48.311 45.8725,51.002 42.5635,51.002 L42.5635,51.002 Z M19.5635,47.002 L19.5635,14.002 L35.4245,14.002 C35.4665,14.002 35.5115,14.06 35.5385,14.14 L35.4065,14.261 L35.5635,14.432 L35.5635,22.002 L42.4245,22.002 C42.4815,22.002 42.5635,22.088 42.5635,22.224 L42.5635,37.002 C38.1525,37.002 34.5635,40.591 34.5635,45.002 C34.5635,45.693 34.6615,46.361 34.8275,47.002 L19.5635,47.002 Z M37.5635,16.61 L40.6775,20.002 L37.5635,20.002 L37.5635,16.61 Z M44.5635,37.266 L44.5635,22.224 C44.5635,21.637 44.3385,21.106 43.9795,20.707 L44.0125,20.677 L37.4445,13.523 C37.1595,12.643 36.3675,12.002 35.4245,12.002 L17.5635,12.002 L17.5635,49.002 L35.5635,49.002 L35.5635,48.866 C36.9285,51.329 39.5535,53.002 42.5635,53.002 C46.9745,53.002 50.5635,49.413 50.5635,45.002 C50.5635,41.282 48.0075,38.157 44.5635,37.266 L44.5635,37.266 Z M43.5635,41.002 L41.5635,41.002 L41.5635,44.002 L38.5635,44.002 L38.5635,46.002 L41.5635,46.002 L41.5635,49.002 L43.5635,49.002 L43.5635,46.002 L46.5635,46.002 L46.5635,44.002 L43.5635,44.002 L43.5635,41.002 Z"
+                      fillRule="evenodd"
+                    />
+                  </svg>
+                  <div
+                    className="event-tile__header"
+                  >
+                    Text Added
+                  </div>
+                  <h3
+                    className="event-tile__title"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "New Text",
+                      }
+                    }
+                  />
+                  <span
+                    className="event-tile__footer"
+                  >
+                    <time
+                      dateTime="2017-04-24"
+                    >
+                      April 24th, 2017
+                    </time>
+                  </span>
+                </div>
+              </div>
+              <div
+                className="utility-button"
+                data-id="destroy"
+                onClick={[Function]}
+                role="button"
+                tabIndex="0"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="manicon-svg utility-button__icon utility-button__icon--notice svg-icon--delete32"
+                  fill="currentColor"
+                  height={26}
+                  viewBox="0 0 32 32"
+                  width={26}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M22.5006476,10.9603607 L23.4993524,11.0112392 L22.8010808,24.6917831 C22.8222428,25.6607758 22.05432,26.4636781 21.074,26.4858 L10.9146542,26.4856713 C9.94567997,26.4636781 9.17775722,25.6607758 9.19944755,24.7281393 L8.50064755,11.0112392 L9.49935241,10.9603607 L10.1986808,24.713617 C10.1895701,25.1307915 10.5201792,25.4764602 10.926,25.4858 L21.0626542,25.4859288 C21.4798208,25.4764602 21.8104299,25.1307915 21.8018476,24.6772608 L22.5006476,10.9603607 Z M5.99999997,11.4266 L5.99999997,10.4266 L26,10.4266 L26,11.4266 L5.99999997,11.4266 Z M12.75,10.9266 L11.75,10.9266 L11.7501673,6.81953297 C11.732004,6.11756111 12.2857775,5.53349733 13.0014,5.51409997 L19.0122785,5.5142871 C19.7142225,5.53349733 20.267996,6.11756111 20.25,6.80659997 L20.25,10.9266 L19.25,10.9266 L19.2501673,6.79366698 C19.2540602,6.64321292 19.1353696,6.51803017 18.9986,6.51409997 L13.0150785,6.51391283 C12.8646304,6.51803017 12.7459398,6.64321292 12.75,6.80659997 L12.75,10.9266 Z M13.5,14.7217 L14.5,14.7217 L14.5,22.25 L13.5,22.25 L13.5,14.7217 Z M17.5,14.7217 L18.5,14.7217 L18.5,22.25 L17.5,22.25 L17.5,14.7217 Z"
+                  />
+                </svg>
+                <span
+                  className="screen-reader-text"
+                >
+                  Delete Event
+                </span>
+              </div>
+            </div>
+          </li>
+        </ul>
+        <div
+          className="entity-list__pagination"
+        >
+          <nav
+            aria-label="Pagination"
+            className="list-pagination"
+          >
+            <ul
+              className="list-pagination__columns"
+            >
+              <li
+                className="list-pagination__column"
+              >
+                <ul>
+                  <li
+                    className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
+                  >
+                    <a
+                      disabled={true}
+                      href="#entities-list1"
+                      onClick={[Function]}
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--arrowLongLeft16"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 16"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                          transform="rotate(180 12 8)"
+                        />
+                      </svg>
+                      <span
+                        className="list-pagination__icon-label"
+                      >
+                        PREV
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+              <li
+                className="list-pagination__column-middle"
+              >
+                <ul
+                  className="list-pagination__pages"
+                >
+                  <li
+                    className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
+                  >
+                    <a
+                      href="#entities-list1"
+                      onClick={[Function]}
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        1
+                      </span>
+                      <span
+                        className="screen-reader-text"
+                      >
+                        Go to page: 
+                        1
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    className="list-pagination__page list-pagination__page--ordinal"
+                  >
+                    <a
+                      href="#entities-list1"
+                      onClick={[Function]}
+                    >
+                      <span
+                        aria-hidden="true"
+                      >
+                        2
+                      </span>
+                      <span
+                        className="screen-reader-text"
+                      >
+                        Go to page: 
+                        2
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+              <li
+                className="list-pagination__column"
+              >
+                <ul>
+                  <li
+                    className="list-pagination__page list-pagination__page--next"
+                  >
+                    <a
+                      href="#entities-list1"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="list-pagination__icon-label"
+                      >
+                        NEXT
+                      </span>
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--arrowLongRight16"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 16"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                        />
+                      </svg>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </nav>
         </div>
       </div>
-      <ul
-        className="entity-list__list entity-list__list--tiles"
-      >
-        <li
-          className="event-entity-row"
-        >
-          <div
-            className="event-entity-row__inner"
-          >
-            <div
-              className="event-tile"
-              onClick={[Function]}
-              role="link"
-            >
-              <div
-                className="event-tile__inner"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="manicon-svg event-tile__icon svg-icon--activityText64"
-                  fill="currentColor"
-                  height={48}
-                  viewBox="0 0 64 64"
-                  width={48}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M63,32 C63,49.121 49.12,63 32,63 C14.879,63 1,49.121 1,32 C1,14.879 14.879,1 32,1 C49.12,1 63,14.879 63,32 M22.5634,39.0022 L34.5634,39.0022 L34.5634,37.0022 L22.5634,37.0022 L22.5634,39.0022 Z M22.5634,35.0022 L37.5634,35.0022 L37.5634,33.0022 L22.5634,33.0022 L22.5634,35.0022 Z M22.5634,31.0022 L34.5634,31.0022 L34.5634,29.0022 L22.5634,29.0022 L22.5634,31.0022 Z M22.5634,27.0022 L37.5634,27.0022 L37.5634,25.0022 L22.5634,25.0022 L22.5634,27.0022 Z M42.5635,51.002 C39.2545,51.002 36.5635,48.311 36.5635,45.002 C36.5635,41.693 39.2545,39.002 42.5635,39.002 C45.8725,39.002 48.5635,41.693 48.5635,45.002 C48.5635,48.311 45.8725,51.002 42.5635,51.002 L42.5635,51.002 Z M19.5635,47.002 L19.5635,14.002 L35.4245,14.002 C35.4665,14.002 35.5115,14.06 35.5385,14.14 L35.4065,14.261 L35.5635,14.432 L35.5635,22.002 L42.4245,22.002 C42.4815,22.002 42.5635,22.088 42.5635,22.224 L42.5635,37.002 C38.1525,37.002 34.5635,40.591 34.5635,45.002 C34.5635,45.693 34.6615,46.361 34.8275,47.002 L19.5635,47.002 Z M37.5635,16.61 L40.6775,20.002 L37.5635,20.002 L37.5635,16.61 Z M44.5635,37.266 L44.5635,22.224 C44.5635,21.637 44.3385,21.106 43.9795,20.707 L44.0125,20.677 L37.4445,13.523 C37.1595,12.643 36.3675,12.002 35.4245,12.002 L17.5635,12.002 L17.5635,49.002 L35.5635,49.002 L35.5635,48.866 C36.9285,51.329 39.5535,53.002 42.5635,53.002 C46.9745,53.002 50.5635,49.413 50.5635,45.002 C50.5635,41.282 48.0075,38.157 44.5635,37.266 L44.5635,37.266 Z M43.5635,41.002 L41.5635,41.002 L41.5635,44.002 L38.5635,44.002 L38.5635,46.002 L41.5635,46.002 L41.5635,49.002 L43.5635,49.002 L43.5635,46.002 L46.5635,46.002 L46.5635,44.002 L43.5635,44.002 L43.5635,41.002 Z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-                <div
-                  className="event-tile__header"
-                >
-                  Text Added
-                </div>
-                <h3
-                  className="event-tile__title"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "New Text",
-                    }
-                  }
-                />
-                <span
-                  className="event-tile__footer"
-                >
-                  <time
-                    dateTime="2017-04-24"
-                  >
-                    April 24th, 2017
-                  </time>
-                </span>
-              </div>
-            </div>
-            <div
-              className="utility-button"
-              data-id="destroy"
-              onClick={[Function]}
-              role="button"
-              tabIndex="0"
-            >
-              <svg
-                aria-hidden={true}
-                className="manicon-svg utility-button__icon utility-button__icon--notice svg-icon--delete32"
-                fill="currentColor"
-                height={26}
-                viewBox="0 0 32 32"
-                width={26}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M22.5006476,10.9603607 L23.4993524,11.0112392 L22.8010808,24.6917831 C22.8222428,25.6607758 22.05432,26.4636781 21.074,26.4858 L10.9146542,26.4856713 C9.94567997,26.4636781 9.17775722,25.6607758 9.19944755,24.7281393 L8.50064755,11.0112392 L9.49935241,10.9603607 L10.1986808,24.713617 C10.1895701,25.1307915 10.5201792,25.4764602 10.926,25.4858 L21.0626542,25.4859288 C21.4798208,25.4764602 21.8104299,25.1307915 21.8018476,24.6772608 L22.5006476,10.9603607 Z M5.99999997,11.4266 L5.99999997,10.4266 L26,10.4266 L26,11.4266 L5.99999997,11.4266 Z M12.75,10.9266 L11.75,10.9266 L11.7501673,6.81953297 C11.732004,6.11756111 12.2857775,5.53349733 13.0014,5.51409997 L19.0122785,5.5142871 C19.7142225,5.53349733 20.267996,6.11756111 20.25,6.80659997 L20.25,10.9266 L19.25,10.9266 L19.2501673,6.79366698 C19.2540602,6.64321292 19.1353696,6.51803017 18.9986,6.51409997 L13.0150785,6.51391283 C12.8646304,6.51803017 12.7459398,6.64321292 12.75,6.80659997 L12.75,10.9266 Z M13.5,14.7217 L14.5,14.7217 L14.5,22.25 L13.5,22.25 L13.5,14.7217 Z M17.5,14.7217 L18.5,14.7217 L18.5,22.25 L17.5,22.25 L17.5,14.7217 Z"
-                />
-              </svg>
-              <span
-                className="screen-reader-text"
-              >
-                Delete Event
-              </span>
-            </div>
-          </div>
-        </li>
-        <li
-          className="event-entity-row"
-        >
-          <div
-            className="event-entity-row__inner"
-          >
-            <div
-              className="event-tile"
-              onClick={[Function]}
-              role="link"
-            >
-              <div
-                className="event-tile__inner"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="manicon-svg event-tile__icon svg-icon--activityText64"
-                  fill="currentColor"
-                  height={48}
-                  viewBox="0 0 64 64"
-                  width={48}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M63,32 C63,49.121 49.12,63 32,63 C14.879,63 1,49.121 1,32 C1,14.879 14.879,1 32,1 C49.12,1 63,14.879 63,32 M22.5634,39.0022 L34.5634,39.0022 L34.5634,37.0022 L22.5634,37.0022 L22.5634,39.0022 Z M22.5634,35.0022 L37.5634,35.0022 L37.5634,33.0022 L22.5634,33.0022 L22.5634,35.0022 Z M22.5634,31.0022 L34.5634,31.0022 L34.5634,29.0022 L22.5634,29.0022 L22.5634,31.0022 Z M22.5634,27.0022 L37.5634,27.0022 L37.5634,25.0022 L22.5634,25.0022 L22.5634,27.0022 Z M42.5635,51.002 C39.2545,51.002 36.5635,48.311 36.5635,45.002 C36.5635,41.693 39.2545,39.002 42.5635,39.002 C45.8725,39.002 48.5635,41.693 48.5635,45.002 C48.5635,48.311 45.8725,51.002 42.5635,51.002 L42.5635,51.002 Z M19.5635,47.002 L19.5635,14.002 L35.4245,14.002 C35.4665,14.002 35.5115,14.06 35.5385,14.14 L35.4065,14.261 L35.5635,14.432 L35.5635,22.002 L42.4245,22.002 C42.4815,22.002 42.5635,22.088 42.5635,22.224 L42.5635,37.002 C38.1525,37.002 34.5635,40.591 34.5635,45.002 C34.5635,45.693 34.6615,46.361 34.8275,47.002 L19.5635,47.002 Z M37.5635,16.61 L40.6775,20.002 L37.5635,20.002 L37.5635,16.61 Z M44.5635,37.266 L44.5635,22.224 C44.5635,21.637 44.3385,21.106 43.9795,20.707 L44.0125,20.677 L37.4445,13.523 C37.1595,12.643 36.3675,12.002 35.4245,12.002 L17.5635,12.002 L17.5635,49.002 L35.5635,49.002 L35.5635,48.866 C36.9285,51.329 39.5535,53.002 42.5635,53.002 C46.9745,53.002 50.5635,49.413 50.5635,45.002 C50.5635,41.282 48.0075,38.157 44.5635,37.266 L44.5635,37.266 Z M43.5635,41.002 L41.5635,41.002 L41.5635,44.002 L38.5635,44.002 L38.5635,46.002 L41.5635,46.002 L41.5635,49.002 L43.5635,49.002 L43.5635,46.002 L46.5635,46.002 L46.5635,44.002 L43.5635,44.002 L43.5635,41.002 Z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-                <div
-                  className="event-tile__header"
-                >
-                  Text Added
-                </div>
-                <h3
-                  className="event-tile__title"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "New Text",
-                    }
-                  }
-                />
-                <span
-                  className="event-tile__footer"
-                >
-                  <time
-                    dateTime="2017-04-24"
-                  >
-                    April 24th, 2017
-                  </time>
-                </span>
-              </div>
-            </div>
-            <div
-              className="utility-button"
-              data-id="destroy"
-              onClick={[Function]}
-              role="button"
-              tabIndex="0"
-            >
-              <svg
-                aria-hidden={true}
-                className="manicon-svg utility-button__icon utility-button__icon--notice svg-icon--delete32"
-                fill="currentColor"
-                height={26}
-                viewBox="0 0 32 32"
-                width={26}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M22.5006476,10.9603607 L23.4993524,11.0112392 L22.8010808,24.6917831 C22.8222428,25.6607758 22.05432,26.4636781 21.074,26.4858 L10.9146542,26.4856713 C9.94567997,26.4636781 9.17775722,25.6607758 9.19944755,24.7281393 L8.50064755,11.0112392 L9.49935241,10.9603607 L10.1986808,24.713617 C10.1895701,25.1307915 10.5201792,25.4764602 10.926,25.4858 L21.0626542,25.4859288 C21.4798208,25.4764602 21.8104299,25.1307915 21.8018476,24.6772608 L22.5006476,10.9603607 Z M5.99999997,11.4266 L5.99999997,10.4266 L26,10.4266 L26,11.4266 L5.99999997,11.4266 Z M12.75,10.9266 L11.75,10.9266 L11.7501673,6.81953297 C11.732004,6.11756111 12.2857775,5.53349733 13.0014,5.51409997 L19.0122785,5.5142871 C19.7142225,5.53349733 20.267996,6.11756111 20.25,6.80659997 L20.25,10.9266 L19.25,10.9266 L19.2501673,6.79366698 C19.2540602,6.64321292 19.1353696,6.51803017 18.9986,6.51409997 L13.0150785,6.51391283 C12.8646304,6.51803017 12.7459398,6.64321292 12.75,6.80659997 L12.75,10.9266 Z M13.5,14.7217 L14.5,14.7217 L14.5,22.25 L13.5,22.25 L13.5,14.7217 Z M17.5,14.7217 L18.5,14.7217 L18.5,22.25 L17.5,22.25 L17.5,14.7217 Z"
-                />
-              </svg>
-              <span
-                className="screen-reader-text"
-              >
-                Delete Event
-              </span>
-            </div>
-          </div>
-        </li>
-      </ul>
-      <div
-        className="entity-list__pagination"
-      >
-        <nav
-          aria-label="Pagination"
-          className="list-pagination"
-        >
-          <ul
-            className="list-pagination__columns"
-          >
-            <li
-              className="list-pagination__column"
-            >
-              <ul>
-                <li
-                  className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
-                >
-                  <a
-                    disabled={true}
-                    href="#entities-list1"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--arrowLongLeft16"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 16"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                        transform="rotate(180 12 8)"
-                      />
-                    </svg>
-                    <span
-                      className="list-pagination__icon-label"
-                    >
-                      PREV
-                    </span>
-                  </a>
-                </li>
-              </ul>
-            </li>
-            <li
-              className="list-pagination__column-middle"
-            >
-              <ul
-                className="list-pagination__pages"
-              >
-                <li
-                  className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
-                >
-                  <a
-                    href="#entities-list1"
-                    onClick={[Function]}
-                  >
-                    <span
-                      aria-hidden="true"
-                    >
-                      1
-                    </span>
-                    <span
-                      className="screen-reader-text"
-                    >
-                      Go to page: 
-                      1
-                    </span>
-                  </a>
-                </li>
-                <li
-                  className="list-pagination__page list-pagination__page--ordinal"
-                >
-                  <a
-                    href="#entities-list1"
-                    onClick={[Function]}
-                  >
-                    <span
-                      aria-hidden="true"
-                    >
-                      2
-                    </span>
-                    <span
-                      className="screen-reader-text"
-                    >
-                      Go to page: 
-                      2
-                    </span>
-                  </a>
-                </li>
-              </ul>
-            </li>
-            <li
-              className="list-pagination__column"
-            >
-              <ul>
-                <li
-                  className="list-pagination__page list-pagination__page--next"
-                >
-                  <a
-                    href="#entities-list1"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="list-pagination__icon-label"
-                    >
-                      NEXT
-                    </span>
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--arrowLongRight16"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 16"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                      />
-                    </svg>
-                  </a>
-                </li>
-              </ul>
-            </li>
-          </ul>
-        </nav>
-      </div>
     </div>
-  </div>
-</section>
+  </section>,
+]
 `;

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Log-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Log-test.js.snap
@@ -37,6 +37,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
         className="entity-list__count"
       >
         <p
+          aria-hidden={true}
           className="list-total"
         >
           Showing 
@@ -49,6 +50,14 @@ exports[`Backend Project Log Container renders correctly 1`] = `
           </span>
            changes: 
         </p>
+        <div
+          aria-atomic={true}
+          aria-live="polite"
+          className="screen-reader-text"
+          role="status"
+        >
+          2 changes. Showing results 1 through 1.
+        </div>
       </div>
     </div>
     <ul

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Resources-test.js.snap
@@ -3,6 +3,12 @@
 exports[`Backend Project Resources Container renders correctly 1`] = `
 <section>
   <div
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />
+  <div
     className="entity-list"
     id="entities-list1"
   >
@@ -87,6 +93,8 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
               Reset
             </button>
             <button
+              aria-expanded={false}
+              aria-haspopup={true}
               className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
               onClick={[Function]}
             >
@@ -329,6 +337,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
           className="entity-list__count"
         >
           <p
+            aria-hidden={true}
             className="list-total"
           >
             Showing 
@@ -341,6 +350,14 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
             </span>
              resources: 
           </p>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          >
+            2 resources. Showing results 1 through 1.
+          </div>
         </div>
       </div>
       <div

--- a/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourceCollectionsList-test.js.snap
+++ b/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourceCollectionsList-test.js.snap
@@ -1,152 +1,162 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Backend Project Resource CollectionList Container renders correctly 1`] = `
-<div
-  className="entity-list"
-  id="entities-list1"
->
-  <h2
-    className="entity-list__title-block entity-list__title"
-  >
-    <figure
-      className="entity-list__title-icon"
-    >
-      <svg
-        aria-hidden={true}
-        className="manicon-svg svg-icon--resourceCollection64"
-        fill="currentColor"
-        height={null}
-        viewBox="0 0 64 64"
-        width={null}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M24,39 L24,45 L40,45 L40,39 L24,39 Z M42,37 L42,47 L22,47 L22,37 L42,37 Z M56,20.4707664 L47.6615077,14 L16.3394622,14 L7.99999996,20.4707998 L7.99999996,25 L56,25 L56,20.4707664 Z M58,27 L5.99999996,27 L5.99999996,19.4912002 L15.6545377,12 L48.3464923,12 L58,19.4912335 L58,27 Z M57,19 L57,21 L6.99999996,21 L6.99999996,19 L57,19 Z M54,52 L54,26 L56,26 L56,54 L7.99999996,54 L7.99999996,26 L9.99999997,26 L9.99999997,52 L54,52 Z M34.998,26.0006 L36.998,26.0006 C36.9980001,27.7862134 36.0453867,29.4361883 34.499,30.3289951 C32.9526134,31.2218018 31.0473866,31.2218018 29.501,30.3289951 C27.9546133,29.4361883 27.0019999,27.7862134 27.002,26.0006 L29.002,26.0006 C29.002,27.0716823 29.5734155,28.0614031 30.501,28.5969443 C31.4285844,29.1324854 32.5714156,29.1324854 33.499,28.5969443 C34.4265845,28.0614031 34.998,27.0716823 34.998,26.0006 Z"
-        />
-      </svg>
-    </figure>
-    Resource Collections
-  </h2>
+Array [
   <div
-    className="entity-list__contents-wrapper"
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
+  <div
+    className="entity-list"
+    id="entities-list1"
   >
-    <div
-      className="entity-list__search entity-list-search"
+    <h2
+      className="entity-list__title-block entity-list__title"
     >
-      <form
-        onSubmit={[Function]}
+      <figure
+        className="entity-list__title-icon"
       >
-        <div
-          className="entity-list-search__keyword-row"
+        <svg
+          aria-hidden={true}
+          className="manicon-svg svg-icon--resourceCollection64"
+          fill="currentColor"
+          height={null}
+          viewBox="0 0 64 64"
+          width={null}
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <button
-            className="entity-list-search__search-button"
-          >
-            <svg
-              aria-hidden={true}
-              className="manicon-svg manicon-magnify svg-icon--search16"
-              fill="currentColor"
-              height={null}
-              viewBox="0 0 16 16"
-              width={null}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
-              />
-            </svg>
-            <span
-              className="screen-reader-text"
-            >
-              Search
-            </span>
-          </button>
-          <div
-            className="entity-list-search__keyword-input-wrapper"
-          >
-            <label
-              className="screen-reader-text"
-              htmlFor="list-search-1"
-            >
-              Enter Search Criteria
-            </label>
-            <input
-              className="entity-list-search__keyword-input"
-              id="list-search-1"
-              onChange={[Function]}
-              placeholder="Search..."
-              type="text"
-              value=""
-            />
-          </div>
-          <button
-            className="entity-list-search__text-button"
-            onClick={[Function]}
-          >
-            Reset
-          </button>
-          <button
-            className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
-            onClick={[Function]}
-          >
-            Options
-          </button>
-        </div>
-      </form>
+          <path
+            d="M24,39 L24,45 L40,45 L40,39 L24,39 Z M42,37 L42,47 L22,47 L22,37 L42,37 Z M56,20.4707664 L47.6615077,14 L16.3394622,14 L7.99999996,20.4707998 L7.99999996,25 L56,25 L56,20.4707664 Z M58,27 L5.99999996,27 L5.99999996,19.4912002 L15.6545377,12 L48.3464923,12 L58,19.4912335 L58,27 Z M57,19 L57,21 L6.99999996,21 L6.99999996,19 L57,19 Z M54,52 L54,26 L56,26 L56,54 L7.99999996,54 L7.99999996,26 L9.99999997,26 L9.99999997,52 L54,52 Z M34.998,26.0006 L36.998,26.0006 C36.9980001,27.7862134 36.0453867,29.4361883 34.499,30.3289951 C32.9526134,31.2218018 31.0473866,31.2218018 29.501,30.3289951 C27.9546133,29.4361883 27.0019999,27.7862134 27.002,26.0006 L29.002,26.0006 C29.002,27.0716823 29.5734155,28.0614031 30.501,28.5969443 C31.4285844,29.1324854 32.5714156,29.1324854 33.499,28.5969443 C34.4265845,28.0614031 34.998,27.0716823 34.998,26.0006 Z"
+          />
+        </svg>
+      </figure>
+      Resource Collections
+    </h2>
+    <div
+      className="entity-list__contents-wrapper"
+    >
       <div
-        className="ReactCollapse--collapse"
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-          }
-        }
+        className="entity-list__search entity-list-search"
       >
-        <div
-          className="ReactCollapse--content"
+        <form
+          onSubmit={[Function]}
         >
-          <div>
-            <div
-              className="entity-list-search__options entity-list-search__options--horizontal"
+          <div
+            className="entity-list-search__keyword-row"
+          >
+            <button
+              className="entity-list-search__search-button"
             >
+              <svg
+                aria-hidden={true}
+                className="manicon-svg manicon-magnify svg-icon--search16"
+                fill="currentColor"
+                height={null}
+                viewBox="0 0 16 16"
+                width={null}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
+                />
+              </svg>
+              <span
+                className="screen-reader-text"
+              >
+                Search
+              </span>
+            </button>
+            <div
+              className="entity-list-search__keyword-input-wrapper"
+            >
+              <label
+                className="screen-reader-text"
+                htmlFor="list-search-1"
+              >
+                Enter Search Criteria
+              </label>
+              <input
+                className="entity-list-search__keyword-input"
+                id="list-search-1"
+                onChange={[Function]}
+                placeholder="Search..."
+                type="text"
+                value=""
+              />
+            </div>
+            <button
+              className="entity-list-search__text-button"
+              onClick={[Function]}
+            >
+              Reset
+            </button>
+            <button
+              aria-expanded={false}
+              aria-haspopup={true}
+              className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
+              onClick={[Function]}
+            >
+              Options
+            </button>
+          </div>
+        </form>
+        <div
+          className="ReactCollapse--collapse"
+          style={
+            Object {
+              "height": 0,
+              "overflow": "hidden",
+            }
+          }
+        >
+          <div
+            className="ReactCollapse--content"
+          >
+            <div>
               <div
-                className="entity-list-search__option entity-list-search__option--horizontal"
+                className="entity-list-search__options entity-list-search__options--horizontal"
               >
                 <div
-                  className="entity-list-search__option-inner"
+                  className="entity-list-search__option entity-list-search__option--horizontal"
                 >
-                  <span
-                    className="entity-list-search__options-label"
-                  >
-                    Order Results:
-                  </span>
                   <div
-                    className="entity-list-search__select-wrapper"
+                    className="entity-list-search__option-inner"
                   >
-                    <select
-                      id="list-search-1"
-                      onChange={[Function]}
-                      value="title"
+                    <span
+                      className="entity-list-search__options-label"
                     >
-                      <option
+                      Order Results:
+                    </span>
+                    <div
+                      className="entity-list-search__select-wrapper"
+                    >
+                      <select
+                        id="list-search-1"
+                        onChange={[Function]}
                         value="title"
                       >
-                        Alphabetical by title
-                      </option>
-                    </select>
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--disclosureDown24"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 24"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <polygon
-                        points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
-                      />
-                    </svg>
+                        <option
+                          value="title"
+                        >
+                          Alphabetical by title
+                        </option>
+                      </select>
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--disclosureDown24"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 24"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polygon
+                          points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                        />
+                      </svg>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -154,309 +164,318 @@ exports[`Backend Project Resource CollectionList Container renders correctly 1`]
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="entity-list__header"
-    >
       <div
-        className="entity-list__button-set"
+        className="entity-list__header"
       >
-        <a
-          className="entity-list__button"
-          href="/backend/projects/1/resource-collections/new"
-          onClick={[Function]}
+        <div
+          className="entity-list__button-set"
         >
-          <svg
+          <a
+            className="entity-list__button"
+            href="/backend/projects/1/resource-collections/new"
+            onClick={[Function]}
+          >
+            <svg
+              aria-hidden={true}
+              className="manicon-svg svg-icon--circlePlus32"
+              fill="currentColor"
+              height={null}
+              viewBox="0 0 32 32"
+              width={null}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M9.99999998,16.5 L9.99999998,15.5 L22,15.5 L22,16.5 L9.99999998,16.5 Z M16.5,22 L15.5,22 L15.5,9.99999998 L16.5,9.99999998 L16.5,22 Z M16,27 C9.92486773,27 4.99999997,22.0751323 4.99999997,16 C4.99999997,9.92486773 9.92486773,4.99999997 16,4.99999997 C22.0751323,4.99999997 27,9.92486773 27,16 C27,22.0751323 22.0751323,27 16,27 Z M16,26 C21.5228475,26 26,21.5228475 26,16 C26,10.4771525 21.5228475,5.99999997 16,5.99999997 C10.4771525,5.99999997 5.99999997,10.4771525 5.99999997,16 C5.99999997,21.5228475 10.4771525,26 16,26 Z"
+              />
+            </svg>
+            Add a new resource collection
+          </a>
+        </div>
+        <div
+          className="entity-list__count"
+        >
+          <p
             aria-hidden={true}
-            className="manicon-svg svg-icon--circlePlus32"
-            fill="currentColor"
-            height={null}
-            viewBox="0 0 32 32"
-            width={null}
-            xmlns="http://www.w3.org/2000/svg"
+            className="list-total"
           >
-            <path
-              d="M9.99999998,16.5 L9.99999998,15.5 L22,15.5 L22,16.5 L9.99999998,16.5 Z M16.5,22 L15.5,22 L15.5,9.99999998 L16.5,9.99999998 L16.5,22 Z M16,27 C9.92486773,27 4.99999997,22.0751323 4.99999997,16 C4.99999997,9.92486773 9.92486773,4.99999997 16,4.99999997 C22.0751323,4.99999997 27,9.92486773 27,16 C27,22.0751323 22.0751323,27 16,27 Z M16,26 C21.5228475,26 26,21.5228475 26,16 C26,10.4771525 21.5228475,5.99999997 16,5.99999997 C10.4771525,5.99999997 5.99999997,10.4771525 5.99999997,16 C5.99999997,21.5228475 10.4771525,26 16,26 Z"
-            />
-          </svg>
-          Add a new resource collection
-        </a>
+            Showing 
+            <span>
+              1-1
+            </span>
+             of 
+            <span>
+              2
+            </span>
+             resource collections: 
+          </p>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          >
+            2 resource collections. Showing results 1 through 1.
+          </div>
+        </div>
       </div>
+      <ul
+        className="entity-list__list entity-list__list--rows"
+      >
+        <li
+          className="entity-row entity-list__entity"
+        >
+          <a
+            aria-describedby="undefined1-describedby"
+            className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
+            href="/backend/projects/resource-collection/2"
+            onClick={[Function]}
+          >
+            <div
+              className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
+            >
+              <div
+                className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
+              >
+                <svg
+                  className="manicon-svg svg-icon--resourceCollection64"
+                  fill="currentColor"
+                  viewBox="0 0 64 64"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24,39 L24,45 L40,45 L40,39 L24,39 Z M42,37 L42,47 L22,47 L22,37 L42,37 Z M56,20.4707664 L47.6615077,14 L16.3394622,14 L7.99999996,20.4707998 L7.99999996,25 L56,25 L56,20.4707664 Z M58,27 L5.99999996,27 L5.99999996,19.4912002 L15.6545377,12 L48.3464923,12 L58,19.4912335 L58,27 Z M57,19 L57,21 L6.99999996,21 L6.99999996,19 L57,19 Z M54,52 L54,26 L56,26 L56,54 L7.99999996,54 L7.99999996,26 L9.99999997,26 L9.99999997,52 L54,52 Z M34.998,26.0006 L36.998,26.0006 C36.9980001,27.7862134 36.0453867,29.4361883 34.499,30.3289951 C32.9526134,31.2218018 31.0473866,31.2218018 29.501,30.3289951 C27.9546133,29.4361883 27.0019999,27.7862134 27.002,26.0006 L29.002,26.0006 C29.002,27.0716823 29.5734155,28.0614031 30.501,28.5969443 C31.4285844,29.1324854 32.5714156,29.1324854 33.499,28.5969443 C34.4265845,28.0614031 34.998,27.0716823 34.998,26.0006 Z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="entity-row__text entity-row__text--in-rows"
+              >
+                <h3
+                  className="entity-row__title entity-row__title--in-rows"
+                >
+                  <span
+                    className="entity-row__title-inner"
+                  >
+                    Rowan
+                  </span>
+                  <span
+                    className="aria-describedby"
+                    id="undefined1-describedby"
+                  >
+                    View Rowan
+                  </span>
+                </h3>
+                <h4
+                  className="entity-row__count entity-row__count--in-rows"
+                >
+                  0 resources
+                </h4>
+                <div
+                  className="entity-row__meta entity-row__meta--in-rows"
+                >
+                  <time
+                    dateTime="2017-04-24"
+                  >
+                    Created April 24, 2017
+                  </time>
+                </div>
+              </div>
+            </div>
+          </a>
+        </li>
+        <li
+          className="entity-row entity-list__entity"
+        >
+          <a
+            aria-describedby="undefined1-describedby"
+            className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
+            href="/backend/projects/resource-collection/3"
+            onClick={[Function]}
+          >
+            <div
+              className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
+            >
+              <div
+                className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
+              >
+                <svg
+                  className="manicon-svg svg-icon--resourceCollection64"
+                  fill="currentColor"
+                  viewBox="0 0 64 64"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24,39 L24,45 L40,45 L40,39 L24,39 Z M42,37 L42,47 L22,47 L22,37 L42,37 Z M56,20.4707664 L47.6615077,14 L16.3394622,14 L7.99999996,20.4707998 L7.99999996,25 L56,25 L56,20.4707664 Z M58,27 L5.99999996,27 L5.99999996,19.4912002 L15.6545377,12 L48.3464923,12 L58,19.4912335 L58,27 Z M57,19 L57,21 L6.99999996,21 L6.99999996,19 L57,19 Z M54,52 L54,26 L56,26 L56,54 L7.99999996,54 L7.99999996,26 L9.99999997,26 L9.99999997,52 L54,52 Z M34.998,26.0006 L36.998,26.0006 C36.9980001,27.7862134 36.0453867,29.4361883 34.499,30.3289951 C32.9526134,31.2218018 31.0473866,31.2218018 29.501,30.3289951 C27.9546133,29.4361883 27.0019999,27.7862134 27.002,26.0006 L29.002,26.0006 C29.002,27.0716823 29.5734155,28.0614031 30.501,28.5969443 C31.4285844,29.1324854 32.5714156,29.1324854 33.499,28.5969443 C34.4265845,28.0614031 34.998,27.0716823 34.998,26.0006 Z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="entity-row__text entity-row__text--in-rows"
+              >
+                <h3
+                  className="entity-row__title entity-row__title--in-rows"
+                >
+                  <span
+                    className="entity-row__title-inner"
+                  >
+                    Rowan
+                  </span>
+                  <span
+                    className="aria-describedby"
+                    id="undefined1-describedby"
+                  >
+                    View Rowan
+                  </span>
+                </h3>
+                <h4
+                  className="entity-row__count entity-row__count--in-rows"
+                >
+                  0 resources
+                </h4>
+                <div
+                  className="entity-row__meta entity-row__meta--in-rows"
+                >
+                  <time
+                    dateTime="2017-04-24"
+                  >
+                    Created April 24, 2017
+                  </time>
+                </div>
+              </div>
+            </div>
+          </a>
+        </li>
+      </ul>
       <div
-        className="entity-list__count"
+        className="entity-list__pagination"
       >
-        <p
-          className="list-total"
+        <nav
+          aria-label="Pagination"
+          className="list-pagination"
         >
-          Showing 
-          <span>
-            1-1
-          </span>
-           of 
-          <span>
-            2
-          </span>
-           resource collections: 
-        </p>
+          <ul
+            className="list-pagination__columns"
+          >
+            <li
+              className="list-pagination__column"
+            >
+              <ul>
+                <li
+                  className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
+                >
+                  <a
+                    disabled={true}
+                    href="#entities-list1"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="manicon-svg svg-icon--arrowLongLeft16"
+                      fill="currentColor"
+                      height={null}
+                      viewBox="0 0 24 16"
+                      width={null}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                        transform="rotate(180 12 8)"
+                      />
+                    </svg>
+                    <span
+                      className="list-pagination__icon-label"
+                    >
+                      PREV
+                    </span>
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              className="list-pagination__column-middle"
+            >
+              <ul
+                className="list-pagination__pages"
+              >
+                <li
+                  className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
+                >
+                  <a
+                    href="#entities-list1"
+                    onClick={[Function]}
+                  >
+                    <span
+                      aria-hidden="true"
+                    >
+                      1
+                    </span>
+                    <span
+                      className="screen-reader-text"
+                    >
+                      Go to page: 
+                      1
+                    </span>
+                  </a>
+                </li>
+                <li
+                  className="list-pagination__page list-pagination__page--ordinal"
+                >
+                  <a
+                    href="#entities-list1"
+                    onClick={[Function]}
+                  >
+                    <span
+                      aria-hidden="true"
+                    >
+                      2
+                    </span>
+                    <span
+                      className="screen-reader-text"
+                    >
+                      Go to page: 
+                      2
+                    </span>
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              className="list-pagination__column"
+            >
+              <ul>
+                <li
+                  className="list-pagination__page list-pagination__page--next"
+                >
+                  <a
+                    href="#entities-list1"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="list-pagination__icon-label"
+                    >
+                      NEXT
+                    </span>
+                    <svg
+                      aria-hidden={true}
+                      className="manicon-svg svg-icon--arrowLongRight16"
+                      fill="currentColor"
+                      height={null}
+                      viewBox="0 0 24 16"
+                      width={null}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                      />
+                    </svg>
+                  </a>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </nav>
       </div>
     </div>
-    <ul
-      className="entity-list__list entity-list__list--rows"
-    >
-      <li
-        className="entity-row entity-list__entity"
-      >
-        <a
-          aria-describedby="undefined1-describedby"
-          className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
-          href="/backend/projects/resource-collection/2"
-          onClick={[Function]}
-        >
-          <div
-            className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
-          >
-            <div
-              className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
-            >
-              <svg
-                className="manicon-svg svg-icon--resourceCollection64"
-                fill="currentColor"
-                viewBox="0 0 64 64"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M24,39 L24,45 L40,45 L40,39 L24,39 Z M42,37 L42,47 L22,47 L22,37 L42,37 Z M56,20.4707664 L47.6615077,14 L16.3394622,14 L7.99999996,20.4707998 L7.99999996,25 L56,25 L56,20.4707664 Z M58,27 L5.99999996,27 L5.99999996,19.4912002 L15.6545377,12 L48.3464923,12 L58,19.4912335 L58,27 Z M57,19 L57,21 L6.99999996,21 L6.99999996,19 L57,19 Z M54,52 L54,26 L56,26 L56,54 L7.99999996,54 L7.99999996,26 L9.99999997,26 L9.99999997,52 L54,52 Z M34.998,26.0006 L36.998,26.0006 C36.9980001,27.7862134 36.0453867,29.4361883 34.499,30.3289951 C32.9526134,31.2218018 31.0473866,31.2218018 29.501,30.3289951 C27.9546133,29.4361883 27.0019999,27.7862134 27.002,26.0006 L29.002,26.0006 C29.002,27.0716823 29.5734155,28.0614031 30.501,28.5969443 C31.4285844,29.1324854 32.5714156,29.1324854 33.499,28.5969443 C34.4265845,28.0614031 34.998,27.0716823 34.998,26.0006 Z"
-                />
-              </svg>
-            </div>
-            <div
-              className="entity-row__text entity-row__text--in-rows"
-            >
-              <h3
-                className="entity-row__title entity-row__title--in-rows"
-              >
-                <span
-                  className="entity-row__title-inner"
-                >
-                  Rowan
-                </span>
-                <span
-                  className="aria-describedby"
-                  id="undefined1-describedby"
-                >
-                  View Rowan
-                </span>
-              </h3>
-              <h4
-                className="entity-row__count entity-row__count--in-rows"
-              >
-                0 resources
-              </h4>
-              <div
-                className="entity-row__meta entity-row__meta--in-rows"
-              >
-                <time
-                  dateTime="2017-04-24"
-                >
-                  Created April 24, 2017
-                </time>
-              </div>
-            </div>
-          </div>
-        </a>
-      </li>
-      <li
-        className="entity-row entity-list__entity"
-      >
-        <a
-          aria-describedby="undefined1-describedby"
-          className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
-          href="/backend/projects/resource-collection/3"
-          onClick={[Function]}
-        >
-          <div
-            className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
-          >
-            <div
-              className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
-            >
-              <svg
-                className="manicon-svg svg-icon--resourceCollection64"
-                fill="currentColor"
-                viewBox="0 0 64 64"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M24,39 L24,45 L40,45 L40,39 L24,39 Z M42,37 L42,47 L22,47 L22,37 L42,37 Z M56,20.4707664 L47.6615077,14 L16.3394622,14 L7.99999996,20.4707998 L7.99999996,25 L56,25 L56,20.4707664 Z M58,27 L5.99999996,27 L5.99999996,19.4912002 L15.6545377,12 L48.3464923,12 L58,19.4912335 L58,27 Z M57,19 L57,21 L6.99999996,21 L6.99999996,19 L57,19 Z M54,52 L54,26 L56,26 L56,54 L7.99999996,54 L7.99999996,26 L9.99999997,26 L9.99999997,52 L54,52 Z M34.998,26.0006 L36.998,26.0006 C36.9980001,27.7862134 36.0453867,29.4361883 34.499,30.3289951 C32.9526134,31.2218018 31.0473866,31.2218018 29.501,30.3289951 C27.9546133,29.4361883 27.0019999,27.7862134 27.002,26.0006 L29.002,26.0006 C29.002,27.0716823 29.5734155,28.0614031 30.501,28.5969443 C31.4285844,29.1324854 32.5714156,29.1324854 33.499,28.5969443 C34.4265845,28.0614031 34.998,27.0716823 34.998,26.0006 Z"
-                />
-              </svg>
-            </div>
-            <div
-              className="entity-row__text entity-row__text--in-rows"
-            >
-              <h3
-                className="entity-row__title entity-row__title--in-rows"
-              >
-                <span
-                  className="entity-row__title-inner"
-                >
-                  Rowan
-                </span>
-                <span
-                  className="aria-describedby"
-                  id="undefined1-describedby"
-                >
-                  View Rowan
-                </span>
-              </h3>
-              <h4
-                className="entity-row__count entity-row__count--in-rows"
-              >
-                0 resources
-              </h4>
-              <div
-                className="entity-row__meta entity-row__meta--in-rows"
-              >
-                <time
-                  dateTime="2017-04-24"
-                >
-                  Created April 24, 2017
-                </time>
-              </div>
-            </div>
-          </div>
-        </a>
-      </li>
-    </ul>
-    <div
-      className="entity-list__pagination"
-    >
-      <nav
-        aria-label="Pagination"
-        className="list-pagination"
-      >
-        <ul
-          className="list-pagination__columns"
-        >
-          <li
-            className="list-pagination__column"
-          >
-            <ul>
-              <li
-                className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
-              >
-                <a
-                  disabled={true}
-                  href="#entities-list1"
-                  onClick={[Function]}
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="manicon-svg svg-icon--arrowLongLeft16"
-                    fill="currentColor"
-                    height={null}
-                    viewBox="0 0 24 16"
-                    width={null}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                      transform="rotate(180 12 8)"
-                    />
-                  </svg>
-                  <span
-                    className="list-pagination__icon-label"
-                  >
-                    PREV
-                  </span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li
-            className="list-pagination__column-middle"
-          >
-            <ul
-              className="list-pagination__pages"
-            >
-              <li
-                className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
-              >
-                <a
-                  href="#entities-list1"
-                  onClick={[Function]}
-                >
-                  <span
-                    aria-hidden="true"
-                  >
-                    1
-                  </span>
-                  <span
-                    className="screen-reader-text"
-                  >
-                    Go to page: 
-                    1
-                  </span>
-                </a>
-              </li>
-              <li
-                className="list-pagination__page list-pagination__page--ordinal"
-              >
-                <a
-                  href="#entities-list1"
-                  onClick={[Function]}
-                >
-                  <span
-                    aria-hidden="true"
-                  >
-                    2
-                  </span>
-                  <span
-                    className="screen-reader-text"
-                  >
-                    Go to page: 
-                    2
-                  </span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li
-            className="list-pagination__column"
-          >
-            <ul>
-              <li
-                className="list-pagination__page list-pagination__page--next"
-              >
-                <a
-                  href="#entities-list1"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="list-pagination__icon-label"
-                  >
-                    NEXT
-                  </span>
-                  <svg
-                    aria-hidden={true}
-                    className="manicon-svg svg-icon--arrowLongRight16"
-                    fill="currentColor"
-                    height={null}
-                    viewBox="0 0 24 16"
-                    width={null}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                    />
-                  </svg>
-                </a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </div>
-</div>
+  </div>,
+]
 `;

--- a/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourcesList-test.js.snap
+++ b/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourcesList-test.js.snap
@@ -1,612 +1,631 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Backend Project Resource ResourcesList Container renders correctly 1`] = `
-<div
-  className="entity-list"
-  id="entities-list1"
->
-  <h2
-    className="entity-list__title-block entity-list__title"
-  >
-    <figure
-      className="entity-list__title-icon"
-    >
-      <svg
-        aria-hidden={true}
-        className="manicon-svg svg-icon--resourceCollection64"
-        fill="currentColor"
-        height={null}
-        viewBox="0 0 64 64"
-        width={null}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M24,39 L24,45 L40,45 L40,39 L24,39 Z M42,37 L42,47 L22,47 L22,37 L42,37 Z M56,20.4707664 L47.6615077,14 L16.3394622,14 L7.99999996,20.4707998 L7.99999996,25 L56,25 L56,20.4707664 Z M58,27 L5.99999996,27 L5.99999996,19.4912002 L15.6545377,12 L48.3464923,12 L58,19.4912335 L58,27 Z M57,19 L57,21 L6.99999996,21 L6.99999996,19 L57,19 Z M54,52 L54,26 L56,26 L56,54 L7.99999996,54 L7.99999996,26 L9.99999997,26 L9.99999997,52 L54,52 Z M34.998,26.0006 L36.998,26.0006 C36.9980001,27.7862134 36.0453867,29.4361883 34.499,30.3289951 C32.9526134,31.2218018 31.0473866,31.2218018 29.501,30.3289951 C27.9546133,29.4361883 27.0019999,27.7862134 27.002,26.0006 L29.002,26.0006 C29.002,27.0716823 29.5734155,28.0614031 30.501,28.5969443 C31.4285844,29.1324854 32.5714156,29.1324854 33.499,28.5969443 C34.4265845,28.0614031 34.998,27.0716823 34.998,26.0006 Z"
-        />
-      </svg>
-    </figure>
-    Resources
-  </h2>
+Array [
   <div
-    className="entity-list__contents-wrapper"
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
+  <div
+    className="entity-list"
+    id="entities-list1"
   >
-    <div
-      className="entity-list__search entity-list-search"
+    <h2
+      className="entity-list__title-block entity-list__title"
     >
-      <form
-        onSubmit={[Function]}
+      <figure
+        className="entity-list__title-icon"
+      >
+        <svg
+          aria-hidden={true}
+          className="manicon-svg svg-icon--resourceCollection64"
+          fill="currentColor"
+          height={null}
+          viewBox="0 0 64 64"
+          width={null}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M24,39 L24,45 L40,45 L40,39 L24,39 Z M42,37 L42,47 L22,47 L22,37 L42,37 Z M56,20.4707664 L47.6615077,14 L16.3394622,14 L7.99999996,20.4707998 L7.99999996,25 L56,25 L56,20.4707664 Z M58,27 L5.99999996,27 L5.99999996,19.4912002 L15.6545377,12 L48.3464923,12 L58,19.4912335 L58,27 Z M57,19 L57,21 L6.99999996,21 L6.99999996,19 L57,19 Z M54,52 L54,26 L56,26 L56,54 L7.99999996,54 L7.99999996,26 L9.99999997,26 L9.99999997,52 L54,52 Z M34.998,26.0006 L36.998,26.0006 C36.9980001,27.7862134 36.0453867,29.4361883 34.499,30.3289951 C32.9526134,31.2218018 31.0473866,31.2218018 29.501,30.3289951 C27.9546133,29.4361883 27.0019999,27.7862134 27.002,26.0006 L29.002,26.0006 C29.002,27.0716823 29.5734155,28.0614031 30.501,28.5969443 C31.4285844,29.1324854 32.5714156,29.1324854 33.499,28.5969443 C34.4265845,28.0614031 34.998,27.0716823 34.998,26.0006 Z"
+          />
+        </svg>
+      </figure>
+      Resources
+    </h2>
+    <div
+      className="entity-list__contents-wrapper"
+    >
+      <div
+        className="entity-list__search entity-list-search"
+      >
+        <form
+          onSubmit={[Function]}
+        >
+          <div
+            className="entity-list-search__keyword-row"
+          >
+            <button
+              className="entity-list-search__search-button"
+            >
+              <svg
+                aria-hidden={true}
+                className="manicon-svg manicon-magnify svg-icon--search16"
+                fill="currentColor"
+                height={null}
+                viewBox="0 0 16 16"
+                width={null}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
+                />
+              </svg>
+              <span
+                className="screen-reader-text"
+              >
+                Search
+              </span>
+            </button>
+            <div
+              className="entity-list-search__keyword-input-wrapper"
+            >
+              <label
+                className="screen-reader-text"
+                htmlFor="list-search-1"
+              >
+                Enter Search Criteria
+              </label>
+              <input
+                className="entity-list-search__keyword-input"
+                id="list-search-1"
+                onChange={[Function]}
+                placeholder="Search..."
+                type="text"
+                value=""
+              />
+            </div>
+            <button
+              className="entity-list-search__text-button"
+              onClick={[Function]}
+            >
+              Reset
+            </button>
+            <button
+              aria-expanded={false}
+              aria-haspopup={true}
+              className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
+              onClick={[Function]}
+            >
+              Options
+            </button>
+          </div>
+        </form>
+        <div
+          className="ReactCollapse--collapse"
+          style={
+            Object {
+              "height": 0,
+              "overflow": "hidden",
+            }
+          }
+        >
+          <div
+            className="ReactCollapse--content"
+          >
+            <div>
+              <div
+                className="entity-list-search__options entity-list-search__options--horizontal"
+              >
+                <div
+                  className="entity-list-search__option entity-list-search__option--horizontal"
+                >
+                  <div
+                    className="entity-list-search__option-inner"
+                  >
+                    <span
+                      className="entity-list-search__options-label "
+                    >
+                      Filter Results:
+                    </span>
+                    <div
+                      className="entity-list-search__select-wrapper"
+                    >
+                      <select
+                        id="list-search-1"
+                        onChange={[Function]}
+                        value=""
+                      >
+                        <option
+                          value=""
+                        >
+                          Select a tag
+                        </option>
+                      </select>
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--disclosureDown24"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 24"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polygon
+                          points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="entity-list-search__option entity-list-search__option--horizontal"
+                >
+                  <div
+                    className="entity-list-search__option-inner"
+                  >
+                    <span
+                      className="entity-list-search__options-label entity-list-search__options-label--empty"
+                    >
+                       
+                    </span>
+                    <div
+                      className="entity-list-search__select-wrapper"
+                    >
+                      <select
+                        id="list-search-1"
+                        onChange={[Function]}
+                        value=""
+                      >
+                        <option
+                          value=""
+                        >
+                          Select a type
+                        </option>
+                      </select>
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--disclosureDown24"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 24"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polygon
+                          points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="entity-list-search__option entity-list-search__option--horizontal"
+                >
+                  <div
+                    className="entity-list-search__option-inner"
+                  >
+                    <span
+                      className="entity-list-search__options-label entity-list-search__options-label--empty"
+                    >
+                       
+                    </span>
+                    <div
+                      className="entity-list-search__select-wrapper"
+                    >
+                      <select
+                        id="list-search-1"
+                        onChange={[Function]}
+                        value=""
+                      />
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--disclosureDown24"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 24"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polygon
+                          points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="entity-list-search__option entity-list-search__option--horizontal"
+                >
+                  <div
+                    className="entity-list-search__option-inner"
+                  >
+                    <span
+                      className="entity-list-search__options-label"
+                    >
+                      Order Results:
+                    </span>
+                    <div
+                      className="entity-list-search__select-wrapper"
+                    >
+                      <select
+                        id="list-search-1"
+                        onChange={[Function]}
+                        value="title"
+                      >
+                        <option
+                          value="title"
+                        >
+                          Alphabetical by title
+                        </option>
+                        <option
+                          value="created_at"
+                        >
+                          Newest resources first
+                        </option>
+                      </select>
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--disclosureDown24"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 24"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polygon
+                          points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="entity-list__header"
       >
         <div
-          className="entity-list-search__keyword-row"
+          className="entity-list__button-set"
         >
-          <button
-            className="entity-list-search__search-button"
+          <a
+            className="entity-list__button"
+            href="/backend/projects/1/resources/new"
+            onClick={[Function]}
           >
             <svg
               aria-hidden={true}
-              className="manicon-svg manicon-magnify svg-icon--search16"
+              className="manicon-svg svg-icon--circlePlus32"
               fill="currentColor"
               height={null}
-              viewBox="0 0 16 16"
+              viewBox="0 0 32 32"
               width={null}
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
+                d="M9.99999998,16.5 L9.99999998,15.5 L22,15.5 L22,16.5 L9.99999998,16.5 Z M16.5,22 L15.5,22 L15.5,9.99999998 L16.5,9.99999998 L16.5,22 Z M16,27 C9.92486773,27 4.99999997,22.0751323 4.99999997,16 C4.99999997,9.92486773 9.92486773,4.99999997 16,4.99999997 C22.0751323,4.99999997 27,9.92486773 27,16 C27,22.0751323 22.0751323,27 16,27 Z M16,26 C21.5228475,26 26,21.5228475 26,16 C26,10.4771525 21.5228475,5.99999997 16,5.99999997 C10.4771525,5.99999997 5.99999997,10.4771525 5.99999997,16 C5.99999997,21.5228475 10.4771525,26 16,26 Z"
               />
             </svg>
-            <span
-              className="screen-reader-text"
-            >
-              Search
-            </span>
-          </button>
-          <div
-            className="entity-list-search__keyword-input-wrapper"
-          >
-            <label
-              className="screen-reader-text"
-              htmlFor="list-search-1"
-            >
-              Enter Search Criteria
-            </label>
-            <input
-              className="entity-list-search__keyword-input"
-              id="list-search-1"
-              onChange={[Function]}
-              placeholder="Search..."
-              type="text"
-              value=""
-            />
-          </div>
-          <button
-            className="entity-list-search__text-button"
+            Add a new resource
+          </a>
+          <a
+            className="entity-list__button"
+            href="/backend/projects/1/resource-import"
             onClick={[Function]}
           >
-            Reset
-          </button>
-          <button
-            className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
-            onClick={[Function]}
-          >
-            Options
-          </button>
+            <svg
+              aria-hidden={true}
+              className="manicon-svg svg-icon--BEResourcesBoxes64"
+              fill="currentColor"
+              height={null}
+              viewBox="0 0 64 64"
+              width={null}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M19.381104,42.2037638 L21.381096,42.2094362 L21.340396,56.5594363 L19.340404,56.5537638 L19.381104,42.2037638 Z M7.94412447,36.1830973 L8.94387546,34.4509027 L20.8809755,41.3405027 L19.8812245,43.0726973 L7.94412447,36.1830973 Z M42.957404,42.2037638 L44.957396,42.2094362 L44.916696,56.5594363 L42.916704,56.5537638 L42.957404,42.2037638 Z M55.0536703,34.5801239 L56.0583298,36.3094761 L44.4190298,43.0712761 L43.4143702,41.3419239 L55.0536703,34.5801239 Z M30.9816031,49.2185031 L31.0183892,36.0214972 L20.0846359,29.7105681 L9.44235692,35.8934954 L9.40465112,49.0905261 L20.3383857,55.4014444 L30.9816031,49.2185031 Z M7.40134881,50.2434739 L7.44564301,34.7405046 L20.0813641,27.3994319 L33.0216108,34.8685028 L32.9783969,50.3714969 L20.3416143,57.7125557 L7.40134881,50.2434739 Z M31.4773702,34.5801239 L32.4820298,36.3094761 L20.8427298,43.0712761 L19.8380702,41.3419239 L31.4773702,34.5801239 Z M54.5576431,49.2185047 L54.5953489,36.0214739 L43.6616143,29.7105557 L33.0183969,35.8934969 L32.9816108,49.0905029 L43.9153641,55.4014319 L54.5576431,49.2185047 Z M30.9783892,50.2434972 L31.0216031,34.7405031 L43.6583857,27.3994443 L56.5986512,34.8685261 L56.554357,50.3714954 L43.9186359,57.7125682 L30.9783892,50.2434972 Z M31.5204245,36.1830973 L32.5201755,34.4509027 L44.4572755,41.3405027 L43.4575245,43.0726973 L31.5204245,36.1830973 Z M42.6616031,28.1065031 L42.6983892,14.9094971 L31.7646359,8.59856809 L21.1223569,14.7814953 L21.0846511,27.9785261 L32.0183857,34.2894443 L42.6616031,28.1065031 Z M19.0813488,29.1314739 L19.125643,13.6285046 L31.7613641,6.28743184 L44.7016109,13.7565028 L44.6583969,29.2594969 L32.0216143,36.6005557 L19.0813488,29.1314739 Z M31.061004,21.0919638 L33.060996,21.0976362 L33.020296,35.4476362 L31.020304,35.4419638 L31.061004,21.0919638 Z M19.6241159,15.0711923 L20.6238841,13.3390077 L32.5608841,20.2287077 L31.5611159,21.9608923 L19.6241159,15.0711923 Z M43.1572702,13.4683239 L44.1619298,15.1976761 L32.5226298,21.9594761 L31.5179702,20.2301239 L43.1572702,13.4683239 Z"
+              />
+            </svg>
+            Bulk add resources
+          </a>
         </div>
-      </form>
-      <div
-        className="ReactCollapse--collapse"
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-          }
-        }
-      >
         <div
-          className="ReactCollapse--content"
+          className="entity-list__count"
         >
-          <div>
-            <div
-              className="entity-list-search__options entity-list-search__options--horizontal"
-            >
-              <div
-                className="entity-list-search__option entity-list-search__option--horizontal"
-              >
-                <div
-                  className="entity-list-search__option-inner"
-                >
-                  <span
-                    className="entity-list-search__options-label "
-                  >
-                    Filter Results:
-                  </span>
-                  <div
-                    className="entity-list-search__select-wrapper"
-                  >
-                    <select
-                      id="list-search-1"
-                      onChange={[Function]}
-                      value=""
-                    >
-                      <option
-                        value=""
-                      >
-                        Select a tag
-                      </option>
-                    </select>
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--disclosureDown24"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 24"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <polygon
-                        points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="entity-list-search__option entity-list-search__option--horizontal"
-              >
-                <div
-                  className="entity-list-search__option-inner"
-                >
-                  <span
-                    className="entity-list-search__options-label entity-list-search__options-label--empty"
-                  >
-                     
-                  </span>
-                  <div
-                    className="entity-list-search__select-wrapper"
-                  >
-                    <select
-                      id="list-search-1"
-                      onChange={[Function]}
-                      value=""
-                    >
-                      <option
-                        value=""
-                      >
-                        Select a type
-                      </option>
-                    </select>
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--disclosureDown24"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 24"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <polygon
-                        points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="entity-list-search__option entity-list-search__option--horizontal"
-              >
-                <div
-                  className="entity-list-search__option-inner"
-                >
-                  <span
-                    className="entity-list-search__options-label entity-list-search__options-label--empty"
-                  >
-                     
-                  </span>
-                  <div
-                    className="entity-list-search__select-wrapper"
-                  >
-                    <select
-                      id="list-search-1"
-                      onChange={[Function]}
-                      value=""
-                    />
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--disclosureDown24"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 24"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <polygon
-                        points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="entity-list-search__option entity-list-search__option--horizontal"
-              >
-                <div
-                  className="entity-list-search__option-inner"
-                >
-                  <span
-                    className="entity-list-search__options-label"
-                  >
-                    Order Results:
-                  </span>
-                  <div
-                    className="entity-list-search__select-wrapper"
-                  >
-                    <select
-                      id="list-search-1"
-                      onChange={[Function]}
-                      value="title"
-                    >
-                      <option
-                        value="title"
-                      >
-                        Alphabetical by title
-                      </option>
-                      <option
-                        value="created_at"
-                      >
-                        Newest resources first
-                      </option>
-                    </select>
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--disclosureDown24"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 24"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <polygon
-                        points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-            </div>
+          <p
+            aria-hidden={true}
+            className="list-total"
+          >
+            Showing 
+            <span>
+              1-1
+            </span>
+             of 
+            <span>
+              2
+            </span>
+             resources: 
+          </p>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          >
+            2 resources. Showing results 1 through 1.
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="entity-list__header"
-    >
-      <div
-        className="entity-list__button-set"
+      <ul
+        className="entity-list__list entity-list__list--rows"
       >
-        <a
-          className="entity-list__button"
-          href="/backend/projects/1/resources/new"
-          onClick={[Function]}
+        <li
+          className="entity-row entity-list__entity"
         >
-          <svg
-            aria-hidden={true}
-            className="manicon-svg svg-icon--circlePlus32"
-            fill="currentColor"
-            height={null}
-            viewBox="0 0 32 32"
-            width={null}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M9.99999998,16.5 L9.99999998,15.5 L22,15.5 L22,16.5 L9.99999998,16.5 Z M16.5,22 L15.5,22 L15.5,9.99999998 L16.5,9.99999998 L16.5,22 Z M16,27 C9.92486773,27 4.99999997,22.0751323 4.99999997,16 C4.99999997,9.92486773 9.92486773,4.99999997 16,4.99999997 C22.0751323,4.99999997 27,9.92486773 27,16 C27,22.0751323 22.0751323,27 16,27 Z M16,26 C21.5228475,26 26,21.5228475 26,16 C26,10.4771525 21.5228475,5.99999997 16,5.99999997 C10.4771525,5.99999997 5.99999997,10.4771525 5.99999997,16 C5.99999997,21.5228475 10.4771525,26 16,26 Z"
-            />
-          </svg>
-          Add a new resource
-        </a>
-        <a
-          className="entity-list__button"
-          href="/backend/projects/1/resource-import"
-          onClick={[Function]}
-        >
-          <svg
-            aria-hidden={true}
-            className="manicon-svg svg-icon--BEResourcesBoxes64"
-            fill="currentColor"
-            height={null}
-            viewBox="0 0 64 64"
-            width={null}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M19.381104,42.2037638 L21.381096,42.2094362 L21.340396,56.5594363 L19.340404,56.5537638 L19.381104,42.2037638 Z M7.94412447,36.1830973 L8.94387546,34.4509027 L20.8809755,41.3405027 L19.8812245,43.0726973 L7.94412447,36.1830973 Z M42.957404,42.2037638 L44.957396,42.2094362 L44.916696,56.5594363 L42.916704,56.5537638 L42.957404,42.2037638 Z M55.0536703,34.5801239 L56.0583298,36.3094761 L44.4190298,43.0712761 L43.4143702,41.3419239 L55.0536703,34.5801239 Z M30.9816031,49.2185031 L31.0183892,36.0214972 L20.0846359,29.7105681 L9.44235692,35.8934954 L9.40465112,49.0905261 L20.3383857,55.4014444 L30.9816031,49.2185031 Z M7.40134881,50.2434739 L7.44564301,34.7405046 L20.0813641,27.3994319 L33.0216108,34.8685028 L32.9783969,50.3714969 L20.3416143,57.7125557 L7.40134881,50.2434739 Z M31.4773702,34.5801239 L32.4820298,36.3094761 L20.8427298,43.0712761 L19.8380702,41.3419239 L31.4773702,34.5801239 Z M54.5576431,49.2185047 L54.5953489,36.0214739 L43.6616143,29.7105557 L33.0183969,35.8934969 L32.9816108,49.0905029 L43.9153641,55.4014319 L54.5576431,49.2185047 Z M30.9783892,50.2434972 L31.0216031,34.7405031 L43.6583857,27.3994443 L56.5986512,34.8685261 L56.554357,50.3714954 L43.9186359,57.7125682 L30.9783892,50.2434972 Z M31.5204245,36.1830973 L32.5201755,34.4509027 L44.4572755,41.3405027 L43.4575245,43.0726973 L31.5204245,36.1830973 Z M42.6616031,28.1065031 L42.6983892,14.9094971 L31.7646359,8.59856809 L21.1223569,14.7814953 L21.0846511,27.9785261 L32.0183857,34.2894443 L42.6616031,28.1065031 Z M19.0813488,29.1314739 L19.125643,13.6285046 L31.7613641,6.28743184 L44.7016109,13.7565028 L44.6583969,29.2594969 L32.0216143,36.6005557 L19.0813488,29.1314739 Z M31.061004,21.0919638 L33.060996,21.0976362 L33.020296,35.4476362 L31.020304,35.4419638 L31.061004,21.0919638 Z M19.6241159,15.0711923 L20.6238841,13.3390077 L32.5608841,20.2287077 L31.5611159,21.9608923 L19.6241159,15.0711923 Z M43.1572702,13.4683239 L44.1619298,15.1976761 L32.5226298,21.9594761 L31.5179702,20.2301239 L43.1572702,13.4683239 Z"
-            />
-          </svg>
-          Bulk add resources
-        </a>
-      </div>
-      <div
-        className="entity-list__count"
-      >
-        <p
-          className="list-total"
-        >
-          Showing 
-          <span>
-            1-1
-          </span>
-           of 
-          <span>
-            2
-          </span>
-           resources: 
-        </p>
-      </div>
-    </div>
-    <ul
-      className="entity-list__list entity-list__list--rows"
-    >
-      <li
-        className="entity-row entity-list__entity"
-      >
-        <a
-          aria-describedby="undefined1-describedby"
-          className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
-          href="/backend/projects/resource/2"
-          onClick={[Function]}
-        >
-          <div
-            className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
+          <a
+            aria-describedby="undefined1-describedby"
+            className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
+            href="/backend/projects/resource/2"
+            onClick={[Function]}
           >
             <div
-              className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
+              className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
             >
-              <svg
-                className="manicon-svg svg-icon--resourceImage64"
-                fill="currentColor"
-                viewBox="0 0 64 64"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
               >
-                <path
-                  d="M5.99999996,13 L5.99999996,51 L58,51 L58,13 L5.99999996,13 Z M60,11 L60,53 L3.99999996,53 L3.99999996,11 L60,11 Z M45.114319,36.7052772 C46.0891538,35.776283 47.4070852,35.2956435 48.7511053,35.3789689 C50.0951254,35.4622943 51.3435959,36.1020435 52.2251484,37.1814515 L59.8029485,47.3896515 L58.1970516,48.5817485 L50.6481834,38.4106653 C50.1480528,37.7992777 49.4157245,37.4240133 48.6273486,37.3751363 C47.8389728,37.3262592 47.0659001,37.608193 46.5124285,38.1351833 L39.6414917,45.0279719 L38.9387682,44.1921171 L25.4012973,28.0888039 C24.8721474,27.5066301 24.1255162,27.1696052 23.3388857,27.1578435 C22.5522552,27.1460819 21.7958816,27.4606339 21.2723966,28.0022606 L5.74239658,45.2113607 L4.25760333,43.8714394 L19.8104371,26.6378727 C20.7408786,25.6737527 22.029067,25.1380356 23.3687863,25.1580671 C24.7085055,25.1780985 25.9801016,25.7520894 26.9067318,26.7726829 L39.7669351,42.06926 L45.114319,36.7052772 Z M45.0127,29.9813 C41.6989915,29.9813 39.0127,27.2950085 39.0127,23.9813 C39.0127,20.6675915 41.6989915,17.9813 45.0127,17.9813 C48.3264085,17.9813 51.0127,20.6675915 51.0127,23.9813 C51.0127,27.2950085 48.3264085,29.9813 45.0127,29.9813 Z M45.0127,27.9813 C47.221839,27.9813 49.0127,26.190439 49.0127,23.9813 C49.0127,21.772161 47.221839,19.9813 45.0127,19.9813 C42.803561,19.9813 41.0127,21.772161 41.0127,23.9813 C41.0127,26.190439 42.803561,27.9813 45.0127,27.9813 Z"
-                />
-              </svg>
-            </div>
-            <div
-              className="entity-row__text entity-row__text--in-rows"
-            >
-              <h3
-                className="entity-row__title entity-row__title--in-rows"
-              >
-                <span
-                  className="entity-row__title-inner"
+                <svg
+                  className="manicon-svg svg-icon--resourceImage64"
+                  fill="currentColor"
+                  viewBox="0 0 64 64"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  Image
-                </span>
-                <span
-                  className="entity-row__labels"
+                  <path
+                    d="M5.99999996,13 L5.99999996,51 L58,51 L58,13 L5.99999996,13 Z M60,11 L60,53 L3.99999996,53 L3.99999996,11 L60,11 Z M45.114319,36.7052772 C46.0891538,35.776283 47.4070852,35.2956435 48.7511053,35.3789689 C50.0951254,35.4622943 51.3435959,36.1020435 52.2251484,37.1814515 L59.8029485,47.3896515 L58.1970516,48.5817485 L50.6481834,38.4106653 C50.1480528,37.7992777 49.4157245,37.4240133 48.6273486,37.3751363 C47.8389728,37.3262592 47.0659001,37.608193 46.5124285,38.1351833 L39.6414917,45.0279719 L38.9387682,44.1921171 L25.4012973,28.0888039 C24.8721474,27.5066301 24.1255162,27.1696052 23.3388857,27.1578435 C22.5522552,27.1460819 21.7958816,27.4606339 21.2723966,28.0022606 L5.74239658,45.2113607 L4.25760333,43.8714394 L19.8104371,26.6378727 C20.7408786,25.6737527 22.029067,25.1380356 23.3687863,25.1580671 C24.7085055,25.1780985 25.9801016,25.7520894 26.9067318,26.7726829 L39.7669351,42.06926 L45.114319,36.7052772 Z M45.0127,29.9813 C41.6989915,29.9813 39.0127,27.2950085 39.0127,23.9813 C39.0127,20.6675915 41.6989915,17.9813 45.0127,17.9813 C48.3264085,17.9813 51.0127,20.6675915 51.0127,23.9813 C51.0127,27.2950085 48.3264085,29.9813 45.0127,29.9813 Z M45.0127,27.9813 C47.221839,27.9813 49.0127,26.190439 49.0127,23.9813 C49.0127,21.772161 47.221839,19.9813 45.0127,19.9813 C42.803561,19.9813 41.0127,21.772161 41.0127,23.9813 C41.0127,26.190439 42.803561,27.9813 45.0127,27.9813 Z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="entity-row__text entity-row__text--in-rows"
+              >
+                <h3
+                  className="entity-row__title entity-row__title--in-rows"
                 >
                   <span
-                    className="entity-row__label"
+                    className="entity-row__title-inner"
                   >
-                    image
+                    Image
                   </span>
-                </span>
-                <span
-                  className="aria-describedby"
-                  id="undefined1-describedby"
+                  <span
+                    className="entity-row__labels"
+                  >
+                    <span
+                      className="entity-row__label"
+                    >
+                      image
+                    </span>
+                  </span>
+                  <span
+                    className="aria-describedby"
+                    id="undefined1-describedby"
+                  >
+                    View Image
+                  </span>
+                </h3>
+                <div
+                  className="entity-row__meta entity-row__meta--in-rows"
                 >
-                  View Image
-                </span>
-              </h3>
-              <div
-                className="entity-row__meta entity-row__meta--in-rows"
-              >
-                <time
-                  dateTime="2017-04-24"
-                >
-                  Created April 24, 2017
-                </time>
+                  <time
+                    dateTime="2017-04-24"
+                  >
+                    Created April 24, 2017
+                  </time>
+                </div>
               </div>
             </div>
-          </div>
-        </a>
-      </li>
-      <li
-        className="entity-row entity-list__entity"
-      >
-        <a
-          aria-describedby="undefined1-describedby"
-          className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
-          href="/backend/projects/resource/3"
-          onClick={[Function]}
+          </a>
+        </li>
+        <li
+          className="entity-row entity-list__entity"
         >
-          <div
-            className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
+          <a
+            aria-describedby="undefined1-describedby"
+            className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
+            href="/backend/projects/resource/3"
+            onClick={[Function]}
           >
             <div
-              className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
+              className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
             >
-              <svg
-                className="manicon-svg svg-icon--resourceImage64"
-                fill="currentColor"
-                viewBox="0 0 64 64"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
               >
-                <path
-                  d="M5.99999996,13 L5.99999996,51 L58,51 L58,13 L5.99999996,13 Z M60,11 L60,53 L3.99999996,53 L3.99999996,11 L60,11 Z M45.114319,36.7052772 C46.0891538,35.776283 47.4070852,35.2956435 48.7511053,35.3789689 C50.0951254,35.4622943 51.3435959,36.1020435 52.2251484,37.1814515 L59.8029485,47.3896515 L58.1970516,48.5817485 L50.6481834,38.4106653 C50.1480528,37.7992777 49.4157245,37.4240133 48.6273486,37.3751363 C47.8389728,37.3262592 47.0659001,37.608193 46.5124285,38.1351833 L39.6414917,45.0279719 L38.9387682,44.1921171 L25.4012973,28.0888039 C24.8721474,27.5066301 24.1255162,27.1696052 23.3388857,27.1578435 C22.5522552,27.1460819 21.7958816,27.4606339 21.2723966,28.0022606 L5.74239658,45.2113607 L4.25760333,43.8714394 L19.8104371,26.6378727 C20.7408786,25.6737527 22.029067,25.1380356 23.3687863,25.1580671 C24.7085055,25.1780985 25.9801016,25.7520894 26.9067318,26.7726829 L39.7669351,42.06926 L45.114319,36.7052772 Z M45.0127,29.9813 C41.6989915,29.9813 39.0127,27.2950085 39.0127,23.9813 C39.0127,20.6675915 41.6989915,17.9813 45.0127,17.9813 C48.3264085,17.9813 51.0127,20.6675915 51.0127,23.9813 C51.0127,27.2950085 48.3264085,29.9813 45.0127,29.9813 Z M45.0127,27.9813 C47.221839,27.9813 49.0127,26.190439 49.0127,23.9813 C49.0127,21.772161 47.221839,19.9813 45.0127,19.9813 C42.803561,19.9813 41.0127,21.772161 41.0127,23.9813 C41.0127,26.190439 42.803561,27.9813 45.0127,27.9813 Z"
-                />
-              </svg>
-            </div>
-            <div
-              className="entity-row__text entity-row__text--in-rows"
-            >
-              <h3
-                className="entity-row__title entity-row__title--in-rows"
-              >
-                <span
-                  className="entity-row__title-inner"
+                <svg
+                  className="manicon-svg svg-icon--resourceImage64"
+                  fill="currentColor"
+                  viewBox="0 0 64 64"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  Image
-                </span>
-                <span
-                  className="entity-row__labels"
+                  <path
+                    d="M5.99999996,13 L5.99999996,51 L58,51 L58,13 L5.99999996,13 Z M60,11 L60,53 L3.99999996,53 L3.99999996,11 L60,11 Z M45.114319,36.7052772 C46.0891538,35.776283 47.4070852,35.2956435 48.7511053,35.3789689 C50.0951254,35.4622943 51.3435959,36.1020435 52.2251484,37.1814515 L59.8029485,47.3896515 L58.1970516,48.5817485 L50.6481834,38.4106653 C50.1480528,37.7992777 49.4157245,37.4240133 48.6273486,37.3751363 C47.8389728,37.3262592 47.0659001,37.608193 46.5124285,38.1351833 L39.6414917,45.0279719 L38.9387682,44.1921171 L25.4012973,28.0888039 C24.8721474,27.5066301 24.1255162,27.1696052 23.3388857,27.1578435 C22.5522552,27.1460819 21.7958816,27.4606339 21.2723966,28.0022606 L5.74239658,45.2113607 L4.25760333,43.8714394 L19.8104371,26.6378727 C20.7408786,25.6737527 22.029067,25.1380356 23.3687863,25.1580671 C24.7085055,25.1780985 25.9801016,25.7520894 26.9067318,26.7726829 L39.7669351,42.06926 L45.114319,36.7052772 Z M45.0127,29.9813 C41.6989915,29.9813 39.0127,27.2950085 39.0127,23.9813 C39.0127,20.6675915 41.6989915,17.9813 45.0127,17.9813 C48.3264085,17.9813 51.0127,20.6675915 51.0127,23.9813 C51.0127,27.2950085 48.3264085,29.9813 45.0127,29.9813 Z M45.0127,27.9813 C47.221839,27.9813 49.0127,26.190439 49.0127,23.9813 C49.0127,21.772161 47.221839,19.9813 45.0127,19.9813 C42.803561,19.9813 41.0127,21.772161 41.0127,23.9813 C41.0127,26.190439 42.803561,27.9813 45.0127,27.9813 Z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="entity-row__text entity-row__text--in-rows"
+              >
+                <h3
+                  className="entity-row__title entity-row__title--in-rows"
                 >
                   <span
-                    className="entity-row__label"
+                    className="entity-row__title-inner"
                   >
-                    image
+                    Image
                   </span>
-                </span>
-                <span
-                  className="aria-describedby"
-                  id="undefined1-describedby"
+                  <span
+                    className="entity-row__labels"
+                  >
+                    <span
+                      className="entity-row__label"
+                    >
+                      image
+                    </span>
+                  </span>
+                  <span
+                    className="aria-describedby"
+                    id="undefined1-describedby"
+                  >
+                    View Image
+                  </span>
+                </h3>
+                <div
+                  className="entity-row__meta entity-row__meta--in-rows"
                 >
-                  View Image
-                </span>
-              </h3>
-              <div
-                className="entity-row__meta entity-row__meta--in-rows"
-              >
-                <time
-                  dateTime="2017-04-24"
-                >
-                  Created April 24, 2017
-                </time>
+                  <time
+                    dateTime="2017-04-24"
+                  >
+                    Created April 24, 2017
+                  </time>
+                </div>
               </div>
             </div>
-          </div>
-        </a>
-      </li>
-    </ul>
-    <div
-      className="entity-list__pagination"
-    >
-      <nav
-        aria-label="Pagination"
-        className="list-pagination"
+          </a>
+        </li>
+      </ul>
+      <div
+        className="entity-list__pagination"
       >
-        <ul
-          className="list-pagination__columns"
+        <nav
+          aria-label="Pagination"
+          className="list-pagination"
         >
-          <li
-            className="list-pagination__column"
+          <ul
+            className="list-pagination__columns"
           >
-            <ul>
-              <li
-                className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
-              >
-                <a
-                  disabled={true}
-                  href="#entities-list1"
-                  onClick={[Function]}
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="manicon-svg svg-icon--arrowLongLeft16"
-                    fill="currentColor"
-                    height={null}
-                    viewBox="0 0 24 16"
-                    width={null}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                      transform="rotate(180 12 8)"
-                    />
-                  </svg>
-                  <span
-                    className="list-pagination__icon-label"
-                  >
-                    PREV
-                  </span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li
-            className="list-pagination__column-middle"
-          >
-            <ul
-              className="list-pagination__pages"
+            <li
+              className="list-pagination__column"
             >
-              <li
-                className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
-              >
-                <a
-                  href="#entities-list1"
-                  onClick={[Function]}
+              <ul>
+                <li
+                  className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
                 >
-                  <span
-                    aria-hidden="true"
+                  <a
+                    disabled={true}
+                    href="#entities-list1"
+                    onClick={[Function]}
                   >
-                    1
-                  </span>
-                  <span
-                    className="screen-reader-text"
-                  >
-                    Go to page: 
-                    1
-                  </span>
-                </a>
-              </li>
-              <li
-                className="list-pagination__page list-pagination__page--ordinal"
+                    <svg
+                      aria-hidden={true}
+                      className="manicon-svg svg-icon--arrowLongLeft16"
+                      fill="currentColor"
+                      height={null}
+                      viewBox="0 0 24 16"
+                      width={null}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                        transform="rotate(180 12 8)"
+                      />
+                    </svg>
+                    <span
+                      className="list-pagination__icon-label"
+                    >
+                      PREV
+                    </span>
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              className="list-pagination__column-middle"
+            >
+              <ul
+                className="list-pagination__pages"
               >
-                <a
-                  href="#entities-list1"
-                  onClick={[Function]}
+                <li
+                  className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                 >
-                  <span
-                    aria-hidden="true"
+                  <a
+                    href="#entities-list1"
+                    onClick={[Function]}
                   >
-                    2
-                  </span>
-                  <span
-                    className="screen-reader-text"
-                  >
-                    Go to page: 
-                    2
-                  </span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li
-            className="list-pagination__column"
-          >
-            <ul>
-              <li
-                className="list-pagination__page list-pagination__page--next"
-              >
-                <a
-                  href="#entities-list1"
-                  onClick={[Function]}
+                    <span
+                      aria-hidden="true"
+                    >
+                      1
+                    </span>
+                    <span
+                      className="screen-reader-text"
+                    >
+                      Go to page: 
+                      1
+                    </span>
+                  </a>
+                </li>
+                <li
+                  className="list-pagination__page list-pagination__page--ordinal"
                 >
-                  <span
-                    className="list-pagination__icon-label"
+                  <a
+                    href="#entities-list1"
+                    onClick={[Function]}
                   >
-                    NEXT
-                  </span>
-                  <svg
-                    aria-hidden={true}
-                    className="manicon-svg svg-icon--arrowLongRight16"
-                    fill="currentColor"
-                    height={null}
-                    viewBox="0 0 24 16"
-                    width={null}
-                    xmlns="http://www.w3.org/2000/svg"
+                    <span
+                      aria-hidden="true"
+                    >
+                      2
+                    </span>
+                    <span
+                      className="screen-reader-text"
+                    >
+                      Go to page: 
+                      2
+                    </span>
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              className="list-pagination__column"
+            >
+              <ul>
+                <li
+                  className="list-pagination__page list-pagination__page--next"
+                >
+                  <a
+                    href="#entities-list1"
+                    onClick={[Function]}
                   >
-                    <path
-                      d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                    />
-                  </svg>
-                </a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </nav>
+                    <span
+                      className="list-pagination__icon-label"
+                    >
+                      NEXT
+                    </span>
+                    <svg
+                      aria-hidden={true}
+                      className="manicon-svg svg-icon--arrowLongRight16"
+                      fill="currentColor"
+                      height={null}
+                      viewBox="0 0 24 16"
+                      width={null}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                      />
+                    </svg>
+                  </a>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </nav>
+      </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;

--- a/client/src/backend/containers/resource-collection/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/backend/containers/resource-collection/__tests__/__snapshots__/Resources-test.js.snap
@@ -1,289 +1,299 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Backend ResourceCollection Resources Container renders correctly 1`] = `
-<div
-  className="entity-list"
-  id="entities-list1"
->
-  <h2
-    className="entity-list__title-block entity-list__title"
-  >
-    <figure
-      className="entity-list__title-icon"
-    >
-      <svg
-        aria-hidden={true}
-        className="manicon-svg svg-icon--resourceCollection64"
-        fill="currentColor"
-        height={null}
-        viewBox="0 0 64 64"
-        width={null}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M24,39 L24,45 L40,45 L40,39 L24,39 Z M42,37 L42,47 L22,47 L22,37 L42,37 Z M56,20.4707664 L47.6615077,14 L16.3394622,14 L7.99999996,20.4707998 L7.99999996,25 L56,25 L56,20.4707664 Z M58,27 L5.99999996,27 L5.99999996,19.4912002 L15.6545377,12 L48.3464923,12 L58,19.4912335 L58,27 Z M57,19 L57,21 L6.99999996,21 L6.99999996,19 L57,19 Z M54,52 L54,26 L56,26 L56,54 L7.99999996,54 L7.99999996,26 L9.99999997,26 L9.99999997,52 L54,52 Z M34.998,26.0006 L36.998,26.0006 C36.9980001,27.7862134 36.0453867,29.4361883 34.499,30.3289951 C32.9526134,31.2218018 31.0473866,31.2218018 29.501,30.3289951 C27.9546133,29.4361883 27.0019999,27.7862134 27.002,26.0006 L29.002,26.0006 C29.002,27.0716823 29.5734155,28.0614031 30.501,28.5969443 C31.4285844,29.1324854 32.5714156,29.1324854 33.499,28.5969443 C34.4265845,28.0614031 34.998,27.0716823 34.998,26.0006 Z"
-        />
-      </svg>
-    </figure>
-    Resources
-    <button
-      className="utility-button"
-      onClick={[Function]}
-      style={
-        Object {
-          "marginLeft": 3,
-        }
-      }
-    >
-      <span
-        className="utility-button__text"
-      >
-        Show collection only
-      </span>
-    </button>
-  </h2>
+Array [
   <div
-    className="entity-list__contents-wrapper"
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
+  <div
+    className="entity-list"
+    id="entities-list1"
   >
-    <div
-      className="entity-list__search entity-list-search"
+    <h2
+      className="entity-list__title-block entity-list__title"
     >
-      <form
-        onSubmit={[Function]}
+      <figure
+        className="entity-list__title-icon"
       >
-        <div
-          className="entity-list-search__keyword-row"
+        <svg
+          aria-hidden={true}
+          className="manicon-svg svg-icon--resourceCollection64"
+          fill="currentColor"
+          height={null}
+          viewBox="0 0 64 64"
+          width={null}
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <button
-            className="entity-list-search__search-button"
-          >
-            <svg
-              aria-hidden={true}
-              className="manicon-svg manicon-magnify svg-icon--search16"
-              fill="currentColor"
-              height={null}
-              viewBox="0 0 16 16"
-              width={null}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
-              />
-            </svg>
-            <span
-              className="screen-reader-text"
-            >
-              Search
-            </span>
-          </button>
-          <div
-            className="entity-list-search__keyword-input-wrapper"
-          >
-            <label
-              className="screen-reader-text"
-              htmlFor="list-search-1"
-            >
-              Enter Search Criteria
-            </label>
-            <input
-              className="entity-list-search__keyword-input"
-              id="list-search-1"
-              onChange={[Function]}
-              placeholder="Search..."
-              type="text"
-              value=""
-            />
-          </div>
-          <button
-            className="entity-list-search__text-button"
-            onClick={[Function]}
-          >
-            Reset
-          </button>
-          <button
-            className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
-            onClick={[Function]}
-          >
-            Options
-          </button>
-        </div>
-      </form>
-      <div
-        className="ReactCollapse--collapse"
+          <path
+            d="M24,39 L24,45 L40,45 L40,39 L24,39 Z M42,37 L42,47 L22,47 L22,37 L42,37 Z M56,20.4707664 L47.6615077,14 L16.3394622,14 L7.99999996,20.4707998 L7.99999996,25 L56,25 L56,20.4707664 Z M58,27 L5.99999996,27 L5.99999996,19.4912002 L15.6545377,12 L48.3464923,12 L58,19.4912335 L58,27 Z M57,19 L57,21 L6.99999996,21 L6.99999996,19 L57,19 Z M54,52 L54,26 L56,26 L56,54 L7.99999996,54 L7.99999996,26 L9.99999997,26 L9.99999997,52 L54,52 Z M34.998,26.0006 L36.998,26.0006 C36.9980001,27.7862134 36.0453867,29.4361883 34.499,30.3289951 C32.9526134,31.2218018 31.0473866,31.2218018 29.501,30.3289951 C27.9546133,29.4361883 27.0019999,27.7862134 27.002,26.0006 L29.002,26.0006 C29.002,27.0716823 29.5734155,28.0614031 30.501,28.5969443 C31.4285844,29.1324854 32.5714156,29.1324854 33.499,28.5969443 C34.4265845,28.0614031 34.998,27.0716823 34.998,26.0006 Z"
+          />
+        </svg>
+      </figure>
+      Resources
+      <button
+        className="utility-button"
+        onClick={[Function]}
         style={
           Object {
-            "height": 0,
-            "overflow": "hidden",
+            "marginLeft": 3,
           }
         }
       >
-        <div
-          className="ReactCollapse--content"
+        <span
+          className="utility-button__text"
         >
-          <div>
-            <div
-              className="entity-list-search__options entity-list-search__options--horizontal"
+          Show collection only
+        </span>
+      </button>
+    </h2>
+    <div
+      className="entity-list__contents-wrapper"
+    >
+      <div
+        className="entity-list__search entity-list-search"
+      >
+        <form
+          onSubmit={[Function]}
+        >
+          <div
+            className="entity-list-search__keyword-row"
+          >
+            <button
+              className="entity-list-search__search-button"
             >
+              <svg
+                aria-hidden={true}
+                className="manicon-svg manicon-magnify svg-icon--search16"
+                fill="currentColor"
+                height={null}
+                viewBox="0 0 16 16"
+                width={null}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
+                />
+              </svg>
+              <span
+                className="screen-reader-text"
+              >
+                Search
+              </span>
+            </button>
+            <div
+              className="entity-list-search__keyword-input-wrapper"
+            >
+              <label
+                className="screen-reader-text"
+                htmlFor="list-search-1"
+              >
+                Enter Search Criteria
+              </label>
+              <input
+                className="entity-list-search__keyword-input"
+                id="list-search-1"
+                onChange={[Function]}
+                placeholder="Search..."
+                type="text"
+                value=""
+              />
+            </div>
+            <button
+              className="entity-list-search__text-button"
+              onClick={[Function]}
+            >
+              Reset
+            </button>
+            <button
+              aria-expanded={false}
+              aria-haspopup={true}
+              className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
+              onClick={[Function]}
+            >
+              Options
+            </button>
+          </div>
+        </form>
+        <div
+          className="ReactCollapse--collapse"
+          style={
+            Object {
+              "height": 0,
+              "overflow": "hidden",
+            }
+          }
+        >
+          <div
+            className="ReactCollapse--content"
+          >
+            <div>
               <div
-                className="entity-list-search__option entity-list-search__option--horizontal"
+                className="entity-list-search__options entity-list-search__options--horizontal"
               >
                 <div
-                  className="entity-list-search__option-inner"
+                  className="entity-list-search__option entity-list-search__option--horizontal"
                 >
-                  <span
-                    className="entity-list-search__options-label "
-                  >
-                    Filter Results:
-                  </span>
                   <div
-                    className="entity-list-search__select-wrapper"
+                    className="entity-list-search__option-inner"
                   >
-                    <select
-                      id="list-search-1"
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="entity-list-search__options-label "
                     >
-                      <option
+                      Filter Results:
+                    </span>
+                    <div
+                      className="entity-list-search__select-wrapper"
+                    >
+                      <select
+                        id="list-search-1"
+                        onChange={[Function]}
                         value=""
                       >
-                        Select a tag
-                      </option>
-                    </select>
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--disclosureDown24"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 24"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <polygon
-                        points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
-                      />
-                    </svg>
+                        <option
+                          value=""
+                        >
+                          Select a tag
+                        </option>
+                      </select>
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--disclosureDown24"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 24"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polygon
+                          points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                        />
+                      </svg>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                className="entity-list-search__option entity-list-search__option--horizontal"
-              >
                 <div
-                  className="entity-list-search__option-inner"
+                  className="entity-list-search__option entity-list-search__option--horizontal"
                 >
-                  <span
-                    className="entity-list-search__options-label entity-list-search__options-label--empty"
-                  >
-                     
-                  </span>
                   <div
-                    className="entity-list-search__select-wrapper"
+                    className="entity-list-search__option-inner"
                   >
-                    <select
-                      id="list-search-1"
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="entity-list-search__options-label entity-list-search__options-label--empty"
                     >
-                      <option
+                       
+                    </span>
+                    <div
+                      className="entity-list-search__select-wrapper"
+                    >
+                      <select
+                        id="list-search-1"
+                        onChange={[Function]}
                         value=""
                       >
-                        Select a type
-                      </option>
-                    </select>
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--disclosureDown24"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 24"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <polygon
-                        points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
-                      />
-                    </svg>
+                        <option
+                          value=""
+                        >
+                          Select a type
+                        </option>
+                      </select>
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--disclosureDown24"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 24"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polygon
+                          points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                        />
+                      </svg>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                className="entity-list-search__option entity-list-search__option--horizontal"
-              >
                 <div
-                  className="entity-list-search__option-inner"
+                  className="entity-list-search__option entity-list-search__option--horizontal"
                 >
-                  <span
-                    className="entity-list-search__options-label entity-list-search__options-label--empty"
-                  >
-                     
-                  </span>
                   <div
-                    className="entity-list-search__select-wrapper"
+                    className="entity-list-search__option-inner"
                   >
-                    <select
-                      id="list-search-1"
-                      onChange={[Function]}
-                      value=""
-                    />
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--disclosureDown24"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 24"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
+                    <span
+                      className="entity-list-search__options-label entity-list-search__options-label--empty"
                     >
-                      <polygon
-                        points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                       
+                    </span>
+                    <div
+                      className="entity-list-search__select-wrapper"
+                    >
+                      <select
+                        id="list-search-1"
+                        onChange={[Function]}
+                        value=""
                       />
-                    </svg>
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--disclosureDown24"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 24"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polygon
+                          points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                        />
+                      </svg>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                className="entity-list-search__option entity-list-search__option--horizontal"
-              >
                 <div
-                  className="entity-list-search__option-inner"
+                  className="entity-list-search__option entity-list-search__option--horizontal"
                 >
-                  <span
-                    className="entity-list-search__options-label"
-                  >
-                    Order Results:
-                  </span>
                   <div
-                    className="entity-list-search__select-wrapper"
+                    className="entity-list-search__option-inner"
                   >
-                    <select
-                      id="list-search-1"
-                      onChange={[Function]}
-                      value="title"
+                    <span
+                      className="entity-list-search__options-label"
                     >
-                      <option
+                      Order Results:
+                    </span>
+                    <div
+                      className="entity-list-search__select-wrapper"
+                    >
+                      <select
+                        id="list-search-1"
+                        onChange={[Function]}
                         value="title"
                       >
-                        Alphabetical by title
-                      </option>
-                      <option
-                        value="created_at"
+                        <option
+                          value="title"
+                        >
+                          Alphabetical by title
+                        </option>
+                        <option
+                          value="created_at"
+                        >
+                          Newest resources first
+                        </option>
+                      </select>
+                      <svg
+                        aria-hidden={true}
+                        className="manicon-svg svg-icon--disclosureDown24"
+                        fill="currentColor"
+                        height={null}
+                        viewBox="0 0 24 24"
+                        width={null}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        Newest resources first
-                      </option>
-                    </select>
-                    <svg
-                      aria-hidden={true}
-                      className="manicon-svg svg-icon--disclosureDown24"
-                      fill="currentColor"
-                      height={null}
-                      viewBox="0 0 24 24"
-                      width={null}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <polygon
-                        points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
-                      />
-                    </svg>
+                        <polygon
+                          points="20.374 9 21 9.78 12 17 3 9.78 3.626 9 12 15.718"
+                        />
+                      </svg>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -291,341 +301,350 @@ exports[`Backend ResourceCollection Resources Container renders correctly 1`] = 
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="entity-list__header"
-    >
       <div
-        className="entity-list__count"
+        className="entity-list__header"
       >
-        <p
-          className="list-total"
+        <div
+          className="entity-list__count"
         >
-          Showing 
-          <span>
-            1-1
-          </span>
-           of 
-          <span>
-            2
-          </span>
-           resources: 
-        </p>
+          <p
+            aria-hidden={true}
+            className="list-total"
+          >
+            Showing 
+            <span>
+              1-1
+            </span>
+             of 
+            <span>
+              2
+            </span>
+             resources: 
+          </p>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          >
+            2 resources. Showing results 1 through 1.
+          </div>
+        </div>
+      </div>
+      <ul
+        className="entity-list__list entity-list__list--rows"
+      >
+        <li
+          className="entity-row entity-list__entity"
+        >
+          <a
+            aria-describedby="undefined1-describedby"
+            className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
+            href="/backend/projects/resource/3"
+            onClick={[Function]}
+          >
+            <div
+              className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
+            >
+              <div
+                className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
+              >
+                <svg
+                  className="manicon-svg svg-icon--resourceImage64"
+                  fill="currentColor"
+                  viewBox="0 0 64 64"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.99999996,13 L5.99999996,51 L58,51 L58,13 L5.99999996,13 Z M60,11 L60,53 L3.99999996,53 L3.99999996,11 L60,11 Z M45.114319,36.7052772 C46.0891538,35.776283 47.4070852,35.2956435 48.7511053,35.3789689 C50.0951254,35.4622943 51.3435959,36.1020435 52.2251484,37.1814515 L59.8029485,47.3896515 L58.1970516,48.5817485 L50.6481834,38.4106653 C50.1480528,37.7992777 49.4157245,37.4240133 48.6273486,37.3751363 C47.8389728,37.3262592 47.0659001,37.608193 46.5124285,38.1351833 L39.6414917,45.0279719 L38.9387682,44.1921171 L25.4012973,28.0888039 C24.8721474,27.5066301 24.1255162,27.1696052 23.3388857,27.1578435 C22.5522552,27.1460819 21.7958816,27.4606339 21.2723966,28.0022606 L5.74239658,45.2113607 L4.25760333,43.8714394 L19.8104371,26.6378727 C20.7408786,25.6737527 22.029067,25.1380356 23.3687863,25.1580671 C24.7085055,25.1780985 25.9801016,25.7520894 26.9067318,26.7726829 L39.7669351,42.06926 L45.114319,36.7052772 Z M45.0127,29.9813 C41.6989915,29.9813 39.0127,27.2950085 39.0127,23.9813 C39.0127,20.6675915 41.6989915,17.9813 45.0127,17.9813 C48.3264085,17.9813 51.0127,20.6675915 51.0127,23.9813 C51.0127,27.2950085 48.3264085,29.9813 45.0127,29.9813 Z M45.0127,27.9813 C47.221839,27.9813 49.0127,26.190439 49.0127,23.9813 C49.0127,21.772161 47.221839,19.9813 45.0127,19.9813 C42.803561,19.9813 41.0127,21.772161 41.0127,23.9813 C41.0127,26.190439 42.803561,27.9813 45.0127,27.9813 Z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="entity-row__text entity-row__text--in-rows"
+              >
+                <h3
+                  className="entity-row__title entity-row__title--in-rows"
+                >
+                  <span
+                    className="entity-row__title-inner"
+                  >
+                    Image
+                  </span>
+                  <span
+                    className="entity-row__labels"
+                  >
+                    <span
+                      className="entity-row__label"
+                    >
+                      image
+                    </span>
+                  </span>
+                  <span
+                    className="aria-describedby"
+                    id="undefined1-describedby"
+                  >
+                    View Image
+                  </span>
+                </h3>
+                <div
+                  className="entity-row__meta entity-row__meta--in-rows"
+                >
+                  <time
+                    dateTime="2017-04-24"
+                  >
+                    Created April 24, 2017
+                  </time>
+                </div>
+              </div>
+              <div
+                className="entity-row__utility"
+              >
+                <div
+                  className="form-input"
+                >
+                  <div
+                    className="toggle-indicator"
+                  >
+                    <div
+                      className="boolean-primary checked"
+                      onClick={[Function]}
+                      role="button"
+                      tabIndex="0"
+                    >
+                      <span
+                        className="screen-reader-text"
+                      >
+                        Remove Resource from Collection
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </a>
+        </li>
+        <li
+          className="entity-row entity-list__entity"
+        >
+          <a
+            aria-describedby="undefined1-describedby"
+            className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
+            href="/backend/projects/resource/4"
+            onClick={[Function]}
+          >
+            <div
+              className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
+            >
+              <div
+                className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
+              >
+                <svg
+                  className="manicon-svg svg-icon--resourceImage64"
+                  fill="currentColor"
+                  viewBox="0 0 64 64"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.99999996,13 L5.99999996,51 L58,51 L58,13 L5.99999996,13 Z M60,11 L60,53 L3.99999996,53 L3.99999996,11 L60,11 Z M45.114319,36.7052772 C46.0891538,35.776283 47.4070852,35.2956435 48.7511053,35.3789689 C50.0951254,35.4622943 51.3435959,36.1020435 52.2251484,37.1814515 L59.8029485,47.3896515 L58.1970516,48.5817485 L50.6481834,38.4106653 C50.1480528,37.7992777 49.4157245,37.4240133 48.6273486,37.3751363 C47.8389728,37.3262592 47.0659001,37.608193 46.5124285,38.1351833 L39.6414917,45.0279719 L38.9387682,44.1921171 L25.4012973,28.0888039 C24.8721474,27.5066301 24.1255162,27.1696052 23.3388857,27.1578435 C22.5522552,27.1460819 21.7958816,27.4606339 21.2723966,28.0022606 L5.74239658,45.2113607 L4.25760333,43.8714394 L19.8104371,26.6378727 C20.7408786,25.6737527 22.029067,25.1380356 23.3687863,25.1580671 C24.7085055,25.1780985 25.9801016,25.7520894 26.9067318,26.7726829 L39.7669351,42.06926 L45.114319,36.7052772 Z M45.0127,29.9813 C41.6989915,29.9813 39.0127,27.2950085 39.0127,23.9813 C39.0127,20.6675915 41.6989915,17.9813 45.0127,17.9813 C48.3264085,17.9813 51.0127,20.6675915 51.0127,23.9813 C51.0127,27.2950085 48.3264085,29.9813 45.0127,29.9813 Z M45.0127,27.9813 C47.221839,27.9813 49.0127,26.190439 49.0127,23.9813 C49.0127,21.772161 47.221839,19.9813 45.0127,19.9813 C42.803561,19.9813 41.0127,21.772161 41.0127,23.9813 C41.0127,26.190439 42.803561,27.9813 45.0127,27.9813 Z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="entity-row__text entity-row__text--in-rows"
+              >
+                <h3
+                  className="entity-row__title entity-row__title--in-rows"
+                >
+                  <span
+                    className="entity-row__title-inner"
+                  >
+                    Image
+                  </span>
+                  <span
+                    className="entity-row__labels"
+                  >
+                    <span
+                      className="entity-row__label"
+                    >
+                      image
+                    </span>
+                  </span>
+                  <span
+                    className="aria-describedby"
+                    id="undefined1-describedby"
+                  >
+                    View Image
+                  </span>
+                </h3>
+                <div
+                  className="entity-row__meta entity-row__meta--in-rows"
+                >
+                  <time
+                    dateTime="2017-04-24"
+                  >
+                    Created April 24, 2017
+                  </time>
+                </div>
+              </div>
+              <div
+                className="entity-row__utility"
+              >
+                <div
+                  className="form-input"
+                >
+                  <div
+                    className="toggle-indicator"
+                  >
+                    <div
+                      className="boolean-primary"
+                      onClick={[Function]}
+                      role="button"
+                      tabIndex="0"
+                    >
+                      <span
+                        className="screen-reader-text"
+                      >
+                        Add Resource to Collection
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </a>
+        </li>
+      </ul>
+      <div
+        className="entity-list__pagination"
+      >
+        <nav
+          aria-label="Pagination"
+          className="list-pagination"
+        >
+          <ul
+            className="list-pagination__columns"
+          >
+            <li
+              className="list-pagination__column"
+            >
+              <ul>
+                <li
+                  className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
+                >
+                  <a
+                    disabled={true}
+                    href="#entities-list1"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="manicon-svg svg-icon--arrowLongLeft16"
+                      fill="currentColor"
+                      height={null}
+                      viewBox="0 0 24 16"
+                      width={null}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                        transform="rotate(180 12 8)"
+                      />
+                    </svg>
+                    <span
+                      className="list-pagination__icon-label"
+                    >
+                      PREV
+                    </span>
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              className="list-pagination__column-middle"
+            >
+              <ul
+                className="list-pagination__pages"
+              >
+                <li
+                  className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
+                >
+                  <a
+                    href="#entities-list1"
+                    onClick={[Function]}
+                  >
+                    <span
+                      aria-hidden="true"
+                    >
+                      1
+                    </span>
+                    <span
+                      className="screen-reader-text"
+                    >
+                      Go to page: 
+                      1
+                    </span>
+                  </a>
+                </li>
+                <li
+                  className="list-pagination__page list-pagination__page--ordinal"
+                >
+                  <a
+                    href="#entities-list1"
+                    onClick={[Function]}
+                  >
+                    <span
+                      aria-hidden="true"
+                    >
+                      2
+                    </span>
+                    <span
+                      className="screen-reader-text"
+                    >
+                      Go to page: 
+                      2
+                    </span>
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              className="list-pagination__column"
+            >
+              <ul>
+                <li
+                  className="list-pagination__page list-pagination__page--next"
+                >
+                  <a
+                    href="#entities-list1"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="list-pagination__icon-label"
+                    >
+                      NEXT
+                    </span>
+                    <svg
+                      aria-hidden={true}
+                      className="manicon-svg svg-icon--arrowLongRight16"
+                      fill="currentColor"
+                      height={null}
+                      viewBox="0 0 24 16"
+                      width={null}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                      />
+                    </svg>
+                  </a>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </nav>
       </div>
     </div>
-    <ul
-      className="entity-list__list entity-list__list--rows"
-    >
-      <li
-        className="entity-row entity-list__entity"
-      >
-        <a
-          aria-describedby="undefined1-describedby"
-          className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
-          href="/backend/projects/resource/3"
-          onClick={[Function]}
-        >
-          <div
-            className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
-          >
-            <div
-              className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
-            >
-              <svg
-                className="manicon-svg svg-icon--resourceImage64"
-                fill="currentColor"
-                viewBox="0 0 64 64"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M5.99999996,13 L5.99999996,51 L58,51 L58,13 L5.99999996,13 Z M60,11 L60,53 L3.99999996,53 L3.99999996,11 L60,11 Z M45.114319,36.7052772 C46.0891538,35.776283 47.4070852,35.2956435 48.7511053,35.3789689 C50.0951254,35.4622943 51.3435959,36.1020435 52.2251484,37.1814515 L59.8029485,47.3896515 L58.1970516,48.5817485 L50.6481834,38.4106653 C50.1480528,37.7992777 49.4157245,37.4240133 48.6273486,37.3751363 C47.8389728,37.3262592 47.0659001,37.608193 46.5124285,38.1351833 L39.6414917,45.0279719 L38.9387682,44.1921171 L25.4012973,28.0888039 C24.8721474,27.5066301 24.1255162,27.1696052 23.3388857,27.1578435 C22.5522552,27.1460819 21.7958816,27.4606339 21.2723966,28.0022606 L5.74239658,45.2113607 L4.25760333,43.8714394 L19.8104371,26.6378727 C20.7408786,25.6737527 22.029067,25.1380356 23.3687863,25.1580671 C24.7085055,25.1780985 25.9801016,25.7520894 26.9067318,26.7726829 L39.7669351,42.06926 L45.114319,36.7052772 Z M45.0127,29.9813 C41.6989915,29.9813 39.0127,27.2950085 39.0127,23.9813 C39.0127,20.6675915 41.6989915,17.9813 45.0127,17.9813 C48.3264085,17.9813 51.0127,20.6675915 51.0127,23.9813 C51.0127,27.2950085 48.3264085,29.9813 45.0127,29.9813 Z M45.0127,27.9813 C47.221839,27.9813 49.0127,26.190439 49.0127,23.9813 C49.0127,21.772161 47.221839,19.9813 45.0127,19.9813 C42.803561,19.9813 41.0127,21.772161 41.0127,23.9813 C41.0127,26.190439 42.803561,27.9813 45.0127,27.9813 Z"
-                />
-              </svg>
-            </div>
-            <div
-              className="entity-row__text entity-row__text--in-rows"
-            >
-              <h3
-                className="entity-row__title entity-row__title--in-rows"
-              >
-                <span
-                  className="entity-row__title-inner"
-                >
-                  Image
-                </span>
-                <span
-                  className="entity-row__labels"
-                >
-                  <span
-                    className="entity-row__label"
-                  >
-                    image
-                  </span>
-                </span>
-                <span
-                  className="aria-describedby"
-                  id="undefined1-describedby"
-                >
-                  View Image
-                </span>
-              </h3>
-              <div
-                className="entity-row__meta entity-row__meta--in-rows"
-              >
-                <time
-                  dateTime="2017-04-24"
-                >
-                  Created April 24, 2017
-                </time>
-              </div>
-            </div>
-            <div
-              className="entity-row__utility"
-            >
-              <div
-                className="form-input"
-              >
-                <div
-                  className="toggle-indicator"
-                >
-                  <div
-                    className="boolean-primary checked"
-                    onClick={[Function]}
-                    role="button"
-                    tabIndex="0"
-                  >
-                    <span
-                      className="screen-reader-text"
-                    >
-                      Remove Resource from Collection
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </a>
-      </li>
-      <li
-        className="entity-row entity-list__entity"
-      >
-        <a
-          aria-describedby="undefined1-describedby"
-          className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
-          href="/backend/projects/resource/4"
-          onClick={[Function]}
-        >
-          <div
-            className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
-          >
-            <div
-              className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
-            >
-              <svg
-                className="manicon-svg svg-icon--resourceImage64"
-                fill="currentColor"
-                viewBox="0 0 64 64"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M5.99999996,13 L5.99999996,51 L58,51 L58,13 L5.99999996,13 Z M60,11 L60,53 L3.99999996,53 L3.99999996,11 L60,11 Z M45.114319,36.7052772 C46.0891538,35.776283 47.4070852,35.2956435 48.7511053,35.3789689 C50.0951254,35.4622943 51.3435959,36.1020435 52.2251484,37.1814515 L59.8029485,47.3896515 L58.1970516,48.5817485 L50.6481834,38.4106653 C50.1480528,37.7992777 49.4157245,37.4240133 48.6273486,37.3751363 C47.8389728,37.3262592 47.0659001,37.608193 46.5124285,38.1351833 L39.6414917,45.0279719 L38.9387682,44.1921171 L25.4012973,28.0888039 C24.8721474,27.5066301 24.1255162,27.1696052 23.3388857,27.1578435 C22.5522552,27.1460819 21.7958816,27.4606339 21.2723966,28.0022606 L5.74239658,45.2113607 L4.25760333,43.8714394 L19.8104371,26.6378727 C20.7408786,25.6737527 22.029067,25.1380356 23.3687863,25.1580671 C24.7085055,25.1780985 25.9801016,25.7520894 26.9067318,26.7726829 L39.7669351,42.06926 L45.114319,36.7052772 Z M45.0127,29.9813 C41.6989915,29.9813 39.0127,27.2950085 39.0127,23.9813 C39.0127,20.6675915 41.6989915,17.9813 45.0127,17.9813 C48.3264085,17.9813 51.0127,20.6675915 51.0127,23.9813 C51.0127,27.2950085 48.3264085,29.9813 45.0127,29.9813 Z M45.0127,27.9813 C47.221839,27.9813 49.0127,26.190439 49.0127,23.9813 C49.0127,21.772161 47.221839,19.9813 45.0127,19.9813 C42.803561,19.9813 41.0127,21.772161 41.0127,23.9813 C41.0127,26.190439 42.803561,27.9813 45.0127,27.9813 Z"
-                />
-              </svg>
-            </div>
-            <div
-              className="entity-row__text entity-row__text--in-rows"
-            >
-              <h3
-                className="entity-row__title entity-row__title--in-rows"
-              >
-                <span
-                  className="entity-row__title-inner"
-                >
-                  Image
-                </span>
-                <span
-                  className="entity-row__labels"
-                >
-                  <span
-                    className="entity-row__label"
-                  >
-                    image
-                  </span>
-                </span>
-                <span
-                  className="aria-describedby"
-                  id="undefined1-describedby"
-                >
-                  View Image
-                </span>
-              </h3>
-              <div
-                className="entity-row__meta entity-row__meta--in-rows"
-              >
-                <time
-                  dateTime="2017-04-24"
-                >
-                  Created April 24, 2017
-                </time>
-              </div>
-            </div>
-            <div
-              className="entity-row__utility"
-            >
-              <div
-                className="form-input"
-              >
-                <div
-                  className="toggle-indicator"
-                >
-                  <div
-                    className="boolean-primary"
-                    onClick={[Function]}
-                    role="button"
-                    tabIndex="0"
-                  >
-                    <span
-                      className="screen-reader-text"
-                    >
-                      Add Resource to Collection
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </a>
-      </li>
-    </ul>
-    <div
-      className="entity-list__pagination"
-    >
-      <nav
-        aria-label="Pagination"
-        className="list-pagination"
-      >
-        <ul
-          className="list-pagination__columns"
-        >
-          <li
-            className="list-pagination__column"
-          >
-            <ul>
-              <li
-                className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
-              >
-                <a
-                  disabled={true}
-                  href="#entities-list1"
-                  onClick={[Function]}
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="manicon-svg svg-icon--arrowLongLeft16"
-                    fill="currentColor"
-                    height={null}
-                    viewBox="0 0 24 16"
-                    width={null}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                      transform="rotate(180 12 8)"
-                    />
-                  </svg>
-                  <span
-                    className="list-pagination__icon-label"
-                  >
-                    PREV
-                  </span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li
-            className="list-pagination__column-middle"
-          >
-            <ul
-              className="list-pagination__pages"
-            >
-              <li
-                className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
-              >
-                <a
-                  href="#entities-list1"
-                  onClick={[Function]}
-                >
-                  <span
-                    aria-hidden="true"
-                  >
-                    1
-                  </span>
-                  <span
-                    className="screen-reader-text"
-                  >
-                    Go to page: 
-                    1
-                  </span>
-                </a>
-              </li>
-              <li
-                className="list-pagination__page list-pagination__page--ordinal"
-              >
-                <a
-                  href="#entities-list1"
-                  onClick={[Function]}
-                >
-                  <span
-                    aria-hidden="true"
-                  >
-                    2
-                  </span>
-                  <span
-                    className="screen-reader-text"
-                  >
-                    Go to page: 
-                    2
-                  </span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li
-            className="list-pagination__column"
-          >
-            <ul>
-              <li
-                className="list-pagination__page list-pagination__page--next"
-              >
-                <a
-                  href="#entities-list1"
-                  onClick={[Function]}
-                >
-                  <span
-                    className="list-pagination__icon-label"
-                  >
-                    NEXT
-                  </span>
-                  <svg
-                    aria-hidden={true}
-                    className="manicon-svg svg-icon--arrowLongRight16"
-                    fill="currentColor"
-                    height={null}
-                    viewBox="0 0 24 16"
-                    width={null}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                    />
-                  </svg>
-                </a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </div>
-</div>
+  </div>,
+]
 `;

--- a/client/src/backend/containers/users/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/containers/users/__tests__/__snapshots__/List-test.js.snap
@@ -2,6 +2,12 @@
 
 exports[`Backend People Users List Container renders correctly 1`] = `
 Array [
+  <div
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
   <span />,
   <div
     className="entity-list"
@@ -87,6 +93,8 @@ Array [
               Reset
             </button>
             <button
+              aria-expanded={false}
+              aria-haspopup={true}
               className="entity-list-search__text-button entity-list-search__text-button--foregrounded"
               onClick={[Function]}
             >
@@ -258,6 +266,7 @@ Array [
           className="entity-list__count"
         >
           <p
+            aria-hidden={true}
             className="list-total"
           >
             Showing 
@@ -270,6 +279,14 @@ Array [
             </span>
              users: 
           </p>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          >
+            2 users. Showing results 1 through 1.
+          </div>
         </div>
       </div>
       <ul

--- a/client/src/frontend/components/project-collection/Filters.js
+++ b/client/src/frontend/components/project-collection/Filters.js
@@ -2,9 +2,12 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import omitBy from "lodash/omitBy";
 import uniqueId from "lodash/uniqueId";
+import isEmpty from "lodash/isEmpty";
 import Utility from "global/components/utility";
 
-export default class ProjectCollectionFilters extends Component {
+import withScreenReaderStatus from "hoc/with-screen-reader-status";
+
+export class ProjectCollectionFilters extends Component {
   static displayName = "ProjectCollection.Filters";
 
   static propTypes = {
@@ -20,6 +23,7 @@ export default class ProjectCollectionFilters extends Component {
   constructor(props) {
     super(props);
     this.state = this.initialState(props.initialFilterState);
+    this.searchInput = React.createRef();
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -28,6 +32,14 @@ export default class ProjectCollectionFilters extends Component {
     }
 
     return null;
+  }
+
+  get showResetButton() {
+    return !isEmpty(this.state.filters);
+  }
+
+  get resetMessage() {
+    return "Search and filters reset.";
   }
 
   setFilters = (event, label) => {
@@ -53,6 +65,10 @@ export default class ProjectCollectionFilters extends Component {
   resetFilters = event => {
     event.preventDefault();
     this.setState(this.initialState(), this.updateResults);
+    // update SR message
+    this.props.setScreenReaderStatus(this.resetMessage);
+    // focus on search field
+    this.searchInput.current.focus();
   };
 
   render() {
@@ -74,6 +90,7 @@ export default class ProjectCollectionFilters extends Component {
             Enter Search Criteria
           </label>
           <input
+            ref={this.searchInput}
             value={this.state.filters.keyword || ""}
             type="text"
             id={this.props.searchId}
@@ -98,10 +115,14 @@ export default class ProjectCollectionFilters extends Component {
             />
           </div>
         </div>
-        <button className="reset-button" onClick={this.resetFilters}>
-          {"Reset Search + Filters"}
-        </button>
+        {this.showResetButton && (
+          <button className="reset-button" onClick={this.resetFilters}>
+            {"Reset Search + Filters"}
+          </button>
+        )}
       </form>
     );
   }
 }
+
+export default withScreenReaderStatus(ProjectCollectionFilters);

--- a/client/src/frontend/components/project-collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/project-collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -37,6 +37,12 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
         </div>
       </div>
     </div>
+    <div
+      aria-atomic={true}
+      aria-live="polite"
+      className="screen-reader-text"
+      role="status"
+    />
     <form
       className="entity-section-wrapper__tools form-list-filter"
       onSubmit={[Function]}
@@ -122,18 +128,15 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
           </svg>
         </div>
       </div>
-      <button
-        className="reset-button"
-        onClick={[Function]}
-      >
-        Reset Search + Filters
-      </button>
     </form>
     <div
       className="entity-section-wrapper__details"
     >
       <p
+        aria-atomic={true}
+        aria-live="polite"
         className="list-total"
+        role="status"
       >
         <span>
           2

--- a/client/src/frontend/components/project-collection/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/frontend/components/project-collection/__tests__/__snapshots__/Filters-test.js.snap
@@ -1,96 +1,98 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frontend.ProjectCollection.Filters component renders correctly 1`] = `
-<form
-  className="entity-section-wrapper__tools form-list-filter"
-  onSubmit={[Function]}
->
+Array [
   <div
-    className="search-input"
-  >
-    <button
-      className="search-button"
-      type="submit"
-    >
-      <span
-        className="screen-reader-text"
-      >
-        Search…
-      </span>
-      <svg
-        aria-hidden={true}
-        className="manicon-svg search-icon svg-icon--search16"
-        fill="currentColor"
-        height={20}
-        viewBox="0 0 16 16"
-        width={20}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
-        />
-      </svg>
-    </button>
-    <label
-      className="screen-reader-text"
-      htmlFor="filters-search-1"
-    >
-      Enter Search Criteria
-    </label>
-    <input
-      id="filters-search-1"
-      onChange={[Function]}
-      placeholder="Search…"
-      type="text"
-      value=""
-    />
-  </div>
-  <div
-    className="select-group inline"
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
+  <form
+    className="entity-section-wrapper__tools form-list-filter"
+    onSubmit={[Function]}
   >
     <div
-      className="select"
+      className="search-input"
     >
-      <select
-        onChange={[Function]}
-        value=""
+      <button
+        className="search-button"
+        type="submit"
       >
-        <option
+        <span
+          className="screen-reader-text"
+        >
+          Search…
+        </span>
+        <svg
+          aria-hidden={true}
+          className="manicon-svg search-icon svg-icon--search16"
+          fill="currentColor"
+          height={20}
+          viewBox="0 0 16 16"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
+          />
+        </svg>
+      </button>
+      <label
+        className="screen-reader-text"
+        htmlFor="filters-search-1"
+      >
+        Enter Search Criteria
+      </label>
+      <input
+        id="filters-search-1"
+        onChange={[Function]}
+        placeholder="Search…"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      className="select-group inline"
+    >
+      <div
+        className="select"
+      >
+        <select
+          onChange={[Function]}
           value=""
         >
-          Sort
-        </option>
-        <option
-          value="sort_title ASC"
+          <option
+            value=""
+          >
+            Sort
+          </option>
+          <option
+            value="sort_title ASC"
+          >
+            A-Z
+          </option>
+          <option
+            value="sort_title DESC"
+          >
+            Z-A
+          </option>
+        </select>
+        <svg
+          aria-hidden={true}
+          className="manicon-svg select__icon svg-icon--disclosureDown16"
+          fill="currentColor"
+          height={20}
+          viewBox="0 0 16 16"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
         >
-          A-Z
-        </option>
-        <option
-          value="sort_title DESC"
-        >
-          Z-A
-        </option>
-      </select>
-      <svg
-        aria-hidden={true}
-        className="manicon-svg select__icon svg-icon--disclosureDown16"
-        fill="currentColor"
-        height={20}
-        viewBox="0 0 16 16"
-        width={20}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <polygon
-          points="8 9.702 13.356 5 13.999 5.733 8 10.999 2 5.733 2.643 5"
-        />
-      </svg>
+          <polygon
+            points="8 9.702 13.356 5 13.999 5.733 8 10.999 2 5.733 2.643 5"
+          />
+        </svg>
+      </div>
     </div>
-  </div>
-  <button
-    className="reset-button"
-    onClick={[Function]}
-  >
-    Reset Search + Filters
-  </button>
-</form>
+  </form>,
+]
 `;

--- a/client/src/frontend/components/project-list/Filters.js
+++ b/client/src/frontend/components/project-list/Filters.js
@@ -2,9 +2,12 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import omitBy from "lodash/omitBy";
 import uniqueId from "lodash/uniqueId";
+import isEmpty from "lodash/isEmpty";
 import Utility from "global/components/utility";
 
-export default class ProjectListFilters extends Component {
+import withScreenReaderStatus from "hoc/with-screen-reader-status";
+
+export class ProjectListFilters extends Component {
   static displayName = "ProjectList.Filters";
 
   static propTypes = {
@@ -22,6 +25,7 @@ export default class ProjectListFilters extends Component {
   constructor(props) {
     super(props);
     this.state = this.initialState(props.initialFilterState);
+    this.searchInput = React.createRef();
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -30,6 +34,14 @@ export default class ProjectListFilters extends Component {
     }
 
     return null;
+  }
+
+  get showResetButton() {
+    return !isEmpty(this.state.filters);
+  }
+
+  get resetMessage() {
+    return "Search and filters reset.";
   }
 
   setFilters = (event, label) => {
@@ -60,6 +72,10 @@ export default class ProjectListFilters extends Component {
   resetFilters = event => {
     event.preventDefault();
     this.setState(this.initialState(), this.updateResults);
+    // update SR message
+    this.props.setScreenReaderStatus(this.resetMessage);
+    // focus on search field
+    this.searchInput.current.focus();
   };
 
   updateResults = event => {
@@ -106,6 +122,7 @@ export default class ProjectListFilters extends Component {
           Enter Search Criteria
         </label>
         <input
+          ref={this.searchInput}
           value={this.state.filters.keyword || ""}
           type="text"
           id={this.props.searchId}
@@ -166,10 +183,14 @@ export default class ProjectListFilters extends Component {
           {this.renderSort()}
           {this.renderFilters()}
         </div>
-        <button className="reset-button" onClick={this.resetFilters}>
-          {"Reset Search + Filters"}
-        </button>
+        {this.showResetButton && (
+          <button className="reset-button" onClick={this.resetFilters}>
+            {"Reset Search + Filters"}
+          </button>
+        )}
       </form>
     );
   }
 }
+
+export default withScreenReaderStatus(ProjectListFilters);

--- a/client/src/frontend/components/project-list/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/frontend/components/project-list/__tests__/__snapshots__/Filters-test.js.snap
@@ -1,138 +1,140 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frontend.ProjectList.Filters component renders correctly 1`] = `
-<form
-  className="form-list-filter entity-section-wrapper__tools"
-  onSubmit={[Function]}
->
+Array [
   <div
-    className="search-input"
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
+  <form
+    className="form-list-filter entity-section-wrapper__tools"
+    onSubmit={[Function]}
   >
-    <button
-      className="search-button"
-      type="submit"
+    <div
+      className="search-input"
     >
-      <span
+      <button
+        className="search-button"
+        type="submit"
+      >
+        <span
+          className="screen-reader-text"
+        >
+          Search…
+        </span>
+        <svg
+          aria-hidden={true}
+          className="manicon-svg svg-icon--search16"
+          fill="currentColor"
+          height={20}
+          viewBox="0 0 16 16"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
+          />
+        </svg>
+      </button>
+      <label
         className="screen-reader-text"
+        htmlFor="filters-search-1"
       >
-        Search…
-      </span>
-      <svg
-        aria-hidden={true}
-        className="manicon-svg svg-icon--search16"
-        fill="currentColor"
-        height={20}
-        viewBox="0 0 16 16"
-        width={20}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
-        />
-      </svg>
-    </button>
-    <label
-      className="screen-reader-text"
-      htmlFor="filters-search-1"
-    >
-      Enter Search Criteria
-    </label>
-    <input
-      id="filters-search-1"
-      onChange={[Function]}
-      placeholder="Search…"
-      type="text"
-      value=""
-    />
-  </div>
-  <div
-    className="select-group inline"
-  >
-    <div
-      className="select"
-    >
-      <select
+        Enter Search Criteria
+      </label>
+      <input
+        id="filters-search-1"
         onChange={[Function]}
+        placeholder="Search…"
+        type="text"
         value=""
-      >
-        <option
-          value=""
-        >
-          Sort
-        </option>
-        <option
-          value="sort_title ASC"
-        >
-          A-Z
-        </option>
-        <option
-          value="sort_title DESC"
-        >
-          Z-A
-        </option>
-      </select>
-      <svg
-        aria-hidden={true}
-        className="manicon-svg select__icon svg-icon--disclosureDown16"
-        fill="currentColor"
-        height={20}
-        viewBox="0 0 16 16"
-        width={20}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <polygon
-          points="8 9.702 13.356 5 13.999 5.733 8 10.999 2 5.733 2.643 5"
-        />
-      </svg>
+      />
     </div>
     <div
-      className="select"
+      className="select-group inline"
     >
-      <select
-        onChange={[Function]}
-        value=""
+      <div
+        className="select"
       >
-        <option
+        <select
+          onChange={[Function]}
           value=""
         >
-          Show All
-        </option>
-        <option
-          value="featured"
+          <option
+            value=""
+          >
+            Sort
+          </option>
+          <option
+            value="sort_title ASC"
+          >
+            A-Z
+          </option>
+          <option
+            value="sort_title DESC"
+          >
+            Z-A
+          </option>
+        </select>
+        <svg
+          aria-hidden={true}
+          className="manicon-svg select__icon svg-icon--disclosureDown16"
+          fill="currentColor"
+          height={20}
+          viewBox="0 0 16 16"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
         >
-          Featured Projects
-        </option>
-        <option
-          value="1"
-        >
-          Subject 1
-        </option>
-        <option
-          value="2"
-        >
-          Subject 2
-        </option>
-      </select>
-      <svg
-        aria-hidden={true}
-        className="manicon-svg select__icon svg-icon--disclosureDown16"
-        fill="currentColor"
-        height={20}
-        viewBox="0 0 16 16"
-        width={20}
-        xmlns="http://www.w3.org/2000/svg"
+          <polygon
+            points="8 9.702 13.356 5 13.999 5.733 8 10.999 2 5.733 2.643 5"
+          />
+        </svg>
+      </div>
+      <div
+        className="select"
       >
-        <polygon
-          points="8 9.702 13.356 5 13.999 5.733 8 10.999 2 5.733 2.643 5"
-        />
-      </svg>
+        <select
+          onChange={[Function]}
+          value=""
+        >
+          <option
+            value=""
+          >
+            Show All
+          </option>
+          <option
+            value="featured"
+          >
+            Featured Projects
+          </option>
+          <option
+            value="1"
+          >
+            Subject 1
+          </option>
+          <option
+            value="2"
+          >
+            Subject 2
+          </option>
+        </select>
+        <svg
+          aria-hidden={true}
+          className="manicon-svg select__icon svg-icon--disclosureDown16"
+          fill="currentColor"
+          height={20}
+          viewBox="0 0 16 16"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polygon
+            points="8 9.702 13.356 5 13.999 5.733 8 10.999 2 5.733 2.643 5"
+          />
+        </svg>
+      </div>
     </div>
-  </div>
-  <button
-    className="reset-button"
-    onClick={[Function]}
-  >
-    Reset Search + Filters
-  </button>
-</form>
+  </form>,
+]
 `;

--- a/client/src/frontend/components/project-list/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/frontend/components/project-list/__tests__/__snapshots__/Following-test.js.snap
@@ -37,6 +37,12 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
         </div>
       </div>
     </header>
+    <div
+      aria-atomic={true}
+      aria-live="polite"
+      className="screen-reader-text"
+      role="status"
+    />
     <form
       className="form-list-filter entity-section-wrapper__tools"
       onSubmit={[Function]}
@@ -154,12 +160,6 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
           </svg>
         </div>
       </div>
-      <button
-        className="reset-button"
-        onClick={[Function]}
-      >
-        Reset Search + Filters
-      </button>
     </form>
     <div
       className="project-list grid entity-section-wrapper__body"

--- a/client/src/frontend/components/project/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/frontend/components/project/__tests__/__snapshots__/Resources-test.js.snap
@@ -35,6 +35,12 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
         </div>
       </div>
     </header>
+    <div
+      aria-atomic={true}
+      aria-live="polite"
+      className="screen-reader-text"
+      role="status"
+    />
     <form
       className="form-list-filter entity-section-wrapper__tools entity-section-wrapper__tools--wide"
       onSubmit={[Function]}
@@ -174,12 +180,6 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
           </svg>
         </div>
       </div>
-      <button
-        className="reset-button"
-        onClick={[Function]}
-      >
-        Reset Search + Filters
-      </button>
     </form>
     <div
       className="entity-section-wrapper__body"
@@ -191,6 +191,7 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
           className="resource-count"
         >
           <p
+            aria-hidden={true}
             className="list-total"
           >
             Showing 
@@ -203,6 +204,14 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
             </span>
              resources: 
           </p>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          >
+            10 resources. Showing results 1 through 5.
+          </div>
         </div>
         <ul>
           <li

--- a/client/src/frontend/components/resource-collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/resource-collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -373,6 +373,12 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
         </svg>
       </a>
     </div>
+    <div
+      aria-atomic={true}
+      aria-live="polite"
+      className="screen-reader-text"
+      role="status"
+    />
     <form
       className="form-list-filter entity-section-wrapper__tools entity-section-wrapper__tools--wide"
       onSubmit={[Function]}
@@ -527,12 +533,6 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
           </svg>
         </div>
       </div>
-      <button
-        className="reset-button"
-        onClick={[Function]}
-      >
-        Reset Search + Filters
-      </button>
     </form>
     <div
       className="entity-section-wrapper__body"
@@ -544,6 +544,7 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
           className="resource-count"
         >
           <p
+            aria-hidden={true}
             className="list-total"
           >
             Showing 
@@ -556,6 +557,14 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
             </span>
              resources: 
           </p>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          >
+            2 resources. Showing results 1 through 1.
+          </div>
         </div>
         <ul>
           <li

--- a/client/src/frontend/components/resource-list/Filters.js
+++ b/client/src/frontend/components/resource-list/Filters.js
@@ -2,10 +2,13 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import capitalize from "lodash/capitalize";
 import omitBy from "lodash/omitBy";
+import isEmpty from "lodash/isEmpty";
 import labelId from "helpers/labelId";
 import Utility from "global/components/utility";
 
-export default class ResourceListFilters extends Component {
+import withScreenReaderStatus from "hoc/with-screen-reader-status";
+
+export class ResourceListFilters extends Component {
   static displayName = "ResourceList.Filters";
 
   static propTypes = {
@@ -23,6 +26,7 @@ export default class ResourceListFilters extends Component {
   constructor(props) {
     super(props);
     this.state = this.initialState(props.initialFilterState);
+    this.searchInput = React.createRef();
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -31,6 +35,14 @@ export default class ResourceListFilters extends Component {
     }
 
     return null;
+  }
+
+  get showResetButton() {
+    return !isEmpty(this.state.filters);
+  }
+
+  get resetMessage() {
+    return "Search and filters reset.";
   }
 
   setFilters = (event, label) => {
@@ -56,6 +68,10 @@ export default class ResourceListFilters extends Component {
   resetFilters = event => {
     event.preventDefault();
     this.setState(this.initialState(), this.updateResults);
+    // update SR message
+    this.props.setScreenReaderStatus(this.resetMessage);
+    // focus on search field
+    this.searchInput.current.focus();
   };
 
   render() {
@@ -77,6 +93,7 @@ export default class ResourceListFilters extends Component {
             Enter Search Criteria
           </label>
           <input
+            ref={this.searchInput}
             value={this.state.filters.keyword || ""}
             type="text"
             id={this.props.searchId}
@@ -145,10 +162,14 @@ export default class ResourceListFilters extends Component {
             />
           </div>
         </div>
-        <button className="reset-button" onClick={this.resetFilters}>
-          {"Reset Search + Filters"}
-        </button>
+        {this.showResetButton && (
+          <button className="reset-button" onClick={this.resetFilters}>
+            {"Reset Search + Filters"}
+          </button>
+        )}
       </form>
     );
   }
 }
+
+export default withScreenReaderStatus(ResourceListFilters);

--- a/client/src/frontend/components/resource-list/__tests__/__snapshots__/Cards-test.js.snap
+++ b/client/src/frontend/components/resource-list/__tests__/__snapshots__/Cards-test.js.snap
@@ -11,6 +11,7 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
       className="resource-count"
     >
       <p
+        aria-hidden={true}
         className="list-total"
       >
         Showing 
@@ -23,6 +24,14 @@ exports[`Frontend.ResourceList.Cards Component renders correctly 1`] = `
         </span>
          resources: 
       </p>
+      <div
+        aria-atomic={true}
+        aria-live="polite"
+        className="screen-reader-text"
+        role="status"
+      >
+        10 resources. Showing results 1 through 5.
+      </div>
     </div>
     <ul>
       <li

--- a/client/src/frontend/components/resource-list/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/frontend/components/resource-list/__tests__/__snapshots__/Filters-test.js.snap
@@ -1,170 +1,172 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frontend.ResourceList.Filters Component renders correctly 1`] = `
-<form
-  className="form-list-filter entity-section-wrapper__tools entity-section-wrapper__tools--wide"
-  onSubmit={[Function]}
->
+Array [
   <div
-    className="search-input"
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
+  <form
+    className="form-list-filter entity-section-wrapper__tools entity-section-wrapper__tools--wide"
+    onSubmit={[Function]}
   >
-    <button
-      className="search-button"
-      type="submit"
+    <div
+      className="search-input"
     >
-      <span
+      <button
+        className="search-button"
+        type="submit"
+      >
+        <span
+          className="screen-reader-text"
+        >
+          Search
+        </span>
+        <svg
+          aria-hidden={true}
+          className="manicon-svg svg-icon--search16"
+          fill="currentColor"
+          height={20}
+          viewBox="0 0 16 16"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
+          />
+        </svg>
+      </button>
+      <label
         className="screen-reader-text"
+        htmlFor="filters-search-1"
       >
-        Search
-      </span>
-      <svg
-        aria-hidden={true}
-        className="manicon-svg svg-icon--search16"
-        fill="currentColor"
-        height={20}
-        viewBox="0 0 16 16"
-        width={20}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
-        />
-      </svg>
-    </button>
-    <label
-      className="screen-reader-text"
-      htmlFor="filters-search-1"
-    >
-      Enter Search Criteria
-    </label>
-    <input
-      id="filters-search-1"
-      onChange={[Function]}
-      placeholder="Search"
-      type="text"
-      value=""
-    />
-  </div>
-  <div
-    className="select-group inline"
-  >
-    <div
-      className="select"
-    >
-      <select
+        Enter Search Criteria
+      </label>
+      <input
+        id="filters-search-1"
         onChange={[Function]}
+        placeholder="Search"
+        type="text"
         value=""
+      />
+    </div>
+    <div
+      className="select-group inline"
+    >
+      <div
+        className="select"
       >
-        <option
+        <select
+          onChange={[Function]}
           value=""
         >
-          Type:
-        </option>
-        <option
-          value="image"
+          <option
+            value=""
+          >
+            Type:
+          </option>
+          <option
+            value="image"
+          >
+            Image
+          </option>
+          <option
+            value="video"
+          >
+            Video
+          </option>
+        </select>
+        <svg
+          aria-hidden={true}
+          className="manicon-svg select__icon svg-icon--disclosureDown16"
+          fill="currentColor"
+          height={20}
+          viewBox="0 0 16 16"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
         >
-          Image
-        </option>
-        <option
-          value="video"
-        >
-          Video
-        </option>
-      </select>
-      <svg
-        aria-hidden={true}
-        className="manicon-svg select__icon svg-icon--disclosureDown16"
-        fill="currentColor"
-        height={20}
-        viewBox="0 0 16 16"
-        width={20}
-        xmlns="http://www.w3.org/2000/svg"
+          <polygon
+            points="8 9.702 13.356 5 13.999 5.733 8 10.999 2 5.733 2.643 5"
+          />
+        </svg>
+      </div>
+      <div
+        className="select"
       >
-        <polygon
-          points="8 9.702 13.356 5 13.999 5.733 8 10.999 2 5.733 2.643 5"
-        />
-      </svg>
-    </div>
-    <div
-      className="select"
-    >
-      <select
-        onChange={[Function]}
-        value=""
-      >
-        <option
+        <select
+          onChange={[Function]}
           value=""
         >
-          Tag:
-        </option>
-        <option
-          value="dog"
+          <option
+            value=""
+          >
+            Tag:
+          </option>
+          <option
+            value="dog"
+          >
+            Dog
+          </option>
+          <option
+            value="puppy"
+          >
+            Puppy
+          </option>
+        </select>
+        <svg
+          aria-hidden={true}
+          className="manicon-svg select__icon svg-icon--disclosureDown16"
+          fill="currentColor"
+          height={20}
+          viewBox="0 0 16 16"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
         >
-          Dog
-        </option>
-        <option
-          value="puppy"
-        >
-          Puppy
-        </option>
-      </select>
-      <svg
-        aria-hidden={true}
-        className="manicon-svg select__icon svg-icon--disclosureDown16"
-        fill="currentColor"
-        height={20}
-        viewBox="0 0 16 16"
-        width={20}
-        xmlns="http://www.w3.org/2000/svg"
+          <polygon
+            points="8 9.702 13.356 5 13.999 5.733 8 10.999 2 5.733 2.643 5"
+          />
+        </svg>
+      </div>
+      <div
+        className="select"
       >
-        <polygon
-          points="8 9.702 13.356 5 13.999 5.733 8 10.999 2 5.733 2.643 5"
-        />
-      </svg>
+        <select
+          onChange={[Function]}
+          value=""
+        >
+          <option
+            value="default"
+          >
+            Sort By:
+          </option>
+          <option
+            value="sort_title ASC"
+          >
+            A-Z
+          </option>
+          <option
+            value="sort_title DESC"
+          >
+            Z-A
+          </option>
+        </select>
+        <svg
+          aria-hidden={true}
+          className="manicon-svg select__icon svg-icon--disclosureDown16"
+          fill="currentColor"
+          height={20}
+          viewBox="0 0 16 16"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polygon
+            points="8 9.702 13.356 5 13.999 5.733 8 10.999 2 5.733 2.643 5"
+          />
+        </svg>
+      </div>
     </div>
-    <div
-      className="select"
-    >
-      <select
-        onChange={[Function]}
-        value=""
-      >
-        <option
-          value="default"
-        >
-          Sort By:
-        </option>
-        <option
-          value="sort_title ASC"
-        >
-          A-Z
-        </option>
-        <option
-          value="sort_title DESC"
-        >
-          Z-A
-        </option>
-      </select>
-      <svg
-        aria-hidden={true}
-        className="manicon-svg select__icon svg-icon--disclosureDown16"
-        fill="currentColor"
-        height={20}
-        viewBox="0 0 16 16"
-        width={20}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <polygon
-          points="8 9.702 13.356 5 13.999 5.733 8 10.999 2 5.733 2.643 5"
-        />
-      </svg>
-    </div>
-  </div>
-  <button
-    className="reset-button"
-    onClick={[Function]}
-  >
-    Reset Search + Filters
-  </button>
-</form>
+  </form>,
+]
 `;

--- a/client/src/frontend/containers/Featured/__tests__/__snapshots__/Featured-test.js.snap
+++ b/client/src/frontend/containers/Featured/__tests__/__snapshots__/Featured-test.js.snap
@@ -49,6 +49,12 @@ exports[`Frontend Featured Container renders correctly 1`] = `
           </div>
         </div>
       </header>
+      <div
+        aria-atomic={true}
+        aria-live="polite"
+        className="screen-reader-text"
+        role="status"
+      />
       <form
         className="form-list-filter entity-section-wrapper__tools"
         onSubmit={[Function]}
@@ -134,12 +140,6 @@ exports[`Frontend Featured Container renders correctly 1`] = `
             </svg>
           </div>
         </div>
-        <button
-          className="reset-button"
-          onClick={[Function]}
-        >
-          Reset Search + Filters
-        </button>
       </form>
       <div
         className="project-list grid entity-section-wrapper__body"

--- a/client/src/frontend/containers/Following/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/frontend/containers/Following/__tests__/__snapshots__/Following-test.js.snap
@@ -43,6 +43,12 @@ exports[`Frontend Following Container renders correctly 1`] = `
           </div>
         </div>
       </header>
+      <div
+        aria-atomic={true}
+        aria-live="polite"
+        className="screen-reader-text"
+        role="status"
+      />
       <form
         className="form-list-filter entity-section-wrapper__tools"
         onSubmit={[Function]}
@@ -160,12 +166,6 @@ exports[`Frontend Following Container renders correctly 1`] = `
             </svg>
           </div>
         </div>
-        <button
-          className="reset-button"
-          onClick={[Function]}
-        >
-          Reset Search + Filters
-        </button>
       </form>
       <div
         className="project-list grid entity-section-wrapper__body"

--- a/client/src/frontend/containers/ProjectCollectionDetail/__tests__/__snapshots__/ProjectCollectionDetail-test.js.snap
+++ b/client/src/frontend/containers/ProjectCollectionDetail/__tests__/__snapshots__/ProjectCollectionDetail-test.js.snap
@@ -75,6 +75,12 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
           </div>
         </div>
       </div>
+      <div
+        aria-atomic={true}
+        aria-live="polite"
+        className="screen-reader-text"
+        role="status"
+      />
       <form
         className="entity-section-wrapper__tools form-list-filter"
         onSubmit={[Function]}
@@ -160,18 +166,15 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
             </svg>
           </div>
         </div>
-        <button
-          className="reset-button"
-          onClick={[Function]}
-        >
-          Reset Search + Filters
-        </button>
       </form>
       <div
         className="entity-section-wrapper__details"
       >
         <p
+          aria-atomic={true}
+          aria-live="polite"
           className="list-total"
+          role="status"
         >
           <span>
             2

--- a/client/src/frontend/containers/ProjectResources/__tests__/__snapshots__/ProjectResources-test.js.snap
+++ b/client/src/frontend/containers/ProjectResources/__tests__/__snapshots__/ProjectResources-test.js.snap
@@ -79,6 +79,12 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
           </div>
         </div>
       </header>
+      <div
+        aria-atomic={true}
+        aria-live="polite"
+        className="screen-reader-text"
+        role="status"
+      />
       <form
         className="form-list-filter entity-section-wrapper__tools entity-section-wrapper__tools--wide"
         onSubmit={[Function]}
@@ -218,12 +224,6 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
             </svg>
           </div>
         </div>
-        <button
-          className="reset-button"
-          onClick={[Function]}
-        >
-          Reset Search + Filters
-        </button>
       </form>
       <div
         className="entity-section-wrapper__body"
@@ -235,6 +235,7 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
             className="resource-count"
           >
             <p
+              aria-hidden={true}
               className="list-total"
             >
               Showing 
@@ -247,6 +248,14 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
               </span>
                resources: 
             </p>
+            <div
+              aria-atomic={true}
+              aria-live="polite"
+              className="screen-reader-text"
+              role="status"
+            >
+              2 resources. Showing results 1 through 1.
+            </div>
           </div>
           <ul>
             <li

--- a/client/src/frontend/containers/ResourceCollectionDetail/__tests__/__snapshots__/ResourceCollectionDetail-test.js.snap
+++ b/client/src/frontend/containers/ResourceCollectionDetail/__tests__/__snapshots__/ResourceCollectionDetail-test.js.snap
@@ -408,6 +408,12 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
           </svg>
         </a>
       </div>
+      <div
+        aria-atomic={true}
+        aria-live="polite"
+        className="screen-reader-text"
+        role="status"
+      />
       <form
         className="form-list-filter entity-section-wrapper__tools entity-section-wrapper__tools--wide"
         onSubmit={[Function]}
@@ -562,12 +568,6 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
             </svg>
           </div>
         </div>
-        <button
-          className="reset-button"
-          onClick={[Function]}
-        >
-          Reset Search + Filters
-        </button>
       </form>
       <div
         className="entity-section-wrapper__body"
@@ -579,6 +579,7 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
             className="resource-count"
           >
             <p
+              aria-hidden={true}
               className="list-total"
             >
               Showing 
@@ -591,6 +592,14 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
               </span>
                resources: 
             </p>
+            <div
+              aria-atomic={true}
+              aria-live="polite"
+              className="screen-reader-text"
+              role="status"
+            >
+              2 resources. Showing results 1 through 1.
+            </div>
           </div>
           <ul>
             <li

--- a/client/src/global/components/search/results/Empty.js
+++ b/client/src/global/components/search/results/Empty.js
@@ -10,7 +10,14 @@ export default class SearchResultsEmpty extends PureComponent {
     return (
       <div className="search-results">
         <span className="label-count">
-          <span className="list-total">No results were found.</span>
+          <span
+            className="list-total"
+            role="status"
+            aria-live="polite"
+            aria-atomic
+          >
+            No results were found.
+          </span>
         </span>
       </div>
     );

--- a/client/src/global/components/utility/EntityCount.js
+++ b/client/src/global/components/utility/EntityCount.js
@@ -19,19 +19,31 @@ export default class EntityCount extends PureComponent {
 
   renderRange(start, end, totalCount, label) {
     return (
-      <p className="list-total">
-        {"Showing "}
-        <span>{`${start}-${end}`}</span>
-        {" of "}
-        <span>{totalCount}</span>
-        {label && ` ${label}: `}
-      </p>
+      <React.Fragment>
+        <p className="list-total" aria-hidden>
+          {"Showing "}
+          <span>{`${start}-${end}`}</span>
+          {" of "}
+          <span>{totalCount}</span>
+          {label && ` ${label}: `}
+        </p>
+        {/* Better readout for screen readers */}
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic
+          className="screen-reader-text"
+        >
+          {`${totalCount} ${label &&
+            label}. Showing results ${start} through ${end}.`}
+        </div>
+      </React.Fragment>
     );
   }
 
   renderCount(totalCount, label) {
     return (
-      <p className="list-total">
+      <p className="list-total" role="status" aria-atomic aria-live="polite">
         <span>{totalCount}</span>
         {` ${label}`}
       </p>

--- a/client/src/global/components/utility/__tests__/__snapshots__/Entitycount-test.js.snap
+++ b/client/src/global/components/utility/__tests__/__snapshots__/Entitycount-test.js.snap
@@ -1,17 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Global.Utility.EntityCount component renders correctly 1`] = `
-<p
-  className="list-total"
->
-  Showing 
-  <span>
-    1-5
-  </span>
-   of 
-  <span>
-    10
-  </span>
-   entities: 
-</p>
+Array [
+  <p
+    aria-hidden={true}
+    className="list-total"
+  >
+    Showing 
+    <span>
+      1-5
+    </span>
+     of 
+    <span>
+      10
+    </span>
+     entities: 
+  </p>,
+  <div
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  >
+    10 entities. Showing results 1 through 5.
+  </div>,
+]
 `;

--- a/client/src/hoc/with-filtered-lists/hoc.js
+++ b/client/src/hoc/with-filtered-lists/hoc.js
@@ -46,7 +46,7 @@ function withFilters(WrappedComponent, filteredLists = {}) {
     }
 
     onReset = key => {
-      this.setValues(key, this.initialValues(key));
+      this.setValues(key, this.initialValues(key), true);
     };
 
     get managedLists() {
@@ -80,17 +80,30 @@ function withFilters(WrappedComponent, filteredLists = {}) {
       return state;
     }
 
+    get resetMessage() {
+      return "Search and filters reset.";
+    }
+
     setParam = (key, paramLike, value) => {
       const param = this.ensureParamObject(key, paramLike);
       this.setValues(key, { [param.name]: value });
     };
 
-    setValues(key, updatedValues) {
+    setValues(key, updatedValues, isReset) {
       const listState = this.listState(key);
       const values = listState.values;
       const newValues = Object.assign({}, values, updatedValues);
       const newListState = Object.assign({}, listState, { values: newValues });
-      this.setState({ [key]: newListState });
+      this.setState({
+        [key]: newListState,
+        message: isReset ? this.resetMessage : null
+      });
+
+      // remove message on timeout was a reset
+      isReset &&
+        setTimeout(() => {
+          this.setState({ message: null });
+        }, 1000);
     }
 
     initialValues(key) {
@@ -179,9 +192,23 @@ function withFilters(WrappedComponent, filteredLists = {}) {
       return snapshot.pagination;
     };
 
+    renderLiveRegion() {
+      return (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic
+          className="screen-reader-text"
+        >
+          {this.state.message}
+        </div>
+      );
+    }
+
     render() {
       return (
         <React.Fragment>
+          {this.renderLiveRegion()}
           <WrappedComponent
             {...this.props}
             entitiesListSearchProps={this.entitiesListSearchProps}

--- a/client/src/hoc/with-screen-reader-status/index.js
+++ b/client/src/hoc/with-screen-reader-status/index.js
@@ -1,0 +1,66 @@
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
+import hoistStatics from "hoist-non-react-statics";
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || "Component";
+}
+
+export default function withScreenReaderStatus(WrappedComponent) {
+  const displayName = `WithScreenReaderStatus('${getDisplayName(
+    WrappedComponent
+  )})`;
+
+  class WithScreenReaderStatus extends PureComponent {
+    static WrappedComponent = WrappedComponent;
+
+    static displayName = displayName;
+
+    constructor(props) {
+      super(props);
+      this.state = { message: null };
+    }
+
+    get childProps() {
+      return {
+        setScreenReaderStatus: this.setStatus
+      }
+    }
+
+    setStatus = message => {
+      // temporarily update state with new message
+      this.setState({ message: message });
+
+      // remove message
+      setTimeout(() => {
+        this.setState({ message: null })
+      }, 1000);
+    }
+
+    renderLiveRegion() {
+      return (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic
+          className="screen-reader-text"
+        >
+          {this.state.message}
+        </div>
+      );
+    }
+
+    render() {
+      const props = Object.assign({}, this.props, this.childProps);
+
+      return (
+        <React.Fragment>
+          {this.renderLiveRegion()}
+          {React.createElement(WrappedComponent, props)}
+        </React.Fragment>
+      );
+    }
+  }
+
+  return hoistStatics(WithScreenReaderStatus, WrappedComponent);
+}

--- a/client/src/reader/containers/notation/__tests__/__snapshots__/Picker-test.js.snap
+++ b/client/src/reader/containers/notation/__tests__/__snapshots__/Picker-test.js.snap
@@ -1,412 +1,420 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Reader Notation Resource Picker Container renders correctly 1`] = `
-<section
-  role="search"
->
+Array [
   <div
-    onMouseDown={[Function]}
-    role="presentation"
+    aria-atomic={true}
+    aria-live="polite"
+    className="screen-reader-text"
+    role="status"
+  />,
+  <section
+    role="search"
   >
     <div
-      className="button-switch-primary"
-    >
-      <button
-        aria-describedby="button-switch-1"
-        className="button-switch-primary__button"
-        onClick={[Function]}
-      >
-        <div
-          className="button-switch-primary__wrapper"
-        >
-          <div
-            className="button-switch-primary__side button-switch-primary__side--selected"
-          >
-            <svg
-              aria-hidden={true}
-              className="manicon-svg svg-icon--resource24"
-              fill="currentColor"
-              height={30}
-              viewBox="0 0 24 24"
-              width={30}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20,7.21504954 L20,16.7580616 L12,20.9927283 L3.99999997,16.7580616 L3.99999997,7.21504954 L12,3.00704952 L20,7.21504954 Z M19,7.81895042 L12,4.13695041 L4.99999997,7.81895042 L4.99999997,16.1559384 L12,19.8612718 L19,16.1559384 L19,7.81895042 Z M12.5,20.4009 L11.5,20.4009 L11.5,11.4612 L12.5,11.4612 L12.5,20.4009 Z M19.2660832,7.04909169 L19.7339168,7.93290827 L12,12.0267282 L4.26608318,7.93290827 L4.73391676,7.04909169 L12,10.8952718 L19.2660832,7.04909169 Z"
-              />
-            </svg>
-            <span
-              className="button-switch-primary__label"
-            >
-              resources
-            </span>
-          </div>
-          <div
-            className="button-switch-primary__side"
-          >
-            <svg
-              aria-hidden={true}
-              className="manicon-svg svg-icon--resourceCollection64"
-              fill="currentColor"
-              height={30}
-              viewBox="0 0 64 64"
-              width={30}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M24,39 L24,45 L40,45 L40,39 L24,39 Z M42,37 L42,47 L22,47 L22,37 L42,37 Z M56,20.4707664 L47.6615077,14 L16.3394622,14 L7.99999996,20.4707998 L7.99999996,25 L56,25 L56,20.4707664 Z M58,27 L5.99999996,27 L5.99999996,19.4912002 L15.6545377,12 L48.3464923,12 L58,19.4912335 L58,27 Z M57,19 L57,21 L6.99999996,21 L6.99999996,19 L57,19 Z M54,52 L54,26 L56,26 L56,54 L7.99999996,54 L7.99999996,26 L9.99999997,26 L9.99999997,52 L54,52 Z M34.998,26.0006 L36.998,26.0006 C36.9980001,27.7862134 36.0453867,29.4361883 34.499,30.3289951 C32.9526134,31.2218018 31.0473866,31.2218018 29.501,30.3289951 C27.9546133,29.4361883 27.0019999,27.7862134 27.002,26.0006 L29.002,26.0006 C29.002,27.0716823 29.5734155,28.0614031 30.501,28.5969443 C31.4285844,29.1324854 32.5714156,29.1324854 33.499,28.5969443 C34.4265845,28.0614031 34.998,27.0716823 34.998,26.0006 Z"
-              />
-            </svg>
-            <span
-              className="button-switch-primary__label"
-            >
-              collections
-            </span>
-          </div>
-        </div>
-      </button>
-      <span
-        className="aria-describedby"
-        id="button-switch-1"
-      >
-        Toggle options to collections
-      </span>
-    </div>
-    <div
-      className="entity-list"
-      id="entities-list1"
+      onMouseDown={[Function]}
+      role="presentation"
     >
       <div
-        className="entity-list__contents-wrapper"
+        className="button-switch-primary"
       >
-        <div
-          className="entity-list__search entity-list-search"
+        <button
+          aria-describedby="button-switch-1"
+          className="button-switch-primary__button"
+          onClick={[Function]}
         >
-          <form
-            onSubmit={[Function]}
+          <div
+            className="button-switch-primary__wrapper"
           >
             <div
-              className="entity-list-search__keyword-row"
+              className="button-switch-primary__side button-switch-primary__side--selected"
             >
-              <button
-                className="entity-list-search__search-button"
+              <svg
+                aria-hidden={true}
+                className="manicon-svg svg-icon--resource24"
+                fill="currentColor"
+                height={30}
+                viewBox="0 0 24 24"
+                width={30}
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden={true}
-                  className="manicon-svg manicon-magnify svg-icon--search16"
-                  fill="currentColor"
-                  height={null}
-                  viewBox="0 0 16 16"
-                  width={null}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
-                  />
-                </svg>
-                <span
-                  className="screen-reader-text"
-                >
-                  Search
-                </span>
-              </button>
-              <div
-                className="entity-list-search__keyword-input-wrapper"
-              >
-                <label
-                  className="screen-reader-text"
-                  htmlFor="list-search-1"
-                >
-                  Enter Search Criteria
-                </label>
-                <input
-                  className="entity-list-search__keyword-input"
-                  id="list-search-1"
-                  onChange={[Function]}
-                  placeholder="Search..."
-                  type="text"
-                  value=""
+                <path
+                  d="M20,7.21504954 L20,16.7580616 L12,20.9927283 L3.99999997,16.7580616 L3.99999997,7.21504954 L12,3.00704952 L20,7.21504954 Z M19,7.81895042 L12,4.13695041 L4.99999997,7.81895042 L4.99999997,16.1559384 L12,19.8612718 L19,16.1559384 L19,7.81895042 Z M12.5,20.4009 L11.5,20.4009 L11.5,11.4612 L12.5,11.4612 L12.5,20.4009 Z M19.2660832,7.04909169 L19.7339168,7.93290827 L12,12.0267282 L4.26608318,7.93290827 L4.73391676,7.04909169 L12,10.8952718 L19.2660832,7.04909169 Z"
                 />
+              </svg>
+              <span
+                className="button-switch-primary__label"
+              >
+                resources
+              </span>
+            </div>
+            <div
+              className="button-switch-primary__side"
+            >
+              <svg
+                aria-hidden={true}
+                className="manicon-svg svg-icon--resourceCollection64"
+                fill="currentColor"
+                height={30}
+                viewBox="0 0 64 64"
+                width={30}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24,39 L24,45 L40,45 L40,39 L24,39 Z M42,37 L42,47 L22,47 L22,37 L42,37 Z M56,20.4707664 L47.6615077,14 L16.3394622,14 L7.99999996,20.4707998 L7.99999996,25 L56,25 L56,20.4707664 Z M58,27 L5.99999996,27 L5.99999996,19.4912002 L15.6545377,12 L48.3464923,12 L58,19.4912335 L58,27 Z M57,19 L57,21 L6.99999996,21 L6.99999996,19 L57,19 Z M54,52 L54,26 L56,26 L56,54 L7.99999996,54 L7.99999996,26 L9.99999997,26 L9.99999997,52 L54,52 Z M34.998,26.0006 L36.998,26.0006 C36.9980001,27.7862134 36.0453867,29.4361883 34.499,30.3289951 C32.9526134,31.2218018 31.0473866,31.2218018 29.501,30.3289951 C27.9546133,29.4361883 27.0019999,27.7862134 27.002,26.0006 L29.002,26.0006 C29.002,27.0716823 29.5734155,28.0614031 30.501,28.5969443 C31.4285844,29.1324854 32.5714156,29.1324854 33.499,28.5969443 C34.4265845,28.0614031 34.998,27.0716823 34.998,26.0006 Z"
+                />
+              </svg>
+              <span
+                className="button-switch-primary__label"
+              >
+                collections
+              </span>
+            </div>
+          </div>
+        </button>
+        <span
+          className="aria-describedby"
+          id="button-switch-1"
+        >
+          Toggle options to collections
+        </span>
+      </div>
+      <div
+        className="entity-list"
+        id="entities-list1"
+      >
+        <div
+          className="entity-list__contents-wrapper"
+        >
+          <div
+            className="entity-list__search entity-list-search"
+          >
+            <form
+              onSubmit={[Function]}
+            >
+              <div
+                className="entity-list-search__keyword-row"
+              >
+                <button
+                  className="entity-list-search__search-button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="manicon-svg manicon-magnify svg-icon--search16"
+                    fill="currentColor"
+                    height={null}
+                    viewBox="0 0 16 16"
+                    width={null}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M7.00000003,3 C4.79086102,3 3.00000001,4.79086101 3.00000001,7.00000002 C3.00000001,9.20913903 4.79086102,11 7.00000003,11 C9.20912238,11 10.999973,9.20916605 11.0000001,7.00005001 C10.9995314,4.79106172 9.20889466,3.00044165 7.00000003,3 Z M10.8715096,10.1643028 L13.9971535,13.2899467 L13.2900467,13.9970535 L10.1644164,10.8714232 C9.30247365,11.5768009 8.20065857,12.0000001 7.00000003,12.0000001 C4.23857626,12.0000001 2,9.76142379 2,7.00000002 C2,4.23857625 4.23857626,1.99999999 7.0001,2 C9.76123985,2.00055206 11.999448,4.23876021 12.0000001,6.99990005 C12.0000001,8.2005577 11.5768322,9.30236028 10.8715096,10.1643028 Z"
+                    />
+                  </svg>
+                  <span
+                    className="screen-reader-text"
+                  >
+                    Search
+                  </span>
+                </button>
+                <div
+                  className="entity-list-search__keyword-input-wrapper"
+                >
+                  <label
+                    className="screen-reader-text"
+                    htmlFor="list-search-1"
+                  >
+                    Enter Search Criteria
+                  </label>
+                  <input
+                    className="entity-list-search__keyword-input"
+                    id="list-search-1"
+                    onChange={[Function]}
+                    placeholder="Search..."
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <button
+                  className="entity-list-search__text-button"
+                  onClick={[Function]}
+                >
+                  Reset
+                </button>
               </div>
-              <button
-                className="entity-list-search__text-button"
+            </form>
+          </div>
+          <div
+            className="entity-list__header"
+          />
+          <ul
+            className="entity-list__list entity-list__list--rows"
+          >
+            <li
+              className="entity-row entity-list__entity"
+            >
+              <a
+                aria-describedby="undefined1-describedby"
+                className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
+                href="/backend/projects/resource/1"
                 onClick={[Function]}
               >
-                Reset
-              </button>
-            </div>
-          </form>
-        </div>
-        <div
-          className="entity-list__header"
-        />
-        <ul
-          className="entity-list__list entity-list__list--rows"
-        >
-          <li
-            className="entity-row entity-list__entity"
-          >
-            <a
-              aria-describedby="undefined1-describedby"
-              className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
-              href="/backend/projects/resource/1"
-              onClick={[Function]}
-            >
-              <div
-                className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
-              >
                 <div
-                  className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
+                  className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
                 >
-                  <svg
-                    className="manicon-svg svg-icon--resourceImage64"
-                    fill="currentColor"
-                    viewBox="0 0 64 64"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <div
+                    className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
                   >
-                    <path
-                      d="M5.99999996,13 L5.99999996,51 L58,51 L58,13 L5.99999996,13 Z M60,11 L60,53 L3.99999996,53 L3.99999996,11 L60,11 Z M45.114319,36.7052772 C46.0891538,35.776283 47.4070852,35.2956435 48.7511053,35.3789689 C50.0951254,35.4622943 51.3435959,36.1020435 52.2251484,37.1814515 L59.8029485,47.3896515 L58.1970516,48.5817485 L50.6481834,38.4106653 C50.1480528,37.7992777 49.4157245,37.4240133 48.6273486,37.3751363 C47.8389728,37.3262592 47.0659001,37.608193 46.5124285,38.1351833 L39.6414917,45.0279719 L38.9387682,44.1921171 L25.4012973,28.0888039 C24.8721474,27.5066301 24.1255162,27.1696052 23.3388857,27.1578435 C22.5522552,27.1460819 21.7958816,27.4606339 21.2723966,28.0022606 L5.74239658,45.2113607 L4.25760333,43.8714394 L19.8104371,26.6378727 C20.7408786,25.6737527 22.029067,25.1380356 23.3687863,25.1580671 C24.7085055,25.1780985 25.9801016,25.7520894 26.9067318,26.7726829 L39.7669351,42.06926 L45.114319,36.7052772 Z M45.0127,29.9813 C41.6989915,29.9813 39.0127,27.2950085 39.0127,23.9813 C39.0127,20.6675915 41.6989915,17.9813 45.0127,17.9813 C48.3264085,17.9813 51.0127,20.6675915 51.0127,23.9813 C51.0127,27.2950085 48.3264085,29.9813 45.0127,29.9813 Z M45.0127,27.9813 C47.221839,27.9813 49.0127,26.190439 49.0127,23.9813 C49.0127,21.772161 47.221839,19.9813 45.0127,19.9813 C42.803561,19.9813 41.0127,21.772161 41.0127,23.9813 C41.0127,26.190439 42.803561,27.9813 45.0127,27.9813 Z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className="entity-row__text entity-row__text--in-rows"
-                >
-                  <h3
-                    className="entity-row__title entity-row__title--in-rows"
-                  >
-                    <span
-                      className="entity-row__title-inner"
+                    <svg
+                      className="manicon-svg svg-icon--resourceImage64"
+                      fill="currentColor"
+                      viewBox="0 0 64 64"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      Image
-                    </span>
-                    <span
-                      className="entity-row__labels"
+                      <path
+                        d="M5.99999996,13 L5.99999996,51 L58,51 L58,13 L5.99999996,13 Z M60,11 L60,53 L3.99999996,53 L3.99999996,11 L60,11 Z M45.114319,36.7052772 C46.0891538,35.776283 47.4070852,35.2956435 48.7511053,35.3789689 C50.0951254,35.4622943 51.3435959,36.1020435 52.2251484,37.1814515 L59.8029485,47.3896515 L58.1970516,48.5817485 L50.6481834,38.4106653 C50.1480528,37.7992777 49.4157245,37.4240133 48.6273486,37.3751363 C47.8389728,37.3262592 47.0659001,37.608193 46.5124285,38.1351833 L39.6414917,45.0279719 L38.9387682,44.1921171 L25.4012973,28.0888039 C24.8721474,27.5066301 24.1255162,27.1696052 23.3388857,27.1578435 C22.5522552,27.1460819 21.7958816,27.4606339 21.2723966,28.0022606 L5.74239658,45.2113607 L4.25760333,43.8714394 L19.8104371,26.6378727 C20.7408786,25.6737527 22.029067,25.1380356 23.3687863,25.1580671 C24.7085055,25.1780985 25.9801016,25.7520894 26.9067318,26.7726829 L39.7669351,42.06926 L45.114319,36.7052772 Z M45.0127,29.9813 C41.6989915,29.9813 39.0127,27.2950085 39.0127,23.9813 C39.0127,20.6675915 41.6989915,17.9813 45.0127,17.9813 C48.3264085,17.9813 51.0127,20.6675915 51.0127,23.9813 C51.0127,27.2950085 48.3264085,29.9813 45.0127,29.9813 Z M45.0127,27.9813 C47.221839,27.9813 49.0127,26.190439 49.0127,23.9813 C49.0127,21.772161 47.221839,19.9813 45.0127,19.9813 C42.803561,19.9813 41.0127,21.772161 41.0127,23.9813 C41.0127,26.190439 42.803561,27.9813 45.0127,27.9813 Z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    className="entity-row__text entity-row__text--in-rows"
+                  >
+                    <h3
+                      className="entity-row__title entity-row__title--in-rows"
                     >
                       <span
-                        className="entity-row__label"
+                        className="entity-row__title-inner"
                       >
-                        image
+                        Image
                       </span>
-                    </span>
-                    <span
-                      className="aria-describedby"
-                      id="undefined1-describedby"
+                      <span
+                        className="entity-row__labels"
+                      >
+                        <span
+                          className="entity-row__label"
+                        >
+                          image
+                        </span>
+                      </span>
+                      <span
+                        className="aria-describedby"
+                        id="undefined1-describedby"
+                      >
+                        View Image
+                      </span>
+                    </h3>
+                    <div
+                      className="entity-row__meta entity-row__meta--in-rows"
                     >
-                      View Image
-                    </span>
-                  </h3>
-                  <div
-                    className="entity-row__meta entity-row__meta--in-rows"
-                  >
-                    <time
-                      dateTime="2017-04-24"
-                    >
-                      Created April 24, 2017
-                    </time>
+                      <time
+                        dateTime="2017-04-24"
+                      >
+                        Created April 24, 2017
+                      </time>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </a>
-          </li>
-          <li
-            className="entity-row entity-list__entity"
-          >
-            <a
-              aria-describedby="undefined1-describedby"
-              className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
-              href="/backend/projects/resource/2"
-              onClick={[Function]}
+              </a>
+            </li>
+            <li
+              className="entity-row entity-list__entity"
             >
-              <div
-                className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
+              <a
+                aria-describedby="undefined1-describedby"
+                className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
+                href="/backend/projects/resource/2"
+                onClick={[Function]}
               >
                 <div
-                  className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
+                  className="entity-row__inner entity-row__inner--in-rows entity-row__inner--with-row-link"
                 >
-                  <svg
-                    className="manicon-svg svg-icon--resourceImage64"
-                    fill="currentColor"
-                    viewBox="0 0 64 64"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <div
+                    className="entity-row__figure entity-row__figure--size-normal entity-row__figure--shape-square entity-row--figure--in-rows"
                   >
-                    <path
-                      d="M5.99999996,13 L5.99999996,51 L58,51 L58,13 L5.99999996,13 Z M60,11 L60,53 L3.99999996,53 L3.99999996,11 L60,11 Z M45.114319,36.7052772 C46.0891538,35.776283 47.4070852,35.2956435 48.7511053,35.3789689 C50.0951254,35.4622943 51.3435959,36.1020435 52.2251484,37.1814515 L59.8029485,47.3896515 L58.1970516,48.5817485 L50.6481834,38.4106653 C50.1480528,37.7992777 49.4157245,37.4240133 48.6273486,37.3751363 C47.8389728,37.3262592 47.0659001,37.608193 46.5124285,38.1351833 L39.6414917,45.0279719 L38.9387682,44.1921171 L25.4012973,28.0888039 C24.8721474,27.5066301 24.1255162,27.1696052 23.3388857,27.1578435 C22.5522552,27.1460819 21.7958816,27.4606339 21.2723966,28.0022606 L5.74239658,45.2113607 L4.25760333,43.8714394 L19.8104371,26.6378727 C20.7408786,25.6737527 22.029067,25.1380356 23.3687863,25.1580671 C24.7085055,25.1780985 25.9801016,25.7520894 26.9067318,26.7726829 L39.7669351,42.06926 L45.114319,36.7052772 Z M45.0127,29.9813 C41.6989915,29.9813 39.0127,27.2950085 39.0127,23.9813 C39.0127,20.6675915 41.6989915,17.9813 45.0127,17.9813 C48.3264085,17.9813 51.0127,20.6675915 51.0127,23.9813 C51.0127,27.2950085 48.3264085,29.9813 45.0127,29.9813 Z M45.0127,27.9813 C47.221839,27.9813 49.0127,26.190439 49.0127,23.9813 C49.0127,21.772161 47.221839,19.9813 45.0127,19.9813 C42.803561,19.9813 41.0127,21.772161 41.0127,23.9813 C41.0127,26.190439 42.803561,27.9813 45.0127,27.9813 Z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className="entity-row__text entity-row__text--in-rows"
-                >
-                  <h3
-                    className="entity-row__title entity-row__title--in-rows"
-                  >
-                    <span
-                      className="entity-row__title-inner"
+                    <svg
+                      className="manicon-svg svg-icon--resourceImage64"
+                      fill="currentColor"
+                      viewBox="0 0 64 64"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      Image
-                    </span>
-                    <span
-                      className="entity-row__labels"
+                      <path
+                        d="M5.99999996,13 L5.99999996,51 L58,51 L58,13 L5.99999996,13 Z M60,11 L60,53 L3.99999996,53 L3.99999996,11 L60,11 Z M45.114319,36.7052772 C46.0891538,35.776283 47.4070852,35.2956435 48.7511053,35.3789689 C50.0951254,35.4622943 51.3435959,36.1020435 52.2251484,37.1814515 L59.8029485,47.3896515 L58.1970516,48.5817485 L50.6481834,38.4106653 C50.1480528,37.7992777 49.4157245,37.4240133 48.6273486,37.3751363 C47.8389728,37.3262592 47.0659001,37.608193 46.5124285,38.1351833 L39.6414917,45.0279719 L38.9387682,44.1921171 L25.4012973,28.0888039 C24.8721474,27.5066301 24.1255162,27.1696052 23.3388857,27.1578435 C22.5522552,27.1460819 21.7958816,27.4606339 21.2723966,28.0022606 L5.74239658,45.2113607 L4.25760333,43.8714394 L19.8104371,26.6378727 C20.7408786,25.6737527 22.029067,25.1380356 23.3687863,25.1580671 C24.7085055,25.1780985 25.9801016,25.7520894 26.9067318,26.7726829 L39.7669351,42.06926 L45.114319,36.7052772 Z M45.0127,29.9813 C41.6989915,29.9813 39.0127,27.2950085 39.0127,23.9813 C39.0127,20.6675915 41.6989915,17.9813 45.0127,17.9813 C48.3264085,17.9813 51.0127,20.6675915 51.0127,23.9813 C51.0127,27.2950085 48.3264085,29.9813 45.0127,29.9813 Z M45.0127,27.9813 C47.221839,27.9813 49.0127,26.190439 49.0127,23.9813 C49.0127,21.772161 47.221839,19.9813 45.0127,19.9813 C42.803561,19.9813 41.0127,21.772161 41.0127,23.9813 C41.0127,26.190439 42.803561,27.9813 45.0127,27.9813 Z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    className="entity-row__text entity-row__text--in-rows"
+                  >
+                    <h3
+                      className="entity-row__title entity-row__title--in-rows"
                     >
                       <span
-                        className="entity-row__label"
+                        className="entity-row__title-inner"
                       >
-                        image
+                        Image
                       </span>
-                    </span>
-                    <span
-                      className="aria-describedby"
-                      id="undefined1-describedby"
+                      <span
+                        className="entity-row__labels"
+                      >
+                        <span
+                          className="entity-row__label"
+                        >
+                          image
+                        </span>
+                      </span>
+                      <span
+                        className="aria-describedby"
+                        id="undefined1-describedby"
+                      >
+                        View Image
+                      </span>
+                    </h3>
+                    <div
+                      className="entity-row__meta entity-row__meta--in-rows"
                     >
-                      View Image
-                    </span>
-                  </h3>
-                  <div
-                    className="entity-row__meta entity-row__meta--in-rows"
-                  >
-                    <time
-                      dateTime="2017-04-24"
-                    >
-                      Created April 24, 2017
-                    </time>
+                      <time
+                        dateTime="2017-04-24"
+                      >
+                        Created April 24, 2017
+                      </time>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </a>
-          </li>
-        </ul>
-        <div
-          className="entity-list__pagination"
-        >
-          <nav
-            aria-label="Pagination"
-            className="list-pagination"
+              </a>
+            </li>
+          </ul>
+          <div
+            className="entity-list__pagination"
           >
-            <ul
-              className="list-pagination__columns"
+            <nav
+              aria-label="Pagination"
+              className="list-pagination"
             >
-              <li
-                className="list-pagination__column"
+              <ul
+                className="list-pagination__columns"
               >
-                <ul>
-                  <li
-                    className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
-                  >
-                    <a
-                      disabled={true}
-                      href="#entities-list1"
-                      onClick={[Function]}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="manicon-svg svg-icon--arrowLongLeft16"
-                        fill="currentColor"
-                        height={null}
-                        viewBox="0 0 24 16"
-                        width={null}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                          transform="rotate(180 12 8)"
-                        />
-                      </svg>
-                      <span
-                        className="list-pagination__icon-label"
-                      >
-                        PREV
-                      </span>
-                    </a>
-                  </li>
-                </ul>
-              </li>
-              <li
-                className="list-pagination__column-middle"
-              >
-                <ul
-                  className="list-pagination__pages"
+                <li
+                  className="list-pagination__column"
                 >
-                  <li
-                    className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
-                  >
-                    <a
-                      href="#entities-list1"
-                      onClick={[Function]}
+                  <ul>
+                    <li
+                      className="list-pagination__page list-pagination__page--prev list-pagination__page--disabled"
                     >
-                      <span
-                        aria-hidden="true"
+                      <a
+                        disabled={true}
+                        href="#entities-list1"
+                        onClick={[Function]}
                       >
-                        1
-                      </span>
-                      <span
-                        className="screen-reader-text"
-                      >
-                        Go to page: 
-                        1
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    className="list-pagination__page list-pagination__page--ordinal"
+                        <svg
+                          aria-hidden={true}
+                          className="manicon-svg svg-icon--arrowLongLeft16"
+                          fill="currentColor"
+                          height={null}
+                          viewBox="0 0 24 16"
+                          width={null}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                            transform="rotate(180 12 8)"
+                          />
+                        </svg>
+                        <span
+                          className="list-pagination__icon-label"
+                        >
+                          PREV
+                        </span>
+                      </a>
+                    </li>
+                  </ul>
+                </li>
+                <li
+                  className="list-pagination__column-middle"
+                >
+                  <ul
+                    className="list-pagination__pages"
                   >
-                    <a
-                      href="#entities-list1"
-                      onClick={[Function]}
+                    <li
+                      className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                     >
-                      <span
-                        aria-hidden="true"
+                      <a
+                        href="#entities-list1"
+                        onClick={[Function]}
                       >
-                        2
-                      </span>
-                      <span
-                        className="screen-reader-text"
-                      >
-                        Go to page: 
-                        2
-                      </span>
-                    </a>
-                  </li>
-                </ul>
-              </li>
-              <li
-                className="list-pagination__column"
-              >
-                <ul>
-                  <li
-                    className="list-pagination__page list-pagination__page--next"
-                  >
-                    <a
-                      href="#entities-list1"
-                      onClick={[Function]}
+                        <span
+                          aria-hidden="true"
+                        >
+                          1
+                        </span>
+                        <span
+                          className="screen-reader-text"
+                        >
+                          Go to page: 
+                          1
+                        </span>
+                      </a>
+                    </li>
+                    <li
+                      className="list-pagination__page list-pagination__page--ordinal"
                     >
-                      <span
-                        className="list-pagination__icon-label"
+                      <a
+                        href="#entities-list1"
+                        onClick={[Function]}
                       >
-                        NEXT
-                      </span>
-                      <svg
-                        aria-hidden={true}
-                        className="manicon-svg svg-icon--arrowLongRight16"
-                        fill="currentColor"
-                        height={null}
-                        viewBox="0 0 24 16"
-                        width={null}
-                        xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                        >
+                          2
+                        </span>
+                        <span
+                          className="screen-reader-text"
+                        >
+                          Go to page: 
+                          2
+                        </span>
+                      </a>
+                    </li>
+                  </ul>
+                </li>
+                <li
+                  className="list-pagination__column"
+                >
+                  <ul>
+                    <li
+                      className="list-pagination__page list-pagination__page--next"
+                    >
+                      <a
+                        href="#entities-list1"
+                        onClick={[Function]}
                       >
-                        <path
-                          d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
-                        />
-                      </svg>
-                    </a>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </nav>
+                        <span
+                          className="list-pagination__icon-label"
+                        >
+                          NEXT
+                        </span>
+                        <svg
+                          aria-hidden={true}
+                          className="manicon-svg svg-icon--arrowLongRight16"
+                          fill="currentColor"
+                          height={null}
+                          viewBox="0 0 24 16"
+                          width={null}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M19.9210555,8.50098377 L2,8.50098377 L2,7.49848233 L19.9183709,7.49848233 L14.6653905,2.76142495 L15.3486096,2 L22.0012062,7.99920999 L15.3651285,14 L14.6808716,13.2395122 L19.9210555,8.50098377 Z"
+                          />
+                        </svg>
+                      </a>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </nav>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>,
+]
 `;


### PR DESCRIPTION
This PR makes a number of changes to search forms across Manifold in order to improve screen reader experience for form interaction:

* Uses the withScreenReaderStatus HOC to notify screen readers when a search form is reset
* Updates withFilters HOC to render screen reader notification when filters are reset
* Changes search results counts to be live regions, and adds improved readout of results text for screen readers
* Limits render of form reset button to when search/filters have been modified
* Sets focus to shift to search input when reset button is clicked
* Adds "aria-haspopup" and "aria-expanded" attributes to buttons that toggle hidden filters

Resolves #2190