### PR TITLE
[R] Replace labelId helper with react-uid

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -139,6 +139,7 @@
     "react-text-mask": "5.x",
     "react-transition-group": "1.x",
     "react-typekit": "^1.0.8",
+    "react-uid": "^2.2.0",
     "redux": "^4.0",
     "redux-actions": "^2.0",
     "redux-promise": "^0.6",

--- a/client/src/backend/components/category/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/backend/components/category/__tests__/__snapshots__/Form-test.js.snap
@@ -13,13 +13,13 @@ exports[`Backend.Category.Form Component renders correctly 1`] = `
     >
       <label
         className=""
-        htmlFor="attributes[title]-text-input-1"
+        htmlFor="text-input-1"
       >
         Title
       </label>
       <input
-        aria-describedby="attributes[title]-text-input-1"
-        id="attributes[title]-text-input-1"
+        aria-describedby="text-input-error-1"
+        id="text-input-1"
         onChange={[Function]}
         placeholder="What would you like to call this category?"
         type="text"

--- a/client/src/backend/components/content-block/TypeForm/types/__tests__/__snapshots__/TableOfContents-test.js.snap
+++ b/client/src/backend/components/content-block/TypeForm/types/__tests__/__snapshots__/TableOfContents-test.js.snap
@@ -8,13 +8,13 @@ Array [
   >
     <label
       className=""
-      htmlFor="attributes[title]-text-input-1"
+      htmlFor="text-input-1"
     >
       Title
     </label>
     <input
-      aria-describedby="attributes[title]-text-input-1"
-      id="attributes[title]-text-input-1"
+      aria-describedby="text-input-error-1"
+      id="text-input-1"
       onChange={[Function]}
       type="text"
       value=""
@@ -27,7 +27,9 @@ Array [
       className="form-input"
       style={Object {}}
     >
-      <label>
+      <label
+        htmlFor="select-1"
+      >
         Text
       </label>
       <div
@@ -48,6 +50,7 @@ Array [
         </svg>
         <select
           aria-describedby="select-error-1"
+          id="select-1"
           onChange={[Function]}
           value=""
         >
@@ -71,13 +74,13 @@ Array [
   >
     <label
       className=""
-      htmlFor="attributes[depth]-text-input-1"
+      htmlFor="number-input-1"
     >
       Depth
     </label>
     <input
-      aria-describedby="attributes[depth]-text-input-1"
-      id="attributes[depth]-text-input-1"
+      aria-describedby="number-input-error-1"
+      id="number-input-1"
       onChange={[Function]}
       type="number"
       value=""
@@ -88,7 +91,7 @@ Array [
   >
     <label
       className="form-input-heading toggle above"
-      htmlFor="switch-input-1"
+      htmlFor={1}
     >
       Show Text Title?
     </label>
@@ -98,7 +101,7 @@ Array [
       <div
         aria-pressed={false}
         className="boolean-primary"
-        id="switch-input-1"
+        id={1}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}

--- a/client/src/backend/components/form/Date.js
+++ b/client/src/backend/components/form/Date.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
+import { UID } from "react-uid";
 import setter from "./setter";
 import parse from "date-fns/parse";
 import range from "lodash/range";
@@ -10,7 +11,6 @@ import getYear from "date-fns/get_year";
 import isEqual from "date-fns/is_equal";
 import getDaysInMonth from "date-fns/get_days_in_month";
 import GlobalForm from "global/components/form";
-import labelId from "helpers/labelId";
 import MaskedInput from "react-text-mask";
 import isNull from "lodash/isNull";
 import IconComposer from "global/components/utility/IconComposer";
@@ -25,14 +25,7 @@ class FormDate extends Component {
     submitKey: PropTypes.string,
     name: PropTypes.string,
     errors: PropTypes.array,
-    id: PropTypes.string,
-    idForError: PropTypes.string,
     wide: PropTypes.bool
-  };
-
-  static defaultProps = {
-    id: labelId("date-input-"),
-    idForError: labelId("date-input-error-")
   };
 
   constructor(props) {
@@ -72,6 +65,10 @@ class FormDate extends Component {
     }
   }
   /* eslint-enable react/no-did-update-set-state */
+
+  get idForErrorPrefix() {
+    return "date-input-error";
+  }
 
   setInputDay = event => {
     const input = Object.assign({}, this.state.input);
@@ -196,51 +193,58 @@ class FormDate extends Component {
     });
 
     return (
-      <GlobalForm.Errorable
-        className={inputClasses}
-        name={this.props.name}
-        errors={this.props.errors}
-        label={this.props.label}
-        idForError={this.props.idForError}
-      >
-        <div className="form-input-heading">{this.props.label}</div>
-        <div className="form-date">
-          <div className="form-select input-month">
-            {this.renderSelectIcon()}
-            <select
-              onChange={this.setInputMonth}
-              value={this.state.input.month}
-            >
-              <option />
-              {this.months.map((month, index) => {
-                return (
-                  <option value={index} key={month}>
-                    {month}
-                  </option>
-                );
-              })}
-            </select>
-          </div>
-          <div className="form-select input-day">
-            {this.renderSelectIcon()}
-            <select onChange={this.setInputDay} value={this.state.input.day}>
-              <option />
-              {this.days().map(day => {
-                return <option key={day}>{day}</option>;
-              })}
-            </select>
-          </div>
-          <div className="form-input">
-            <MaskedInput
-              type="text"
-              mask={[/\d/, /\d/, /\d/, /\d/]}
-              className="input-year"
-              onChange={this.setInputYear}
-              value={this.state.input.year}
-            />
-          </div>
-        </div>
-      </GlobalForm.Errorable>
+      <UID>
+        {id => (
+          <GlobalForm.Errorable
+            className={inputClasses}
+            name={this.props.name}
+            errors={this.props.errors}
+            label={this.props.label}
+            idForError={`${this.idForErrorPrefix}-${id}`}
+          >
+            <div className="form-input-heading">{this.props.label}</div>
+            <div className="form-date">
+              <div className="form-select input-month">
+                {this.renderSelectIcon()}
+                <select
+                  onChange={this.setInputMonth}
+                  value={this.state.input.month}
+                >
+                  <option />
+                  {this.months.map((month, index) => {
+                    return (
+                      <option value={index} key={month}>
+                        {month}
+                      </option>
+                    );
+                  })}
+                </select>
+              </div>
+              <div className="form-select input-day">
+                {this.renderSelectIcon()}
+                <select
+                  onChange={this.setInputDay}
+                  value={this.state.input.day}
+                >
+                  <option />
+                  {this.days().map(day => {
+                    return <option key={day}>{day}</option>;
+                  })}
+                </select>
+              </div>
+              <div className="form-input">
+                <MaskedInput
+                  type="text"
+                  mask={[/\d/, /\d/, /\d/, /\d/]}
+                  className="input-year"
+                  onChange={this.setInputYear}
+                  value={this.state.input.year}
+                />
+              </div>
+            </div>
+          </GlobalForm.Errorable>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/DatePicker.js
+++ b/client/src/backend/components/form/DatePicker.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
+import { UID } from "react-uid";
 import setter from "./setter";
 import GlobalForm from "global/components/form";
 import Header from "./DatePicker/Header";
-import labelId from "helpers/labelId";
 import MaskedInput from "./MaskedTextInput";
 import classnames from "classnames";
 import ReactDatePicker from "react-datepicker";
@@ -18,11 +18,6 @@ class DatePicker extends PureComponent {
     wide: PropTypes.bool
   };
 
-  static defaultProps = {
-    id: labelId("date-picker-"),
-    idForError: labelId("date-picker-error-")
-  };
-
   get value() {
     if (!this.props.value) return null;
     const date = isDate(this.props.value)
@@ -30,6 +25,10 @@ class DatePicker extends PureComponent {
       : new Date(this.props.value);
 
     return this.dateUTC(date);
+  }
+
+  get idForErrorPrefix() {
+    return "date-picker-error";
   }
 
   // The API returns values in UTC, but the JS tries to render dates in the user's local
@@ -57,38 +56,53 @@ class DatePicker extends PureComponent {
     });
 
     return (
-      <GlobalForm.Errorable
-        className={inputClasses}
-        name={this.props.name}
-        errors={this.props.errors}
-        label={this.props.label}
-        idForError={this.props.idForError}
-      >
-        <h4 className="form-input-heading">{this.props.label}</h4>
-        <ReactDatePicker
-          customInput={
-            <MaskedInput
-              type="text"
-              mask={[/\d/, /\d/, "/", /\d/, /\d/, "/", /\d/, /\d/, /\d/, /\d/]}
-            />
-          }
-          placeholderText={this.props.placeholder}
-          dropdownMode="scroll"
-          dateFormat="MM/dd/yyyy"
-          selected={this.value}
-          onChange={this.handleChange}
-          renderCustomHeader={props => <Header {...props} />}
-        />
-        {this.props.value && (
-          <button
-            type="button"
-            className="form-date-picker__button"
-            onClick={this.clear}
+      <UID>
+        {id => (
+          <GlobalForm.Errorable
+            className={inputClasses}
+            name={this.props.name}
+            errors={this.props.errors}
+            label={this.props.label}
+            idForError={`${this.idForErrorPrefix}-${id}`}
           >
-            Clear
-          </button>
+            <h4 className="form-input-heading">{this.props.label}</h4>
+            <ReactDatePicker
+              customInput={
+                <MaskedInput
+                  type="text"
+                  mask={[
+                    /\d/,
+                    /\d/,
+                    "/",
+                    /\d/,
+                    /\d/,
+                    "/",
+                    /\d/,
+                    /\d/,
+                    /\d/,
+                    /\d/
+                  ]}
+                />
+              }
+              placeholderText={this.props.placeholder}
+              dropdownMode="scroll"
+              dateFormat="MM/dd/yyyy"
+              selected={this.value}
+              onChange={this.handleChange}
+              renderCustomHeader={props => <Header {...props} />}
+            />
+            {this.props.value && (
+              <button
+                type="button"
+                className="form-date-picker__button"
+                onClick={this.clear}
+              >
+                Clear
+              </button>
+            )}
+          </GlobalForm.Errorable>
         )}
-      </GlobalForm.Errorable>
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/GeneratedPasswordInput.js
+++ b/client/src/backend/components/form/GeneratedPasswordInput.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 import setter from "./setter";
 import GlobalForm from "global/components/form";
 import generatePassword from "helpers/passwordGenerator";
@@ -15,15 +15,11 @@ class FormGeneratedPasswordInput extends Component {
     value: PropTypes.any,
     focusOnMount: PropTypes.bool,
     errors: PropTypes.array,
-    set: PropTypes.func,
-    id: PropTypes.string,
-    idForError: PropTypes.string
+    set: PropTypes.func
   };
 
   static defaultProps = {
-    focusOnMount: false,
-    id: labelId("generated-password-"),
-    idForError: labelId("generated-password-error-")
+    focusOnMount: false
   };
 
   constructor(props) {
@@ -42,6 +38,14 @@ class FormGeneratedPasswordInput extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (this.state !== prevState) this.setValueFromCurrentState();
+  }
+
+  get idPrefix() {
+    return "generated-password";
+  }
+
+  get idForErrorPrefix() {
+    return "generated-password-error";
   }
 
   setValueFromCurrentState() {
@@ -65,7 +69,7 @@ class FormGeneratedPasswordInput extends Component {
     this.setState({ password: value });
   }
 
-  renderInput() {
+  renderInput(id) {
     const type = this.state.showPassword ? "text" : "password";
 
     return (
@@ -73,7 +77,7 @@ class FormGeneratedPasswordInput extends Component {
         ref={input => {
           this.inputElement = input;
         }}
-        id={this.props.id}
+        id={`${this.idPrefix}-${id}`}
         aria-describedby={this.props.idForError}
         type={type}
         placeholder={"Enter a password"}
@@ -87,31 +91,35 @@ class FormGeneratedPasswordInput extends Component {
     const icon = !this.state.showPassword ? "eyeClosed32" : "eyeOpen32";
 
     return (
-      <GlobalForm.Errorable
-        className="form-input password-input"
-        name={this.props.name}
-        errors={this.props.errors}
-        label="Password"
-        idForError={this.props.idForError}
-      >
-        <label htmlFor={this.props.id}>Password</label>
-        <span
-          className="password-input__visibility-toggle"
-          onClick={event => this.togglePassword(event)}
-          role="button"
-          tabIndex="0"
-        >
-          <IconComposer
-            icon={icon}
-            size="default"
-            iconClass="password-input__visibility-icon"
-          />
-          <span className="screen-reader-text">
-            {this.state.showPassword ? "hide password" : "show password"}
-          </span>
-        </span>
-        {this.renderInput()}
-      </GlobalForm.Errorable>
+      <UID>
+        {id => (
+          <GlobalForm.Errorable
+            className="form-input password-input"
+            name={this.props.name}
+            errors={this.props.errors}
+            label="Password"
+            idForError={`${this.idForErrorPrefix}-${id}`}
+          >
+            <label htmlFor={`${this.idPrefix}-${id}`}>Password</label>
+            <span
+              className="password-input__visibility-toggle"
+              onClick={event => this.togglePassword(event)}
+              role="button"
+              tabIndex="0"
+            >
+              <IconComposer
+                icon={icon}
+                size="default"
+                iconClass="password-input__visibility-icon"
+              />
+              <span className="screen-reader-text">
+                {this.state.showPassword ? "hide password" : "show password"}
+              </span>
+            </span>
+            {this.renderInput(id)}
+          </GlobalForm.Errorable>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/HasMany/index.js
+++ b/client/src/backend/components/form/HasMany/index.js
@@ -1,10 +1,10 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
+import { UID } from "react-uid";
 import GlobalForm from "global/components/form";
 import List from "./List";
 import Header from "./Header";
-import labelId from "helpers/labelId";
 import setter from "../setter";
 import OptionsList from "../OptionsList";
 import isArray from "lodash/isArray";
@@ -29,7 +29,6 @@ export class FormHasMany extends PureComponent {
     entityAvatarAttribute: PropTypes.string,
     placeholder: PropTypes.string,
     errors: PropTypes.array,
-    idForError: PropTypes.string,
     instructions: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     set: PropTypes.func,
     name: PropTypes.string,
@@ -39,7 +38,6 @@ export class FormHasMany extends PureComponent {
   };
 
   static defaultProps = {
-    idForError: labelId("predictive-text-belongs-to-error-"),
     searchable: true,
     emptyMessage: "None Added"
   };
@@ -70,6 +68,10 @@ export class FormHasMany extends PureComponent {
   get entities() {
     const entities = this.props.name ? this.props.value : this.props.entities;
     return entities || [];
+  }
+
+  get idForErrorPrefix() {
+    return "predictive-text-belongs-to-error";
   }
 
   selectOne(entity) {
@@ -111,41 +113,45 @@ export class FormHasMany extends PureComponent {
     });
 
     return (
-      <GlobalForm.Errorable
-        className={inputClasses}
-        name={this.props.name}
-        errors={this.props.errors}
-        label={this.props.label}
-        idForError={this.props.idForError}
-      >
-        <Header
-          label={this.props.label}
-          labelTag={this.props.labelTag}
-          labelHeader={this.props.labelHeader}
-          instructions={this.props.instructions}
-        />
-        <nav className="has-many-list">
-          {this.renderList(
-            this.props.orderable || this.props.editClickHandler,
-            this.props
-          )}
-          <OptionsList
-            placeholder={this.props.placeholder}
-            label={this.entityName}
-            onNew={this.props.onNew ? this.onNew : null}
-            onSelect={this.onSelect}
-            fetch={this.props.fetch}
-            fetchOptions={this.props.fetchOptions}
-            options={this.props.options}
-            searchable={this.props.searchable}
-            idForError={this.props.idForError}
-          />
-          {this.renderList(
-            !this.props.orderable && !this.props.editClickHandler,
-            this.props
-          )}
-        </nav>
-      </GlobalForm.Errorable>
+      <UID name={id => `${this.idForErrorPrefix}-${id}`}>
+        {id => (
+          <GlobalForm.Errorable
+            className={inputClasses}
+            name={this.props.name}
+            errors={this.props.errors}
+            label={this.props.label}
+            idForError={id}
+          >
+            <Header
+              label={this.props.label}
+              labelTag={this.props.labelTag}
+              labelHeader={this.props.labelHeader}
+              instructions={this.props.instructions}
+            />
+            <nav className="has-many-list">
+              {this.renderList(
+                this.props.orderable || this.props.editClickHandler,
+                this.props
+              )}
+              <OptionsList
+                placeholder={this.props.placeholder}
+                label={this.entityName}
+                onNew={this.props.onNew ? this.onNew : null}
+                onSelect={this.onSelect}
+                fetch={this.props.fetch}
+                fetchOptions={this.props.fetchOptions}
+                options={this.props.options}
+                searchable={this.props.searchable}
+                idForError={id}
+              />
+              {this.renderList(
+                !this.props.orderable && !this.props.editClickHandler,
+                this.props
+              )}
+            </nav>
+          </GlobalForm.Errorable>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/MaskedTextInput.js
+++ b/client/src/backend/components/form/MaskedTextInput.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 import MaskedInput from "react-text-mask";
 import createNumberMask from "text-mask-addons/dist/createNumberMask";
 import fill from "lodash/fill";
@@ -22,18 +22,17 @@ class FormMaskedTextInput extends Component {
     onChange: PropTypes.func,
     value: PropTypes.string,
     instructions: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-    id: PropTypes.string,
     onClick: PropTypes.func,
     wide: PropTypes.bool
-  };
-
-  static defaultProps = {
-    id: labelId("masked-text-")
   };
 
   constructor() {
     super();
     this.placeholderChar = "\u005F"; // react-text-mask default "_"
+  }
+
+  get idPrefix() {
+    return "masked-text";
   }
 
   currencyMask() {
@@ -97,22 +96,26 @@ class FormMaskedTextInput extends Component {
     });
 
     return (
-      <div className={inputClasses}>
-        <label htmlFor={this.props.id} className={labelClass}>
-          {this.props.label}
-        </label>
-        <MaskedInput
-          onChange={this.props.onChange}
-          value={this.props.value}
-          id={this.props.id}
-          type="text"
-          mask={mask}
-          placeholder={this.props.placeholder}
-          placeholderChar={this.placeholderChar}
-          onClick={this.props.onClick}
-        />
-        <Instructions instructions={this.props.instructions} />
-      </div>
+      <UID name={id => `${this.idPrefix}-${id}`}>
+        {id => (
+          <div className={inputClasses}>
+            <label htmlFor={id} className={labelClass}>
+              {this.props.label}
+            </label>
+            <MaskedInput
+              onChange={this.props.onChange}
+              value={this.props.value}
+              id={id}
+              type="text"
+              mask={mask}
+              placeholder={this.props.placeholder}
+              placeholderChar={this.placeholderChar}
+              onClick={this.props.onClick}
+            />
+            <Instructions instructions={this.props.instructions} />
+          </div>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/NumberInput.js
+++ b/client/src/backend/components/form/NumberInput.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { UID } from "react-uid";
 import BaseInput from "./BaseInput";
-import labelId from "helpers/labelId";
 import isNull from "lodash/isNull";
 import isUndefined from "lodash/isUndefined";
 
@@ -18,16 +18,20 @@ export default class FormNumberInput extends Component {
     value: PropTypes.any,
     focusOnMount: PropTypes.bool,
     errors: PropTypes.array,
-    id: PropTypes.string,
-    idForError: PropTypes.string,
     wide: PropTypes.bool
   };
 
   static defaultProps = {
-    focusOnMount: false,
-    id: labelId("text-input-"),
-    idForError: labelId("text-input-error-")
+    focusOnMount: false
   };
+
+  get idPrefix() {
+    return "number-input";
+  }
+
+  get idForErrorPrefix() {
+    return "number-input-error";
+  }
 
   renderValue = value => {
     if (isNull(value) || isUndefined(value)) return "";
@@ -35,22 +39,19 @@ export default class FormNumberInput extends Component {
   };
 
   render() {
-    const id = this.props.name
-      ? this.props.name + "-" + this.props.id
-      : this.props.id;
-    const errorId = this.props.name
-      ? this.props.name + "-" + this.props.id
-      : this.props.id;
-
     return (
-      <BaseInput
-        {...this.props}
-        inputClasses="form-number-input"
-        id={id}
-        idForError={errorId}
-        inputType="number"
-        renderValue={this.renderValue}
-      />
+      <UID>
+        {id => (
+          <BaseInput
+            {...this.props}
+            inputClasses="form-number-input"
+            id={`${this.idPrefix}-${id}`}
+            idForError={`${this.idForErrorPrefix}-${id}`}
+            inputType="number"
+            renderValue={this.renderValue}
+          />
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/Radios.js
+++ b/client/src/backend/components/form/Radios.js
@@ -1,10 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { UID } from "react-uid";
 import GlobalForm from "global/components/form";
 import Option from "./Radio/Option";
 import RadioLabel from "./Radio/Label";
 import classnames from "classnames";
-import labelId from "helpers/labelId";
 import isString from "lodash/isString";
 import Instructions from "./Instructions";
 import withFormOptions from "hoc/with-form-options";
@@ -27,17 +27,13 @@ class FormRadios extends Component {
     name: PropTypes.string,
     value: PropTypes.any,
     set: PropTypes.func,
-    id: PropTypes.string,
-    idForError: PropTypes.string,
     inputClasses: PropTypes.string,
     instructions: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     focusOnMount: PropTypes.bool
   };
 
   static defaultProps = {
-    focusOnMount: false,
-    id: labelId("radios-"),
-    idForError: labelId("radios-error-")
+    focusOnMount: false
   };
 
   get focusOnMount() {
@@ -65,32 +61,44 @@ class FormRadios extends Component {
     });
   }
 
+  get idPrefix() {
+    return "radios";
+  }
+
+  get idForErrorPrefix() {
+    return "radios-error";
+  }
+
   render() {
     return (
-      <GlobalForm.Errorable
-        className={this.inputClasses}
-        name={this.props.name}
-        errors={this.props.errors}
-        label={this.props.label}
-        idForError={this.props.idForError}
-      >
-        <fieldset className="form-input-radios__wrapper">
-          <RadioLabel
+      <UID>
+        {id => (
+          <GlobalForm.Errorable
+            className={this.inputClasses}
+            name={this.props.name}
+            errors={this.props.errors}
             label={this.props.label}
-            prompt={this.props.prompt}
-            hasInstructions={isString(this.props.instructions)}
-          />
-          <Instructions instructions={this.props.instructions} />
-          {this.options.map((option, index) => (
-            <Option
-              key={`${this.props.id}-${option.internalValue}`}
-              option={option}
-              focusOnMount={this.focusOnMount && index === 0}
-              {...this.optionProps}
-            />
-          ))}
-        </fieldset>
-      </GlobalForm.Errorable>
+            idForError={`${this.idForErrorPrefix}-${id}`}
+          >
+            <fieldset className="form-input-radios__wrapper">
+              <RadioLabel
+                label={this.props.label}
+                prompt={this.props.prompt}
+                hasInstructions={isString(this.props.instructions)}
+              />
+              <Instructions instructions={this.props.instructions} />
+              {this.options.map((option, index) => (
+                <Option
+                  key={`${this.idPrefix}-${id}-${option.internalValue}`}
+                  option={option}
+                  focusOnMount={this.focusOnMount && index === 0}
+                  {...this.optionProps}
+                />
+              ))}
+            </fieldset>
+          </GlobalForm.Errorable>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/Select.js
+++ b/client/src/backend/components/form/Select.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 import GlobalForm from "global/components/form";
 import Instructions from "./Instructions";
 import withFormOptions from "hoc/with-form-options";
@@ -23,20 +23,21 @@ class FormSelect extends Component {
         internalValue: PropTypes.any.isRequired
       })
     ).isRequired,
-    focusOnMount: PropTypes.bool,
-    id: PropTypes.string,
-    idForError: PropTypes.string
-  };
-
-  static defaultProps = {
-    id: labelId("select-"),
-    idForError: labelId("select-error-")
+    focusOnMount: PropTypes.bool
   };
 
   componentDidMount() {
     if (this.props.focusOnMount === true && this.inputElement) {
       this.inputElement.focus();
     }
+  }
+
+  get idPrefix() {
+    return "select";
+  }
+
+  get idForErrorPrefix() {
+    return "select-error";
   }
 
   render() {
@@ -49,36 +50,42 @@ class FormSelect extends Component {
     });
 
     return (
-      <div className="form-input">
-        <GlobalForm.Errorable
-          className="form-input"
-          name={this.props.name}
-          errors={this.props.errors}
-          label={this.props.label}
-          idForError={this.props.idForError}
-        >
-          <label htmlFor={this.id}>{this.props.label}</label>
-          <div className="form-select">
-            <IconComposer
-              icon="disclosureDown16"
-              size={20}
-              iconClass="form-select__icon"
-            />
-            <select
-              id={this.id}
-              aria-describedby={this.props.idForError}
-              onChange={this.props.onChange}
-              value={this.props.value}
-              ref={input => {
-                this.inputElement = input;
-              }}
+      <UID>
+        {id => (
+          <div className="form-input">
+            <GlobalForm.Errorable
+              className="form-input"
+              name={this.props.name}
+              errors={this.props.errors}
+              label={this.props.label}
+              idForError={`${this.idForErrorPrefix}-${id}`}
             >
-              {options}
-            </select>
+              <label htmlFor={`${this.idPrefix}-${id}`}>
+                {this.props.label}
+              </label>
+              <div className="form-select">
+                <IconComposer
+                  icon="disclosureDown16"
+                  size={20}
+                  iconClass="form-select__icon"
+                />
+                <select
+                  id={`${this.idPrefix}-${id}`}
+                  aria-describedby={`${this.idForErrorPrefix}-${id}`}
+                  onChange={this.props.onChange}
+                  value={this.props.value}
+                  ref={input => {
+                    this.inputElement = input;
+                  }}
+                >
+                  {options}
+                </select>
+              </div>
+              <Instructions instructions={this.props.instructions} />
+            </GlobalForm.Errorable>
           </div>
-          <Instructions instructions={this.props.instructions} />
-        </GlobalForm.Errorable>
-      </div>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/Switch.js
+++ b/client/src/backend/components/form/Switch.js
@@ -1,9 +1,9 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
+import { UID } from "react-uid";
 import setter from "./setter";
 import Instructions from "./Instructions";
-import labelId from "helpers/labelId";
 
 class FormSwitch extends Component {
   static displayName = "Form.Switch";
@@ -21,13 +21,11 @@ class FormSwitch extends Component {
       false: PropTypes.string
     }),
     focusOnMount: PropTypes.bool,
-    id: PropTypes.string,
     wide: PropTypes.bool
   };
 
   static defaultProps = {
     labelPos: "above",
-    id: labelId("switch-input-"),
     focusOnMount: false
   };
 
@@ -80,6 +78,10 @@ class FormSwitch extends Component {
     return this.determineChecked(this.props.value);
   }
 
+  get idPrefix() {
+    return "switch-input";
+  }
+
   truthy(value) {
     return value === true || value === "true";
   }
@@ -127,37 +129,43 @@ class FormSwitch extends Component {
     this.setState({ focused: false });
   };
 
-  render() {
-    const label = (
-      <label className={this.labelClasses} htmlFor={this.props.id}>
+  renderLabel(id) {
+    return (
+      <label className={this.labelClasses} htmlFor={id}>
         {this.props.label}
       </label>
     );
+  }
 
+  render() {
     return (
-      <div className={this.wrapperClasses}>
-        {this.props.labelPos === "above" ? label : null}
-        <div className="toggle-indicator">
-          {/* Add .checked to .boolean-primary to change visual state */}
-          <div
-            ref={b => {
-              this.button = b;
-            }}
-            onFocus={this.focus}
-            onBlur={this.blur}
-            onClick={this.handleClick}
-            className={this.switchClasses}
-            role="button"
-            tabIndex="0"
-            aria-pressed={this.checked}
-            id={this.props.id}
-          >
-            <span className="screen-reader-text">{this.props.label}</span>
+      <UID name={id => `${this.idPrefix}-${id}`}>
+        {id => (
+          <div className={this.wrapperClasses}>
+            {this.props.labelPos === "above" && this.renderLabel(id)}
+            <div className="toggle-indicator">
+              {/* Add .checked to .boolean-primary to change visual state */}
+              <div
+                ref={b => {
+                  this.button = b;
+                }}
+                onFocus={this.focus}
+                onBlur={this.blur}
+                onClick={this.handleClick}
+                className={this.switchClasses}
+                role="button"
+                tabIndex="0"
+                aria-pressed={this.checked}
+                id={id}
+              >
+                <span className="screen-reader-text">{this.props.label}</span>
+              </div>
+            </div>
+            {this.props.labelPos === "below" && this.renderLabel(id)}
+            <Instructions instructions={this.props.instructions} />
           </div>
-        </div>
-        {this.props.labelPos === "below" ? label : null}
-        <Instructions instructions={this.props.instructions} />
-      </div>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/TagList.js
+++ b/client/src/backend/components/form/TagList.js
@@ -6,7 +6,7 @@ import ConnectedFormInputs from "backend/containers/form-inputs/connected-inputs
 import List from "./HasMany/List";
 import classnames from "classnames";
 import isString from "lodash/isString";
-import uniqueId from "lodash/uniqueId";
+import { UID } from "react-uid";
 import Instructions from "./Instructions";
 import { tagsAPI } from "api";
 
@@ -21,16 +21,9 @@ class FormTagList extends Component {
     instructions: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     set: PropTypes.func.isRequired,
     wide: PropTypes.bool,
-    id: PropTypes.string,
     errors: PropTypes.array,
     name: PropTypes.string,
-    tagScope: PropTypes.string,
-    idForError: PropTypes.string
-  };
-
-  static defaultProps = {
-    id: uniqueId("tag-list-"),
-    idForError: uniqueId("tag-list-error-")
+    tagScope: PropTypes.string
   };
 
   constructor() {
@@ -49,6 +42,14 @@ class FormTagList extends Component {
     if (this.props.tagScope) options.kind = this.props.tagScope;
 
     return options;
+  }
+
+  get idPrefix() {
+    return "tag-list";
+  }
+
+  get idForErrorPrefix() {
+    return "tag-list-error";
   }
 
   arrayEntities(value) {
@@ -95,35 +96,35 @@ class FormTagList extends Component {
       "form-input": true,
       wide: this.props.wide
     });
-    const id = this.props.name
-      ? this.props.name + "-" + this.props.id
-      : this.props.id;
-    const errorId = this.props.name
-      ? this.props.name + "-" + this.props.id
-      : this.props.id;
 
     return (
-      <GlobalForm.Errorable
-        className={inputClasses}
-        name={this.props.name}
-        errors={this.props.errors}
-        label={this.props.label}
-        idForError={errorId}
-      >
-        <label htmlFor={id} className={labelClass}>
-          {this.props.label}
-        </label>
-        <ConnectedFormInputs.PredictiveInput
-          placeholder="Enter a Tag"
-          fetch={tagsAPI.index}
-          fetchOptions={this.fetchOptions}
-          onSelect={this.handleAdd}
-          onNew={this.handleAdd}
-          label={this.tagLabel}
-        />
-        <Instructions instructions={this.props.instructions} />
-        <div className="has-many-list">{this.renderList(this.props.value)}</div>
-      </GlobalForm.Errorable>
+      <UID>
+        {id => (
+          <GlobalForm.Errorable
+            className={inputClasses}
+            name={this.props.name}
+            errors={this.props.errors}
+            label={this.props.label}
+            idForError={`${this.idForErrorPrefix}-${id}`}
+          >
+            <label htmlFor={`${this.idPrefix}-${id}`} className={labelClass}>
+              {this.props.label}
+            </label>
+            <ConnectedFormInputs.PredictiveInput
+              placeholder="Enter a Tag"
+              fetch={tagsAPI.index}
+              fetchOptions={this.fetchOptions}
+              onSelect={this.handleAdd}
+              onNew={this.handleAdd}
+              label={this.tagLabel}
+            />
+            <Instructions instructions={this.props.instructions} />
+            <div className="has-many-list">
+              {this.renderList(this.props.value)}
+            </div>
+          </GlobalForm.Errorable>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/TextArea.js
+++ b/client/src/backend/components/form/TextArea.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 import setter from "./setter";
 import GlobalForm from "global/components/form";
 import isString from "lodash/isString";
@@ -18,17 +18,21 @@ class FormTextArea extends Component {
     value: PropTypes.string,
     errors: PropTypes.array,
     name: PropTypes.string,
-    id: PropTypes.string,
-    idForError: PropTypes.string,
     instructions: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     wide: PropTypes.bool
   };
 
   static defaultProps = {
-    height: 100,
-    id: labelId("textarea-"),
-    idForError: labelId("textarea-error-")
+    height: 100
   };
+
+  get idPrefix() {
+    return "textarea";
+  }
+
+  get idForErrorPrefix() {
+    return "textarea-error";
+  }
 
   render() {
     const labelClass = classnames({
@@ -40,28 +44,32 @@ class FormTextArea extends Component {
     });
 
     return (
-      <div className={inputClasses}>
-        <GlobalForm.Errorable
-          className="form-input"
-          name={this.props.name}
-          errors={this.props.errors}
-          label={this.props.label}
-          idForError={this.props.idForError}
-        >
-          <label htmlFor={this.props.id} className={labelClass}>
-            {this.props.label}
-          </label>
-          <Instructions instructions={this.props.instructions} />
-          <textarea
-            id={this.props.id}
-            aria-describedby={this.props.idForError}
-            style={{ height: this.props.height }}
-            placeholder={this.props.placeholder}
-            onChange={this.props.onChange}
-            value={this.props.value || ""}
-          />
-        </GlobalForm.Errorable>
-      </div>
+      <UID>
+        {id => (
+          <div className={inputClasses}>
+            <GlobalForm.Errorable
+              className="form-input"
+              name={this.props.name}
+              errors={this.props.errors}
+              label={this.props.label}
+              idForError={`${this.idForErrorPrefix}-${id}`}
+            >
+              <label htmlFor={`${this.idPrefix}-${id}`} className={labelClass}>
+                {this.props.label}
+              </label>
+              <Instructions instructions={this.props.instructions} />
+              <textarea
+                id={`${this.idPrefix}-${id}`}
+                aria-describedby={`${this.idForErrorPrefix}-${id}`}
+                style={{ height: this.props.height }}
+                placeholder={this.props.placeholder}
+                onChange={this.props.onChange}
+                value={this.props.value || ""}
+              />
+            </GlobalForm.Errorable>
+          </div>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/TextInput.js
+++ b/client/src/backend/components/form/TextInput.js
@@ -1,8 +1,8 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import isArray from "lodash/isArray";
+import { UID } from "react-uid";
 import BaseInput from "./BaseInput";
-import labelId from "helpers/labelId";
 
 export default class FormTextInput extends Component {
   static displayName = "Form.TextInput";
@@ -19,18 +19,22 @@ export default class FormTextInput extends Component {
     errors: PropTypes.array,
     password: PropTypes.bool,
     join: PropTypes.func,
-    id: PropTypes.string,
-    idForError: PropTypes.string,
     wide: PropTypes.bool
   };
 
   static defaultProps = {
     focusOnMount: false,
     password: false,
-    join: array => array.join(", "),
-    id: labelId("text-input-"),
-    idForError: labelId("text-input-error-")
+    join: array => array.join(", ")
   };
+
+  get idPrefix() {
+    return "text-input";
+  }
+
+  get idForErrorPrefix() {
+    return "text-input-error";
+  }
 
   renderValue = value => {
     if (!value) return "";
@@ -40,21 +44,19 @@ export default class FormTextInput extends Component {
 
   render() {
     const inputType = this.props.password ? "password" : "text";
-    const id = this.props.name
-      ? this.props.name + "-" + this.props.id
-      : this.props.id;
-    const errorId = this.props.name
-      ? this.props.name + "-" + this.props.id
-      : this.props.id;
 
     return (
-      <BaseInput
-        {...this.props}
-        id={id}
-        idForError={errorId}
-        inputType={inputType}
-        renderValue={this.renderValue}
-      />
+      <UID>
+        {id => (
+          <BaseInput
+            {...this.props}
+            id={`${this.idPrefix}-${id}`}
+            idForError={`${this.idForErrorPrefix}-${id}`}
+            inputType={inputType}
+            renderValue={this.renderValue}
+          />
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/TusUpload.js
+++ b/client/src/backend/components/form/TusUpload.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 import setter from "./setter";
 import Base from "./Upload/Base";
 import tus from "tus-js-client";
@@ -26,15 +26,11 @@ export class FormTusUpload extends Component {
     remove: PropTypes.string, // name of the model remove field: attributes[removeAvatar]
     value: PropTypes.any, // the current value of the field in the connected model
     initialValue: PropTypes.string, // the initial value of the input when it's rendered
-    errors: PropTypes.array,
-    inputId: PropTypes.string,
-    idForError: PropTypes.string
+    errors: PropTypes.array
   };
 
   static defaultProps = {
-    layout: "square",
-    inputId: labelId("upload-"),
-    idForError: labelId("upload-error-")
+    layout: "square"
   };
 
   constructor(props) {
@@ -43,6 +39,14 @@ export class FormTusUpload extends Component {
       progress: null,
       error: null
     };
+  }
+
+  get idPrefix() {
+    return "upload";
+  }
+
+  get idForErrorPrefix() {
+    return "upload-error";
   }
 
   removeFile() {
@@ -104,16 +108,22 @@ export class FormTusUpload extends Component {
   render() {
     const { set: setIgnored, ...baseProps } = this.props;
     return (
-      <Base
-        {...baseProps}
-        accepts={{
-          accepts: null,
-          extensions: null
-        }}
-        progress={this.state.progress}
-        uploadError={this.state.error}
-        updateValue={this.updateValue}
-      />
+      <UID>
+        {id => (
+          <Base
+            {...baseProps}
+            accepts={{
+              accepts: null,
+              extensions: null
+            }}
+            progress={this.state.progress}
+            uploadError={this.state.error}
+            updateValue={this.updateValue}
+            inputId={`${this.idPrefix}-${id}`}
+            idForError={`${this.idForErrorPrefix}-${id}`}
+          />
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/Upload/Base.js
+++ b/client/src/backend/components/form/Upload/Base.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import labelId from "helpers/labelId";
 import Dropzone from "react-dropzone";
 import GlobalForm from "global/components/form";
 import classnames from "classnames";
@@ -31,8 +30,8 @@ export default class FormUpload extends Component {
     value: PropTypes.any, // the current value of the field in the connected model
     initialValue: PropTypes.string, // the initial value of the input when it's rendered
     errors: PropTypes.array,
-    inputId: PropTypes.string,
-    idForError: PropTypes.string,
+    inputId: PropTypes.string.isRequired,
+    idForError: PropTypes.string.isRequired,
     wide: PropTypes.bool,
     progress: PropTypes.string,
     fileNameFrom: PropTypes.string,
@@ -43,9 +42,7 @@ export default class FormUpload extends Component {
   static defaultProps = {
     layout: "square",
     accepts: null,
-    wide: false,
-    inputId: labelId("upload-"),
-    idForError: labelId("upload-error-")
+    wide: false
   };
 
   constructor(props) {

--- a/client/src/backend/components/form/Upload/index.js
+++ b/client/src/backend/components/form/Upload/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 import setter from "../setter";
 import Base from "./Base";
 import get from "lodash/get";
@@ -85,17 +85,21 @@ export class FormUpload extends Component {
     value: PropTypes.any, // the current value of the field in the connected model
     initialValue: PropTypes.string, // the initial value of the input when it's rendered
     errors: PropTypes.array,
-    inputId: PropTypes.string,
-    fileNameFrom: PropTypes.string,
-    idForError: PropTypes.string
+    fileNameFrom: PropTypes.string
   };
 
   static defaultProps = {
     layout: "square",
-    accepts: "any",
-    inputId: labelId("upload-"),
-    idForError: labelId("upload-error-")
+    accepts: "any"
   };
+
+  get idPrefix() {
+    return "upload";
+  }
+
+  get idForErrorPrefix() {
+    return "upload-error";
+  }
 
   updateValue = state => {
     const { attachment, removed } = state;
@@ -124,11 +128,17 @@ export class FormUpload extends Component {
   render() {
     const { set: _set, setOther: _setOther, ...baseProps } = this.props;
     return (
-      <Base
-        {...baseProps}
-        accepts={this.accepts(this.props)}
-        updateValue={this.updateValue}
-      />
+      <UID>
+        {id => (
+          <Base
+            {...baseProps}
+            accepts={this.accepts(this.props)}
+            updateValue={this.updateValue}
+            inputId={`${this.idPrefix}-${id}`}
+            idForError={`${this.idForErrorPrefix}-${id}`}
+          />
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/__tests__/__snapshots__/DatePicker-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/DatePicker-test.js.snap
@@ -21,10 +21,10 @@ exports[`Backend.Form.DatePicker component renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="masked-text-1"
+          htmlFor={1}
         />
         <react-text-mask
-          id="masked-text-1"
+          id={1}
           mask={
             Array [
               /\\\\d/,

--- a/client/src/backend/components/form/__tests__/__snapshots__/GeneratedPasswordInput-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/GeneratedPasswordInput-test.js.snap
@@ -37,7 +37,6 @@ exports[`Backend.Form.GeneratedPasswordInput component renders correctly 1`] = `
     </span>
   </span>
   <input
-    aria-describedby="generated-password-error-1"
     id="generated-password-1"
     onChange={[Function]}
     placeholder="Enter a password"

--- a/client/src/backend/components/form/__tests__/__snapshots__/MaskedTestInput-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/MaskedTestInput-test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Backend.Form.MaskedTextInput component renders correctly 1`] = `"<div class=\\"form-input\\"><label for=\\"masked-text-1\\" class=\\"\\">Label this</label>ReactTextMask</div>"`;
+exports[`Backend.Form.MaskedTextInput component renders correctly 1`] = `"<div class=\\"form-input\\"><label for=\\"1\\" class=\\"\\">Label this</label>ReactTextMask</div>"`;

--- a/client/src/backend/components/form/__tests__/__snapshots__/NumberInput-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/NumberInput-test.js.snap
@@ -7,13 +7,13 @@ exports[`Backend.Form.NumberInput component renders correctly 1`] = `
 >
   <label
     className=""
-    htmlFor="attributes[property]-text-input-1"
+    htmlFor="number-input-1"
   >
     A form label
   </label>
   <input
-    aria-describedby="attributes[property]-text-input-1"
-    id="attributes[property]-text-input-1"
+    aria-describedby="number-input-error-1"
+    id="number-input-1"
     onChange={[Function]}
     type="number"
     value=""

--- a/client/src/backend/components/form/__tests__/__snapshots__/Select-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/Select-test.js.snap
@@ -8,7 +8,9 @@ exports[`Backend.Form.Select component renders correctly 1`] = `
     className="form-input"
     style={Object {}}
   >
-    <label>
+    <label
+      htmlFor="select-1"
+    >
       Label this
     </label>
     <div
@@ -29,6 +31,7 @@ exports[`Backend.Form.Select component renders correctly 1`] = `
       </svg>
       <select
         aria-describedby="select-error-1"
+        id="select-1"
         onChange={[Function]}
         value=""
       >

--- a/client/src/backend/components/form/__tests__/__snapshots__/Switch-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/Switch-test.js.snap
@@ -6,7 +6,7 @@ exports[`Backend.Form.Switch component renders correctly 1`] = `
 >
   <label
     className="form-input-heading toggle above"
-    htmlFor="switch-input-1"
+    htmlFor={1}
   >
     Label this
   </label>
@@ -16,7 +16,7 @@ exports[`Backend.Form.Switch component renders correctly 1`] = `
     <div
       aria-pressed={false}
       className="boolean-primary"
-      id="switch-input-1"
+      id={1}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}

--- a/client/src/backend/components/form/__tests__/__snapshots__/SwitchArray-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/SwitchArray-test.js.snap
@@ -23,7 +23,7 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
       >
         <label
           className="form-input-heading toggle above"
-          htmlFor="switch-input-1"
+          htmlFor={1}
         >
           Option one
         </label>
@@ -33,7 +33,7 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
           <div
             aria-pressed={false}
             className="boolean-primary"
-            id="switch-input-1"
+            id={1}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -53,7 +53,7 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
       >
         <label
           className="form-input-heading toggle above"
-          htmlFor="switch-input-1"
+          htmlFor={1}
         >
           Option two
         </label>
@@ -63,7 +63,7 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
           <div
             aria-pressed={false}
             className="boolean-primary"
-            id="switch-input-1"
+            id={1}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}

--- a/client/src/backend/components/form/__tests__/__snapshots__/TagList-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/TagList-test.js.snap
@@ -7,7 +7,7 @@ exports[`Backend.Form.TagList component renders correctly 1`] = `
 >
   <label
     className=""
-    htmlFor="attributes[tags]-tag-list-1"
+    htmlFor="tag-list-1"
   >
     Tags
   </label>

--- a/client/src/backend/components/form/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/TextInput-test.js.snap
@@ -7,13 +7,13 @@ exports[`Backend.Form.TextInput component renders correctly 1`] = `
 >
   <label
     className=""
-    htmlFor="attributes[property]-text-input-1"
+    htmlFor="text-input-1"
   >
     A form label
   </label>
   <input
-    aria-describedby="attributes[property]-text-input-1"
-    id="attributes[property]-text-input-1"
+    aria-describedby="text-input-error-1"
+    id="text-input-1"
     onChange={[Function]}
     type="text"
     value=""

--- a/client/src/backend/components/ingestion/form/__tests__/__snapshots__/Upload-test.js.snap
+++ b/client/src/backend/components/ingestion/form/__tests__/__snapshots__/Upload-test.js.snap
@@ -122,7 +122,7 @@ exports[`Backend.Ingestion.Form.Upload component renders correctly 1`] = `
       URL
     </label>
     <input
-      aria-describedby="text-input-1"
+      aria-describedby="text-input-error-1"
       id="text-input-1"
       onChange={[Function]}
       type="text"

--- a/client/src/backend/components/ingestion/form/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/backend/components/ingestion/form/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -128,7 +128,7 @@ exports[`Backend.Ingestion.Form.Wrapper component renders correctly 1`] = `
           URL
         </label>
         <input
-          aria-describedby="text-input-1"
+          aria-describedby="text-input-error-1"
           id="text-input-1"
           onChange={[Function]}
           type="text"

--- a/client/src/backend/components/list/EntitiesList/Entity/Row.js
+++ b/client/src/backend/components/list/EntitiesList/Entity/Row.js
@@ -5,7 +5,7 @@ import isArray from "lodash/isArray";
 import isString from "lodash/isString";
 import LabelSet from "./LabelSet";
 import { Link } from "react-router-dom";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 
 export default class EntitiesListRow extends PureComponent {
   static displayName = "List.EntitiesList.Entity.Row";
@@ -199,7 +199,7 @@ export default class EntitiesListRow extends PureComponent {
     return this.props.isSortable;
   }
 
-  wrapWithAnchor(child, url, block = false) {
+  wrapWithAnchor(child, id, url, block = false) {
     const className = classNames({
       "entity-row__row-link": true,
       "entity-row__row-link--block": block,
@@ -211,7 +211,7 @@ export default class EntitiesListRow extends PureComponent {
       <Link
         className={className}
         to={url}
-        aria-describedby={`${this.labelId}-describedby`}
+        aria-describedby={`${id}-describedby`}
       >
         {child}
       </Link>
@@ -233,69 +233,72 @@ export default class EntitiesListRow extends PureComponent {
     );
   }
 
-  wrapWithClickHandler(child, block = false) {
+  wrapWithClickHandler(child, id, block = false) {
     if (!this.onRowClick) return child;
     if (isString(this.onRowClick))
-      return this.wrapWithAnchor(child, this.onRowClick, block);
+      return this.wrapWithAnchor(child, id, this.onRowClick, block);
     return this.wrapWithButton(child, this.onRowClick, block);
   }
 
-  inlineLink(child) {
+  inlineLink(child, id) {
     if (this.rowClickMode !== "inline") return child;
-    return this.wrapWithClickHandler(child, false);
+    return this.wrapWithClickHandler(child, id, false);
   }
 
-  blockLink(child) {
+  blockLink(child, id) {
     if (!this.entireRowIsClickable) return child;
-    return this.wrapWithClickHandler(child, true);
+    return this.wrapWithClickHandler(child, id, true);
   }
 
   render() {
-    this.labelId = labelId();
-
     return (
-      <li className="entity-row entity-list__entity">
-        {this.blockLink(
-          <div className={this.rowClassNames}>
-            {this.figure && (
-              <div className={this.figureClassNames}>
-                {this.inlineLink(this.figure)}
-              </div>
+      <UID>
+        {id => (
+          <li className="entity-row entity-list__entity">
+            {this.blockLink(
+              <div className={this.rowClassNames}>
+                {this.figure && (
+                  <div className={this.figureClassNames}>
+                    {this.inlineLink(this.figure)}
+                  </div>
+                )}
+                <div className={this.textClassNames}>
+                  {this.title && (
+                    <h3 className={this.titleClassNames}>
+                      <span className="entity-row__title-inner">
+                        {this.inlineLink(this.title, id)}
+                      </span>
+                      {this.hasLabels && <LabelSet labels={this.labels} />}
+                      <span
+                        id={`${id}-describedby`}
+                        className="aria-describedby"
+                      >
+                        {`View ${this.titlePlainText}`}
+                      </span>
+                    </h3>
+                  )}
+                  {!this.title && this.hasLabels && (
+                    <LabelSet labels={this.labels} />
+                  )}
+                  {this.hasSubtitle && (
+                    <h4 className={this.subtitleClassNames}>{this.subtitle}</h4>
+                  )}
+                  {this.hasCount && (
+                    <h4 className={this.countClassNames}>{this.count}</h4>
+                  )}
+                  {this.hasMeta && (
+                    <div className={this.metaClassNames}>{this.meta}</div>
+                  )}
+                </div>
+                {this.utility && (
+                  <div className="entity-row__utility">{this.utility}</div>
+                )}
+              </div>,
+              id
             )}
-            <div className={this.textClassNames}>
-              {this.title && (
-                <h3 className={this.titleClassNames}>
-                  <span className="entity-row__title-inner">
-                    {this.inlineLink(this.title)}
-                  </span>
-                  {this.hasLabels && <LabelSet labels={this.labels} />}
-                  <span
-                    id={`${this.labelId}-describedby`}
-                    className="aria-describedby"
-                  >
-                    {`View ${this.titlePlainText}`}
-                  </span>
-                </h3>
-              )}
-              {!this.title && this.hasLabels && (
-                <LabelSet labels={this.labels} />
-              )}
-              {this.hasSubtitle && (
-                <h4 className={this.subtitleClassNames}>{this.subtitle}</h4>
-              )}
-              {this.hasCount && (
-                <h4 className={this.countClassNames}>{this.count}</h4>
-              )}
-              {this.hasMeta && (
-                <div className={this.metaClassNames}>{this.meta}</div>
-              )}
-            </div>
-            {this.utility && (
-              <div className="entity-row__utility">{this.utility}</div>
-            )}
-          </div>
+          </li>
         )}
-      </li>
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/list/EntitiesList/List/Search.js
+++ b/client/src/backend/components/list/EntitiesList/List/Search.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
+import { UID } from "react-uid";
 import Utility from "global/components/utility";
-import labelId from "helpers/labelId";
 import { Collapse } from "react-collapse";
 import classNames from "classnames";
 import has from "lodash/has";
@@ -91,6 +91,10 @@ export default class ListEntitiesListSearch extends PureComponent {
     return this.props.searchStyle;
   }
 
+  get idPrefix() {
+    return "list-search";
+  }
+
   setKeywordState(event) {
     const value = event.target.value;
     this.setState({ keyword: value });
@@ -162,7 +166,6 @@ export default class ListEntitiesListSearch extends PureComponent {
   /* eslint-disable react/no-array-index-key */
   /* these filters never change after render */
   render() {
-    const label = labelId("list-search-");
     const baseClass = "entity-list-search";
 
     return (
@@ -178,18 +181,24 @@ export default class ListEntitiesListSearch extends PureComponent {
                 <span className="screen-reader-text">Search</span>
               </button>
               <div className={`${baseClass}__keyword-input-wrapper`}>
-                <label htmlFor={label} className="screen-reader-text">
-                  Enter Search Criteria
-                </label>
-                <input
-                  ref={this.searchInput}
-                  className={`${baseClass}__keyword-input`}
-                  id={label}
-                  value={this.state.keyword}
-                  type="text"
-                  placeholder={this.paramLabel(this.keywordParam)}
-                  onChange={e => this.setKeywordState(e)}
-                />
+                <UID name={id => `${this.idPrefix}-${id}`}>
+                  {id => (
+                    <React.Fragment>
+                      <label htmlFor={id} className="screen-reader-text">
+                        Enter Search Criteria
+                      </label>
+                      <input
+                        ref={this.searchInput}
+                        className={`${baseClass}__keyword-input`}
+                        id={id}
+                        value={this.state.keyword}
+                        type="text"
+                        placeholder={this.paramLabel(this.keywordParam)}
+                        onChange={e => this.setKeywordState(e)}
+                      />
+                    </React.Fragment>
+                  )}
+                </UID>
               </div>
               <button
                 onClick={this.resetSearch}
@@ -228,22 +237,26 @@ export default class ListEntitiesListSearch extends PureComponent {
                         {i === 0 ? "Filter Results:" : "\u00A0"}
                       </span>
                       <div className={`${baseClass}__select-wrapper`}>
-                        <select
-                          id={labelId("list-search-")}
-                          onChange={e => this.setParam(e, param)}
-                          value={this.paramValue(param)}
-                        >
-                          {this.paramOptions(param).map(
-                            (option, optionIndex) => (
-                              <option
-                                key={optionIndex}
-                                value={option.value || ""}
-                              >
-                                {option.label}
-                              </option>
-                            )
+                        <UID name={id => `${this.idPrefix}-${id}`}>
+                          {id => (
+                            <select
+                              id={id}
+                              onChange={e => this.setParam(e, param)}
+                              value={this.paramValue(param)}
+                            >
+                              {this.paramOptions(param).map(
+                                (option, optionIndex) => (
+                                  <option
+                                    key={optionIndex}
+                                    value={option.value || ""}
+                                  >
+                                    {option.label}
+                                  </option>
+                                )
+                              )}
+                            </select>
                           )}
-                        </select>
+                        </UID>
                         <Utility.IconComposer icon="disclosureDown24" />
                       </div>
                     </div>
@@ -258,22 +271,26 @@ export default class ListEntitiesListSearch extends PureComponent {
                         Order Results:
                       </span>
                       <div className={`${baseClass}__select-wrapper`}>
-                        <select
-                          id={labelId("list-search-")}
-                          onChange={e => this.setParam(e, this.orderParam)}
-                          value={this.paramValue(this.orderParam)}
-                        >
-                          {this.paramOptions(this.orderParam).map(
-                            (option, optionIndex) => (
-                              <option
-                                key={optionIndex}
-                                value={option.value || ""}
-                              >
-                                {option.label}
-                              </option>
-                            )
+                        <UID name={id => `${this.idPrefix}-${id}`}>
+                          {id => (
+                            <select
+                              id={id}
+                              onChange={e => this.setParam(e, this.orderParam)}
+                              value={this.paramValue(this.orderParam)}
+                            >
+                              {this.paramOptions(this.orderParam).map(
+                                (option, optionIndex) => (
+                                  <option
+                                    key={optionIndex}
+                                    value={option.value || ""}
+                                  >
+                                    {option.label}
+                                  </option>
+                                )
+                              )}
+                            </select>
                           )}
-                        </select>
+                        </UID>
                         <Utility.IconComposer icon="disclosureDown24" />
                       </div>
                     </div>

--- a/client/src/backend/components/list/EntitiesList/List/index.js
+++ b/client/src/backend/components/list/EntitiesList/List/index.js
@@ -12,7 +12,7 @@ import isPlainObject from "lodash/isPlainObject";
 import isFunction from "lodash/isFunction";
 import isBoolean from "lodash/isBoolean";
 import isNil from "lodash/isNil";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 
 export default class ListEntities extends PureComponent {
   static displayName = "List.Entities.List";
@@ -182,14 +182,16 @@ export default class ListEntities extends PureComponent {
     return isFunction(this.callbacks.onReorder);
   }
 
+  get idPrefix() {
+    return "entities-list";
+  }
+
   callback(name) {
     if (!this.callbacks) return null;
     return this.callbacks[name];
   }
 
   render() {
-    const listId = labelId("entities-list");
-
     const wrapperClassNames = classNames({
       "entity-list": true,
       "entity-list--bare": this.listStyle === "bare"
@@ -210,48 +212,52 @@ export default class ListEntities extends PureComponent {
     });
 
     return (
-      <div id={listId} className={wrapperClassNames}>
-        {this.title && (
-          <Title
-            title={this.title}
-            titleIcon={this.titleIcon}
-            titleStyle={this.titleStyle}
-            titleLink={this.titleLink}
-            pagination={this.pagination}
-            showCount={this.showCountInTitle}
-          />
-        )}
-        <div className={contentsWrapperClassName}>
-          {this.instructions && (
-            <Instructions instructions={this.instructions} />
-          )}
-          {this.hasSearch && this.search}
-          <div className="entity-list__header">
-            {this.hasButtons && <ButtonSet buttons={this.buttons} />}
-            {this.showCount && (
-              <Count
-                showCount={this.showCount}
-                unit={this.unit}
+      <UID name={id => `${this.idPrefix}-${id}`}>
+        {id => (
+          <div id={id} className={wrapperClassNames}>
+            {this.title && (
+              <Title
+                title={this.title}
+                titleIcon={this.titleIcon}
+                titleStyle={this.titleStyle}
+                titleLink={this.titleLink}
                 pagination={this.pagination}
+                showCount={this.showCountInTitle}
               />
             )}
+            <div className={contentsWrapperClassName}>
+              {this.instructions && (
+                <Instructions instructions={this.instructions} />
+              )}
+              {this.hasSearch && this.search}
+              <div className="entity-list__header">
+                {this.hasButtons && <ButtonSet buttons={this.buttons} />}
+                {this.showCount && (
+                  <Count
+                    showCount={this.showCount}
+                    unit={this.unit}
+                    pagination={this.pagination}
+                  />
+                )}
+              </div>
+              {!this.isSortable && (
+                <Entities {...this.props} className={listClassNames} />
+              )}
+              {this.isSortable && (
+                <SortableEntities {...this.props} className={listClassNames} />
+              )}
+              {this.pagination && (
+                <Pagination
+                  pagination={this.pagination}
+                  paginationTarget={`#${id}`}
+                  onPageClick={this.callback("onPageClick")}
+                  style={this.paginationStyle}
+                />
+              )}
+            </div>
           </div>
-          {!this.isSortable && (
-            <Entities {...this.props} className={listClassNames} />
-          )}
-          {this.isSortable && (
-            <SortableEntities {...this.props} className={listClassNames} />
-          )}
-          {this.pagination && (
-            <Pagination
-              pagination={this.pagination}
-              paginationTarget={`#${listId}`}
-              onPageClick={this.callback("onPageClick")}
-              style={this.paginationStyle}
-            />
-          )}
-        </div>
-      </div>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/project-collection/Header.js
+++ b/client/src/backend/components/project-collection/Header.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import Navigation from "backend/components/navigation";
 import { Link } from "react-router-dom";
-import labelId from "helpers/labelId";
 import lh from "helpers/linkHandler";
 import IconComposer from "global/components/utility/IconComposer";
 
@@ -11,10 +10,6 @@ export default class ProjectCollectionHeader extends PureComponent {
 
   static propTypes = {
     projectCollection: PropTypes.object
-  };
-
-  static defaultProps = {
-    sortId: labelId("project-collection-header-")
   };
 
   get iconName() {

--- a/client/src/backend/components/project-collection/SortBy.js
+++ b/client/src/backend/components/project-collection/SortBy.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import uniqueId from "lodash/uniqueId";
+import { UID } from "react-uid";
 import IconComposer from "global/components/utility/IconComposer";
 
 export default class ProjectCollectionSortBy extends PureComponent {
@@ -9,13 +9,12 @@ export default class ProjectCollectionSortBy extends PureComponent {
 
   static propTypes = {
     projectCollection: PropTypes.object,
-    sortChangeHandler: PropTypes.func.isRequired,
-    sortId: PropTypes.string
+    sortChangeHandler: PropTypes.func.isRequired
   };
 
-  static defaultProps = {
-    sortId: uniqueId("collection-sort-")
-  };
+  get idPrefix() {
+    return "collection-sort";
+  }
 
   isManualSort(projectCollection) {
     if (!projectCollection) return false;
@@ -49,47 +48,54 @@ export default class ProjectCollectionSortBy extends PureComponent {
     const selected = projectCollection.attributes.sortOrder;
 
     return (
-      <div className="select-group">
-        <label htmlFor={this.props.sortId}>Order Collection By:</label>
-        <div className="select" key="filter[order]">
-          <select
-            id={this.props.sortId}
-            onChange={this.handleChange}
-            value={selected}
-            data-id={"filter"}
-          >
-            <option key="created_at_desc" value="created_at_desc">
-              Date Created (Newest First)
-            </option>
-            <option key="created_at_asc" value="created_at_asc">
-              Date Created (Oldest First)
-            </option>
-            <option key="updated_at_desc" value="updated_at_desc">
-              Last Updated (Newest First)
-            </option>
-            <option key="updated_at_asc" value="updated_at_asc">
-              Last Updated (Oldest First)
-            </option>
-            <option key="title_asc" value="title_asc">
-              Title A to Z
-            </option>
-            <option key="title_desc" value="title_desc">
-              Title Z to A
-            </option>
-            <option key="publication_date_desc" value="publication_date_desc">
-              Publication Date (Newest First)
-            </option>
-            <option key="publication_date_asc" value="publication_date_asc">
-              Publication Date (Oldest First)
-            </option>
-          </select>
-          <IconComposer
-            icon="disclosureDown16"
-            size={22}
-            iconClass="form-select__disclosure-icon"
-          />
-        </div>
-      </div>
+      <UID name={id => `${this.idPrefix}-${id}`}>
+        {id => (
+          <div className="select-group">
+            <label htmlFor={id}>Order Collection By:</label>
+            <div className="select" key="filter[order]">
+              <select
+                id={id}
+                onChange={this.handleChange}
+                value={selected}
+                data-id={"filter"}
+              >
+                <option key="created_at_desc" value="created_at_desc">
+                  Date Created (Newest First)
+                </option>
+                <option key="created_at_asc" value="created_at_asc">
+                  Date Created (Oldest First)
+                </option>
+                <option key="updated_at_desc" value="updated_at_desc">
+                  Last Updated (Newest First)
+                </option>
+                <option key="updated_at_asc" value="updated_at_asc">
+                  Last Updated (Oldest First)
+                </option>
+                <option key="title_asc" value="title_asc">
+                  Title A to Z
+                </option>
+                <option key="title_desc" value="title_desc">
+                  Title Z to A
+                </option>
+                <option
+                  key="publication_date_desc"
+                  value="publication_date_desc"
+                >
+                  Publication Date (Newest First)
+                </option>
+                <option key="publication_date_asc" value="publication_date_asc">
+                  Publication Date (Oldest First)
+                </option>
+              </select>
+              <IconComposer
+                icon="disclosureDown16"
+                size={22}
+                iconClass="form-select__disclosure-icon"
+              />
+            </div>
+          </div>
+        )}
+      </UID>
     );
   }
 

--- a/client/src/backend/components/project-collection/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/components/project-collection/__tests__/__snapshots__/List-test.js.snap
@@ -6,7 +6,7 @@ exports[`Backend.ProjectCollection.List component renders correctly 1`] = `
 >
   <div
     className="entity-list entity-list--bare"
-    id="entities-list1"
+    id={1}
   >
     <div
       className="entity-list__contents-wrapper"

--- a/client/src/backend/components/project-collection/form/IconPicker.js
+++ b/client/src/backend/components/project-collection/form/IconPicker.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import GlobalForm from "global/components/form";
 import classNames from "classnames";
 import IconComputed from "global/components/icon-computed";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 
 export default class IconPicker extends Component {
   static displayName = "ProjectCollection.Form.IconPicker";
@@ -13,17 +13,13 @@ export default class IconPicker extends Component {
     name: PropTypes.string,
     errors: PropTypes.array,
     label: PropTypes.string,
-    id: PropTypes.string,
-    idForError: PropTypes.string,
     getModelValue: PropTypes.func,
     setOther: PropTypes.func,
     wide: PropTypes.bool
   };
 
   static defaultProps = {
-    name: "attributes[icon]",
-    id: labelId("icon-picker-"),
-    idForError: labelId("icon-picker-error-")
+    name: "attributes[icon]"
   };
 
   get selected() {
@@ -40,6 +36,14 @@ export default class IconPicker extends Component {
       "touch",
       "mug"
     ];
+  }
+
+  get idPrefix() {
+    return "icon-picker";
+  }
+
+  get idForErrorPrefix() {
+    return "icon-picker";
   }
 
   handleIconChange = icon => {
@@ -67,9 +71,9 @@ export default class IconPicker extends Component {
     );
   }
 
-  renderIconList() {
+  renderIconList(id) {
     return (
-      <ul className="icon-row" id={this.props.id}>
+      <ul className="icon-row" id={`${this.idPrefix}-${id}`}>
         {this.icons.map(icon => {
           return this.renderIcon(icon);
         })}
@@ -84,25 +88,32 @@ export default class IconPicker extends Component {
     });
 
     return (
-      <div className={inputClasses}>
-        <GlobalForm.Errorable
-          className="form-input"
-          name={this.props.name}
-          errors={this.props.errors}
-          label={this.props.label}
-          idForError={this.props.idForError}
-        >
-          <label className="form-input-heading" htmlFor={this.props.id}>
-            Collection Icon:
-          </label>
-          <div>
-            <span className="screen-reader-text">
-              Select an icon for the project collection.
-            </span>
-            {this.renderIconList()}
+      <UID>
+        {id => (
+          <div className={inputClasses}>
+            <GlobalForm.Errorable
+              className="form-input"
+              name={this.props.name}
+              errors={this.props.errors}
+              label={this.props.label}
+              idForError={`${this.idForErrorPrefix}-${id}`}
+            >
+              <label
+                className="form-input-heading"
+                htmlFor={`${this.idPrefix}-${id}`}
+              >
+                Collection Icon:
+              </label>
+              <div>
+                <span className="screen-reader-text">
+                  Select an icon for the project collection.
+                </span>
+                {this.renderIconList(id)}
+              </div>
+            </GlobalForm.Errorable>
           </div>
-        </GlobalForm.Errorable>
-      </div>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/project-collection/form/__tests__/__snapshots__/KindPicker-test.js.snap
+++ b/client/src/backend/components/project-collection/form/__tests__/__snapshots__/KindPicker-test.js.snap
@@ -14,7 +14,7 @@ exports[`Backend.ProjectCollection.Form.KindPicker component renders correctly 1
       className="button-switch-primary"
     >
       <button
-        aria-describedby="button-switch-1"
+        aria-describedby={1}
         className="button-switch-primary__button"
         onClick={[Function]}
       >
@@ -69,7 +69,7 @@ exports[`Backend.ProjectCollection.Form.KindPicker component renders correctly 1
       </button>
       <span
         className="aria-describedby"
-        id="button-switch-1"
+        id={1}
       >
         Toggle kind to Smart
       </span>

--- a/client/src/backend/components/project-collection/form/__tests__/__snapshots__/SmartAttributes-test.js.snap
+++ b/client/src/backend/components/project-collection/form/__tests__/__snapshots__/SmartAttributes-test.js.snap
@@ -8,13 +8,13 @@ Array [
   >
     <label
       className="has-instructions"
-      htmlFor="attributes[numberOfProjects]-text-input-1"
+      htmlFor="number-input-1"
     >
       Number of Projects:
     </label>
     <input
-      aria-describedby="attributes[numberOfProjects]-text-input-1"
-      id="attributes[numberOfProjects]-text-input-1"
+      aria-describedby="number-input-error-1"
+      id="number-input-1"
       onChange={[Function]}
       type="number"
       value=""
@@ -30,7 +30,7 @@ Array [
   >
     <label
       className="form-input-heading toggle above"
-      htmlFor="switch-input-1"
+      htmlFor={1}
     >
       Featured Projects:
     </label>
@@ -40,7 +40,7 @@ Array [
       <div
         aria-pressed={false}
         className="boolean-primary"
-        id="switch-input-1"
+        id={1}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -122,7 +122,7 @@ Array [
   >
     <label
       className=""
-      htmlFor="attributes[tagList]-tag-list-1"
+      htmlFor="tag-list-1"
     >
       Tags
     </label>

--- a/client/src/backend/components/resource/form/KindPicker.js
+++ b/client/src/backend/components/resource/form/KindPicker.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 import classNames from "classnames";
 import IconComputed from "global/components/icon-computed";
 import Form from "backend/components/form";
@@ -12,13 +12,12 @@ class KindPicker extends PureComponent {
   static propTypes = {
     getModelValue: PropTypes.func,
     includeButtons: PropTypes.bool,
-    set: PropTypes.func,
-    id: PropTypes.string
+    set: PropTypes.func
   };
 
-  static defaultProps = {
-    id: labelId("kind-")
-  };
+  get idPrefix() {
+    return "kind";
+  }
 
   renderKindPickerButtons(kindList) {
     if (!kindList) return null;
@@ -87,42 +86,46 @@ class KindPicker extends PureComponent {
     });
 
     return (
-      <div className="resource-kind-picker form-secondary">
-        <div className="form-input">
-          <label htmlFor={this.props.id}>Kind</label>
-          <div className={selectClass}>
-            <div className="form-select">
-              <IconComposer
-                icon="disclosureDown16"
-                size={22}
-                iconClass="form-select__icon"
-              />
-              <select
-                id={this.props.id}
-                onChange={event => {
-                  this.props.set(event.target.value);
-                }}
-                value={this.props
-                  .getModelValue("attributes[kind]")
-                  .toLowerCase()}
-              >
-                {kindList.map(kind => {
-                  const safeKind = kind.toLowerCase();
+      <UID name={id => `${this.idPrefix}-${id}`}>
+        {id => (
+          <div className="resource-kind-picker form-secondary">
+            <div className="form-input">
+              <label htmlFor={id}>Kind</label>
+              <div className={selectClass}>
+                <div className="form-select">
+                  <IconComposer
+                    icon="disclosureDown16"
+                    size={22}
+                    iconClass="form-select__icon"
+                  />
+                  <select
+                    id={id}
+                    onChange={event => {
+                      this.props.set(event.target.value);
+                    }}
+                    value={this.props
+                      .getModelValue("attributes[kind]")
+                      .toLowerCase()}
+                  >
+                    {kindList.map(kind => {
+                      const safeKind = kind.toLowerCase();
 
-                  return (
-                    <option key={safeKind} value={safeKind} id={safeKind}>
-                      {kind}
-                    </option>
-                  );
-                })}
-              </select>
+                      return (
+                        <option key={safeKind} value={safeKind} id={safeKind}>
+                          {kind}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </div>
+              </div>
+              {this.props.includeButtons
+                ? this.renderKindPickerButtons(kindList)
+                : null}
             </div>
           </div>
-          {this.props.includeButtons
-            ? this.renderKindPickerButtons(kindList)
-            : null}
-        </div>
-      </div>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/resource/form/__tests__/__snapshots__/KindPicker-test.js.snap
+++ b/client/src/backend/components/resource/form/__tests__/__snapshots__/KindPicker-test.js.snap
@@ -8,7 +8,7 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
     className="form-input"
   >
     <label
-      htmlFor="kind-1"
+      htmlFor={1}
     >
       Kind
     </label>
@@ -32,7 +32,7 @@ exports[`Backend.Resource.Form.KindPicker component renders correctly 1`] = `
           />
         </svg>
         <select
-          id="kind-1"
+          id={1}
           onChange={[Function]}
           value="image"
         >

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Interactive-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Interactive-test.js.snap
@@ -10,13 +10,13 @@ exports[`Backend.Resource.Form.Interactive component when sub kind is embed rend
   >
     <label
       className=""
-      htmlFor="attributes[minimumWidth]-text-input-1"
+      htmlFor="text-input-1"
     >
       Minimum Width
     </label>
     <input
-      aria-describedby="attributes[minimumWidth]-text-input-1"
-      id="attributes[minimumWidth]-text-input-1"
+      aria-describedby="text-input-error-1"
+      id="text-input-1"
       onChange={[Function]}
       placeholder="The minimum display width"
       type="text"
@@ -29,13 +29,13 @@ exports[`Backend.Resource.Form.Interactive component when sub kind is embed rend
   >
     <label
       className=""
-      htmlFor="attributes[minimumHeight]-text-input-1"
+      htmlFor="text-input-1"
     >
       Minimum Height
     </label>
     <input
-      aria-describedby="attributes[minimumHeight]-text-input-1"
-      id="attributes[minimumHeight]-text-input-1"
+      aria-describedby="text-input-error-1"
+      id="text-input-1"
       onChange={[Function]}
       placeholder="The minimum display height"
       type="text"
@@ -48,13 +48,13 @@ exports[`Backend.Resource.Form.Interactive component when sub kind is embed rend
   >
     <label
       className=""
-      htmlFor="attributes[externalUrl]-text-input-1"
+      htmlFor="text-input-1"
     >
       iFrame URL
     </label>
     <input
-      aria-describedby="attributes[externalUrl]-text-input-1"
-      id="attributes[externalUrl]-text-input-1"
+      aria-describedby="text-input-error-1"
+      id="text-input-1"
       onChange={[Function]}
       placeholder="Enter iFrame URL"
       type="text"
@@ -74,13 +74,13 @@ exports[`Backend.Resource.Form.Interactive component when sub kind is iframe ren
   >
     <label
       className=""
-      htmlFor="attributes[minimumWidth]-text-input-1"
+      htmlFor="text-input-1"
     >
       Minimum Width
     </label>
     <input
-      aria-describedby="attributes[minimumWidth]-text-input-1"
-      id="attributes[minimumWidth]-text-input-1"
+      aria-describedby="text-input-error-1"
+      id="text-input-1"
       onChange={[Function]}
       placeholder="The minimum display width"
       type="text"
@@ -93,13 +93,13 @@ exports[`Backend.Resource.Form.Interactive component when sub kind is iframe ren
   >
     <label
       className=""
-      htmlFor="attributes[minimumHeight]-text-input-1"
+      htmlFor="text-input-1"
     >
       Minimum Height
     </label>
     <input
-      aria-describedby="attributes[minimumHeight]-text-input-1"
-      id="attributes[minimumHeight]-text-input-1"
+      aria-describedby="text-input-error-1"
+      id="text-input-1"
       onChange={[Function]}
       placeholder="The minimum display height"
       type="text"
@@ -112,13 +112,13 @@ exports[`Backend.Resource.Form.Interactive component when sub kind is iframe ren
   >
     <label
       className=""
-      htmlFor="attributes[externalUrl]-text-input-1"
+      htmlFor="text-input-1"
     >
       iFrame URL
     </label>
     <input
-      aria-describedby="attributes[externalUrl]-text-input-1"
-      id="attributes[externalUrl]-text-input-1"
+      aria-describedby="text-input-error-1"
+      id="text-input-1"
       onChange={[Function]}
       placeholder="Enter iFrame URL"
       type="text"

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Link-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Link-test.js.snap
@@ -10,13 +10,13 @@ exports[`Backend.Resource.Form.Link component renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor="attributes[externalUrl]-text-input-1"
+      htmlFor="text-input-1"
     >
       Link URL
     </label>
     <input
-      aria-describedby="attributes[externalUrl]-text-input-1"
-      id="attributes[externalUrl]-text-input-1"
+      aria-describedby="text-input-error-1"
+      id="text-input-1"
       onChange={[Function]}
       placeholder="Enter link URL"
       type="text"

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Video-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Video-test.js.snap
@@ -9,7 +9,7 @@ exports[`Backend.Resource.Form.Video component renders correctly 1`] = `
   >
     <label
       className="form-input-heading toggle above"
-      htmlFor="switch-input-1"
+      htmlFor={1}
     >
       Is this an externally linked video?
     </label>
@@ -19,7 +19,7 @@ exports[`Backend.Resource.Form.Video component renders correctly 1`] = `
       <div
         aria-pressed={false}
         className="boolean-primary"
-        id="switch-input-1"
+        id={1}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -126,7 +126,7 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
   >
     <label
       className="form-input-heading toggle above"
-      htmlFor="switch-input-1"
+      htmlFor={1}
     >
       Is this an externally linked video?
     </label>
@@ -136,7 +136,7 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
       <div
         aria-pressed={false}
         className="boolean-primary"
-        id="switch-input-1"
+        id={1}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -160,13 +160,13 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
     >
       <label
         className="has-instructions"
-        htmlFor="attributes[externalId]-text-input-1"
+        htmlFor="text-input-1"
       >
         Video ID
       </label>
       <input
-        aria-describedby="attributes[externalId]-text-input-1"
-        id="attributes[externalId]-text-input-1"
+        aria-describedby="text-input-error-1"
+        id="text-input-1"
         onChange={[Function]}
         placeholder="Video ID"
         type="text"
@@ -185,7 +185,9 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
         className="form-input"
         style={Object {}}
       >
-        <label>
+        <label
+          htmlFor="select-1"
+        >
           External Video Type
         </label>
         <div
@@ -206,6 +208,7 @@ exports[`Backend.Resource.Form.Video component when sub kind is external_video r
           </svg>
           <select
             aria-describedby="select-error-1"
+            id="select-1"
             onChange={[Function]}
             value=""
           >

--- a/client/src/backend/components/twitter-query/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/backend/components/twitter-query/__tests__/__snapshots__/Form-test.js.snap
@@ -13,13 +13,13 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
     >
       <label
         className=""
-        htmlFor="attributes[query]-text-input-1"
+        htmlFor="text-input-1"
       >
         Query
       </label>
       <input
-        aria-describedby="attributes[query]-text-input-1"
-        id="attributes[query]-text-input-1"
+        aria-describedby="text-input-error-1"
+        id="text-input-1"
         onChange={[Function]}
         placeholder="Enter query"
         type="text"
@@ -47,7 +47,9 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
         className="form-input"
         style={Object {}}
       >
-        <label>
+        <label
+          htmlFor="select-1"
+        >
           Fetch tweets by:
         </label>
         <div
@@ -68,6 +70,7 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
           </svg>
           <select
             aria-describedby="select-error-1"
+            id="select-1"
             onChange={[Function]}
             value=""
           >
@@ -90,7 +93,7 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
     >
       <label
         className="form-input-heading toggle above"
-        htmlFor="switch-input-1"
+        htmlFor={1}
       >
         Active
       </label>
@@ -100,7 +103,7 @@ exports[`Backend.TwitterQuery.Form Component renders correctly 1`] = `
         <div
           aria-pressed={true}
           className="boolean-primary checked"
-          id="switch-input-1"
+          id={1}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}

--- a/client/src/backend/containers/dashboards/__tests__/__snapshots__/Admin-test.js.snap
+++ b/client/src/backend/containers/dashboards/__tests__/__snapshots__/Admin-test.js.snap
@@ -32,7 +32,7 @@ Array [
               >
                 <div
                   className="entity-list"
-                  id="entities-list1"
+                  id={1}
                 >
                   <h2
                     aria-atomic={true}
@@ -104,13 +104,13 @@ Array [
                           >
                             <label
                               className="screen-reader-text"
-                              htmlFor="list-search-1"
+                              htmlFor={1}
                             >
                               Enter Search Criteria
                             </label>
                             <input
                               className="entity-list-search__keyword-input"
-                              id="list-search-1"
+                              id={1}
                               onChange={[Function]}
                               placeholder="Search..."
                               type="text"
@@ -164,7 +164,7 @@ Array [
                                     className="entity-list-search__select-wrapper"
                                   >
                                     <select
-                                      id="list-search-1"
+                                      id={1}
                                       onChange={[Function]}
                                       value=""
                                     >
@@ -215,7 +215,7 @@ Array [
                                     className="entity-list-search__select-wrapper"
                                   >
                                     <select
-                                      id="list-search-1"
+                                      id={1}
                                       onChange={[Function]}
                                       value=""
                                     >
@@ -261,7 +261,7 @@ Array [
                                     className="entity-list-search__select-wrapper"
                                   >
                                     <select
-                                      id="list-search-1"
+                                      id={1}
                                       onChange={[Function]}
                                       value="updated_at DESC"
                                     >
@@ -321,7 +321,7 @@ Array [
                         className="entity-row entity-list__entity"
                       >
                         <a
-                          aria-describedby="undefined1-describedby"
+                          aria-describedby="1-describedby"
                           className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
                           href="/backend/projects/1"
                           onClick={[Function]}
@@ -424,7 +424,7 @@ Array [
                                 </span>
                                 <span
                                   className="aria-describedby"
-                                  id="undefined1-describedby"
+                                  id="1-describedby"
                                 >
                                   View Rowan Test
                                 </span>
@@ -445,7 +445,7 @@ Array [
                         className="entity-row entity-list__entity"
                       >
                         <a
-                          aria-describedby="undefined1-describedby"
+                          aria-describedby="1-describedby"
                           className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
                           href="/backend/projects/2"
                           onClick={[Function]}
@@ -548,7 +548,7 @@ Array [
                                 </span>
                                 <span
                                   className="aria-describedby"
-                                  id="undefined1-describedby"
+                                  id="1-describedby"
                                 >
                                   View Rowan Test
                                 </span>
@@ -585,7 +585,7 @@ Array [
                               >
                                 <a
                                   disabled={true}
-                                  href="#entities-list1"
+                                  href="#1"
                                   onClick={[Function]}
                                 >
                                   <svg
@@ -621,7 +621,7 @@ Array [
                                 className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                               >
                                 <a
-                                  href="#entities-list1"
+                                  href="#1"
                                   onClick={[Function]}
                                 >
                                   <span
@@ -641,7 +641,7 @@ Array [
                                 className="list-pagination__page list-pagination__page--ordinal"
                               >
                                 <a
-                                  href="#entities-list1"
+                                  href="#1"
                                   onClick={[Function]}
                                 >
                                   <span
@@ -667,7 +667,7 @@ Array [
                                 className="list-pagination__page list-pagination__page--next"
                               >
                                 <a
-                                  href="#entities-list1"
+                                  href="#1"
                                   onClick={[Function]}
                                 >
                                   <span
@@ -711,7 +711,7 @@ Array [
               >
                 <div
                   className="entity-list"
-                  id="entities-list1"
+                  id={1}
                 >
                   <h2
                     className="entity-list__title-block entity-list__title"
@@ -749,7 +749,7 @@ Array [
                         className="entity-row entity-list__entity"
                       >
                         <a
-                          aria-describedby="undefined1-describedby"
+                          aria-describedby="1-describedby"
                           className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
                           href="/backend/projects/3"
                           onClick={[Function]}
@@ -776,7 +776,7 @@ Array [
                                 </span>
                                 <span
                                   className="aria-describedby"
-                                  id="undefined1-describedby"
+                                  id="1-describedby"
                                 >
                                   View Rowan Test
                                 </span>
@@ -792,7 +792,7 @@ Array [
                         className="entity-row entity-list__entity"
                       >
                         <a
-                          aria-describedby="undefined1-describedby"
+                          aria-describedby="1-describedby"
                           className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
                           href="/backend/projects/4"
                           onClick={[Function]}
@@ -819,7 +819,7 @@ Array [
                                 </span>
                                 <span
                                   className="aria-describedby"
-                                  id="undefined1-describedby"
+                                  id="1-describedby"
                                 >
                                   View Rowan Test
                                 </span>

--- a/client/src/backend/containers/makers/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/backend/containers/makers/__tests__/__snapshots__/Edit-test.js.snap
@@ -58,13 +58,13 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[prefix]-text-input-1"
+            htmlFor="text-input-1"
           >
             Title
           </label>
           <input
-            aria-describedby="attributes[prefix]-text-input-1"
-            id="attributes[prefix]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Title"
             type="text"
@@ -77,13 +77,13 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[firstName]-text-input-1"
+            htmlFor="text-input-1"
           >
             First Name
           </label>
           <input
-            aria-describedby="attributes[firstName]-text-input-1"
-            id="attributes[firstName]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="First Name"
             type="text"
@@ -96,13 +96,13 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[middleName]-text-input-1"
+            htmlFor="text-input-1"
           >
             Middle Name
           </label>
           <input
-            aria-describedby="attributes[middleName]-text-input-1"
-            id="attributes[middleName]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Middle Name"
             type="text"
@@ -115,13 +115,13 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[lastName]-text-input-1"
+            htmlFor="text-input-1"
           >
             Last Name
           </label>
           <input
-            aria-describedby="attributes[lastName]-text-input-1"
-            id="attributes[lastName]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Last Name"
             type="text"
@@ -134,13 +134,13 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[suffix]-text-input-1"
+            htmlFor="text-input-1"
           >
             Suffix
           </label>
           <input
-            aria-describedby="attributes[suffix]-text-input-1"
-            id="attributes[suffix]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Suffix"
             type="text"

--- a/client/src/backend/containers/makers/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/containers/makers/__tests__/__snapshots__/List-test.js.snap
@@ -11,7 +11,7 @@ Array [
   <span />,
   <div
     className="entity-list"
-    id="entities-list1"
+    id={1}
   >
     <header
       className="entity-list__title-block backend-header"
@@ -73,13 +73,13 @@ Array [
             >
               <label
                 className="screen-reader-text"
-                htmlFor="list-search-1"
+                htmlFor={1}
               >
                 Enter Search Criteria
               </label>
               <input
                 className="entity-list-search__keyword-input"
-                id="list-search-1"
+                id={1}
                 onChange={[Function]}
                 placeholder="Search..."
                 type="text"
@@ -133,7 +133,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value="last_name"
                       >
@@ -209,7 +209,7 @@ Array [
           className="entity-row entity-list__entity"
         >
           <a
-            aria-describedby="undefined1-describedby"
+            aria-describedby="1-describedby"
             className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
             href="/backend/records/makers/1"
             onClick={[Function]}
@@ -245,7 +245,7 @@ Array [
                   </span>
                   <span
                     className="aria-describedby"
-                    id="undefined1-describedby"
+                    id="1-describedby"
                   >
                     View Rowan Ida
                   </span>
@@ -274,7 +274,7 @@ Array [
                 >
                   <a
                     disabled={true}
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <svg
@@ -310,7 +310,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -330,7 +330,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -356,7 +356,7 @@ Array [
                   className="list-pagination__page list-pagination__page--next"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span

--- a/client/src/backend/containers/makers/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/makers/__tests__/__snapshots__/New-test.js.snap
@@ -30,13 +30,13 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[prefix]-text-input-1"
+            htmlFor="text-input-1"
           >
             Title
           </label>
           <input
-            aria-describedby="attributes[prefix]-text-input-1"
-            id="attributes[prefix]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Title"
             type="text"
@@ -49,13 +49,13 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[firstName]-text-input-1"
+            htmlFor="text-input-1"
           >
             First Name
           </label>
           <input
-            aria-describedby="attributes[firstName]-text-input-1"
-            id="attributes[firstName]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="First Name"
             type="text"
@@ -68,13 +68,13 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[middleName]-text-input-1"
+            htmlFor="text-input-1"
           >
             Middle Name
           </label>
           <input
-            aria-describedby="attributes[middleName]-text-input-1"
-            id="attributes[middleName]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Middle Name"
             type="text"
@@ -87,13 +87,13 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[lastName]-text-input-1"
+            htmlFor="text-input-1"
           >
             Last Name
           </label>
           <input
-            aria-describedby="attributes[lastName]-text-input-1"
-            id="attributes[lastName]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Last Name"
             type="text"
@@ -106,13 +106,13 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[suffix]-text-input-1"
+            htmlFor="text-input-1"
           >
             Suffix
           </label>
           <input
-            aria-describedby="attributes[suffix]-text-input-1"
-            id="attributes[suffix]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Suffix"
             type="text"

--- a/client/src/backend/containers/permission/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/backend/containers/permission/__tests__/__snapshots__/Edit-test.js.snap
@@ -72,7 +72,7 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
               >
                 <label
                   className="form-input-heading toggle above"
-                  htmlFor="switch-input-1"
+                  htmlFor={1}
                 >
                   Can modify project?
                 </label>
@@ -82,7 +82,7 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
                   <div
                     aria-pressed={false}
                     className="boolean-primary"
-                    id="switch-input-1"
+                    id={1}
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
@@ -102,7 +102,7 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
               >
                 <label
                   className="form-input-heading toggle above"
-                  htmlFor="switch-input-1"
+                  htmlFor={1}
                 >
                   Can modify resource metadata?
                 </label>
@@ -112,7 +112,7 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
                   <div
                     aria-pressed={false}
                     className="boolean-primary"
-                    id="switch-input-1"
+                    id={1}
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
@@ -132,7 +132,7 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
               >
                 <label
                   className="form-input-heading toggle above"
-                  htmlFor="switch-input-1"
+                  htmlFor={1}
                 >
                   Is a project author?
                 </label>
@@ -142,7 +142,7 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
                   <div
                     aria-pressed={false}
                     className="boolean-primary"
-                    id="switch-input-1"
+                    id={1}
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}

--- a/client/src/backend/containers/permission/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/backend/containers/permission/__tests__/__snapshots__/Form-test.js.snap
@@ -62,7 +62,7 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
             >
               <label
                 className="form-input-heading toggle above"
-                htmlFor="switch-input-1"
+                htmlFor={1}
               >
                 Can modify project?
               </label>
@@ -72,7 +72,7 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
                 <div
                   aria-pressed={false}
                   className="boolean-primary"
-                  id="switch-input-1"
+                  id={1}
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
@@ -92,7 +92,7 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
             >
               <label
                 className="form-input-heading toggle above"
-                htmlFor="switch-input-1"
+                htmlFor={1}
               >
                 Can modify resource metadata?
               </label>
@@ -102,7 +102,7 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
                 <div
                   aria-pressed={false}
                   className="boolean-primary"
-                  id="switch-input-1"
+                  id={1}
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
@@ -122,7 +122,7 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
             >
               <label
                 className="form-input-heading toggle above"
-                htmlFor="switch-input-1"
+                htmlFor={1}
               >
                 Is a project author?
               </label>
@@ -132,7 +132,7 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
                 <div
                   aria-pressed={false}
                   className="boolean-primary"
-                  id="switch-input-1"
+                  id={1}
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}

--- a/client/src/backend/containers/permission/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/containers/permission/__tests__/__snapshots__/List-test.js.snap
@@ -4,7 +4,7 @@ exports[`Backend Permissions List Container renders correctly 1`] = `
 <section>
   <div
     className="entity-list"
-    id="entities-list1"
+    id={1}
   >
     <header
       className="entity-list__title-block entity-list__title backend-header"
@@ -53,7 +53,7 @@ exports[`Backend Permissions List Container renders correctly 1`] = `
           className="entity-row entity-list__entity"
         >
           <a
-            aria-describedby="undefined1-describedby"
+            aria-describedby="1-describedby"
             className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag entity-row__row-link--is-active"
             href="/backend/projects/1/permissions/2"
             onClick={[Function]}
@@ -98,7 +98,7 @@ exports[`Backend Permissions List Container renders correctly 1`] = `
                   </span>
                   <span
                     className="aria-describedby"
-                    id="undefined1-describedby"
+                    id="1-describedby"
                   >
                     View Rowan Ida
                   </span>

--- a/client/src/backend/containers/permission/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/permission/__tests__/__snapshots__/New-test.js.snap
@@ -76,7 +76,7 @@ exports[`Backend Permission New Container renders correctly 1`] = `
               >
                 <label
                   className="form-input-heading toggle above"
-                  htmlFor="switch-input-1"
+                  htmlFor={1}
                 >
                   Can modify project?
                 </label>
@@ -86,7 +86,7 @@ exports[`Backend Permission New Container renders correctly 1`] = `
                   <div
                     aria-pressed={false}
                     className="boolean-primary"
-                    id="switch-input-1"
+                    id={1}
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
@@ -106,7 +106,7 @@ exports[`Backend Permission New Container renders correctly 1`] = `
               >
                 <label
                   className="form-input-heading toggle above"
-                  htmlFor="switch-input-1"
+                  htmlFor={1}
                 >
                   Can modify resource metadata?
                 </label>
@@ -116,7 +116,7 @@ exports[`Backend Permission New Container renders correctly 1`] = `
                   <div
                     aria-pressed={false}
                     className="boolean-primary"
-                    id="switch-input-1"
+                    id={1}
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
@@ -136,7 +136,7 @@ exports[`Backend Permission New Container renders correctly 1`] = `
               >
                 <label
                   className="form-input-heading toggle above"
-                  htmlFor="switch-input-1"
+                  htmlFor={1}
                 >
                   Is a project author?
                 </label>
@@ -146,7 +146,7 @@ exports[`Backend Permission New Container renders correctly 1`] = `
                   <div
                     aria-pressed={false}
                     className="boolean-primary"
-                    id="switch-input-1"
+                    id={1}
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}

--- a/client/src/backend/containers/project-collection/Detail/__tests__/__snapshots__/Manual-test.js.snap
+++ b/client/src/backend/containers/project-collection/Detail/__tests__/__snapshots__/Manual-test.js.snap
@@ -3,7 +3,7 @@
 exports[`Backend.ProjectCollection.Detail.Manual component renders correctly 1`] = `
 <div
   className="entity-list"
-  id="entities-list1"
+  id={1}
 >
   <div
     className="entity-list__contents-wrapper"
@@ -18,7 +18,7 @@ exports[`Backend.ProjectCollection.Detail.Manual component renders correctly 1`]
         className="entity-row entity-list__entity"
       >
         <a
-          aria-describedby="undefined1-describedby"
+          aria-describedby="1-describedby"
           className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag entity-row__row-link--in-grid"
           href="/backend/projects/2"
           onClick={[Function]}
@@ -205,7 +205,7 @@ exports[`Backend.ProjectCollection.Detail.Manual component renders correctly 1`]
                 </span>
                 <span
                   className="aria-describedby"
-                  id="undefined1-describedby"
+                  id="1-describedby"
                 >
                   View Rowan Test
                 </span>

--- a/client/src/backend/containers/project-collection/Detail/__tests__/__snapshots__/Smart-test.js.snap
+++ b/client/src/backend/containers/project-collection/Detail/__tests__/__snapshots__/Smart-test.js.snap
@@ -3,7 +3,7 @@
 exports[`Backend.ProjectCollection.Detail.Smart component renders correctly 1`] = `
 <div
   className="entity-list"
-  id="entities-list1"
+  id={1}
 >
   <div
     className="entity-list__contents-wrapper"
@@ -18,7 +18,7 @@ exports[`Backend.ProjectCollection.Detail.Smart component renders correctly 1`] 
         className="entity-row entity-list__entity"
       >
         <a
-          aria-describedby="undefined1-describedby"
+          aria-describedby="1-describedby"
           className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag entity-row__row-link--in-grid"
           href="/backend/projects/2"
           onClick={[Function]}
@@ -205,7 +205,7 @@ exports[`Backend.ProjectCollection.Detail.Smart component renders correctly 1`] 
                 </span>
                 <span
                   className="aria-describedby"
-                  id="undefined1-describedby"
+                  id="1-describedby"
                 >
                   View Rowan Test
                 </span>

--- a/client/src/backend/containers/project-collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/backend/containers/project-collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -57,7 +57,7 @@ exports[`Backend.ProjectCollection.Detail container renders correctly 1`] = `
   </div>
   <div
     className="entity-list"
-    id="entities-list1"
+    id={1}
   >
     <div
       className="entity-list__contents-wrapper"

--- a/client/src/backend/containers/project-collection/__tests__/__snapshots__/ManageProjects-test.js.snap
+++ b/client/src/backend/containers/project-collection/__tests__/__snapshots__/ManageProjects-test.js.snap
@@ -47,7 +47,7 @@ Array [
   </header>,
   <div
     className="entity-list"
-    id="entities-list1"
+    id={1}
   >
     <div
       className="entity-list__contents-wrapper"
@@ -88,13 +88,13 @@ Array [
             >
               <label
                 className="screen-reader-text"
-                htmlFor="list-search-1"
+                htmlFor={1}
               >
                 Enter Search Criteria
               </label>
               <input
                 className="entity-list-search__keyword-input"
-                id="list-search-1"
+                id={1}
                 onChange={[Function]}
                 placeholder="Search..."
                 type="text"
@@ -148,7 +148,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       >
@@ -199,7 +199,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       >
@@ -245,7 +245,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value="updated_at DESC"
                       >
@@ -597,7 +597,7 @@ Array [
                 </span>
                 <span
                   className="aria-describedby"
-                  id="undefined1-describedby"
+                  id="1-describedby"
                 >
                   View Rowan Test
                 </span>
@@ -886,7 +886,7 @@ Array [
                 </span>
                 <span
                   className="aria-describedby"
-                  id="undefined1-describedby"
+                  id="1-describedby"
                 >
                   View Rowan Test
                 </span>
@@ -922,7 +922,7 @@ Array [
                 >
                   <a
                     disabled={true}
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <svg
@@ -958,7 +958,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -978,7 +978,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -1004,7 +1004,7 @@ Array [
                   className="list-pagination__page list-pagination__page--next"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span

--- a/client/src/backend/containers/project-collection/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/project-collection/__tests__/__snapshots__/New-test.js.snap
@@ -17,13 +17,13 @@ exports[`Backend.ProjectCollection.New container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[title]-text-input-1"
+            htmlFor="text-input-1"
           >
             Collection Title:
           </label>
           <input
-            aria-describedby="attributes[title]-text-input-1"
-            id="attributes[title]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Enter collection name"
             type="text"
@@ -44,7 +44,7 @@ exports[`Backend.ProjectCollection.New container renders correctly 1`] = `
             className="button-switch-primary"
           >
             <button
-              aria-describedby="button-switch-1"
+              aria-describedby={1}
               className="button-switch-primary__button"
               onClick={[Function]}
             >
@@ -99,7 +99,7 @@ exports[`Backend.ProjectCollection.New container renders correctly 1`] = `
             </button>
             <span
               className="aria-describedby"
-              id="button-switch-1"
+              id={1}
             >
               Toggle kind to Smart
             </span>
@@ -112,13 +112,13 @@ exports[`Backend.ProjectCollection.New container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[slug]-text-input-1"
+          htmlFor="text-input-1"
         >
           Slug:
         </label>
         <input
-          aria-describedby="attributes[slug]-text-input-1"
-          id="attributes[slug]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Enter slug"
           type="text"
@@ -157,7 +157,7 @@ exports[`Backend.ProjectCollection.New container renders correctly 1`] = `
       >
         <label
           className="form-input-heading toggle above"
-          htmlFor="switch-input-1"
+          htmlFor={1}
         >
           Visible:
         </label>
@@ -167,7 +167,7 @@ exports[`Backend.ProjectCollection.New container renders correctly 1`] = `
           <div
             aria-pressed={false}
             className="boolean-primary"
-            id="switch-input-1"
+            id={1}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -187,7 +187,7 @@ exports[`Backend.ProjectCollection.New container renders correctly 1`] = `
       >
         <label
           className="form-input-heading toggle above"
-          htmlFor="switch-input-1"
+          htmlFor={1}
         >
           Show on homepage:
         </label>
@@ -197,7 +197,7 @@ exports[`Backend.ProjectCollection.New container renders correctly 1`] = `
           <div
             aria-pressed={false}
             className="boolean-primary"
-            id="switch-input-1"
+            id={1}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}

--- a/client/src/backend/containers/project-collection/__tests__/__snapshots__/Settings-test.js.snap
+++ b/client/src/backend/containers/project-collection/__tests__/__snapshots__/Settings-test.js.snap
@@ -17,13 +17,13 @@ exports[`Backend.ProjectCollection.Settings container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[title]-text-input-1"
+            htmlFor="text-input-1"
           >
             Collection Title:
           </label>
           <input
-            aria-describedby="attributes[title]-text-input-1"
-            id="attributes[title]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Enter collection name"
             type="text"
@@ -72,7 +72,7 @@ exports[`Backend.ProjectCollection.Settings container renders correctly 1`] = `
             className="button-switch-primary"
           >
             <button
-              aria-describedby="button-switch-1"
+              aria-describedby={1}
               className="button-switch-primary__button"
               onClick={[Function]}
             >
@@ -127,7 +127,7 @@ exports[`Backend.ProjectCollection.Settings container renders correctly 1`] = `
             </button>
             <span
               className="aria-describedby"
-              id="button-switch-1"
+              id={1}
             >
               Toggle kind to Smart
             </span>
@@ -140,13 +140,13 @@ exports[`Backend.ProjectCollection.Settings container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[slug]-text-input-1"
+          htmlFor="text-input-1"
         >
           Slug:
         </label>
         <input
-          aria-describedby="attributes[slug]-text-input-1"
-          id="attributes[slug]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Enter slug"
           type="text"
@@ -185,7 +185,7 @@ exports[`Backend.ProjectCollection.Settings container renders correctly 1`] = `
       >
         <label
           className="form-input-heading toggle above"
-          htmlFor="switch-input-1"
+          htmlFor={1}
         >
           Visible:
         </label>
@@ -195,7 +195,7 @@ exports[`Backend.ProjectCollection.Settings container renders correctly 1`] = `
           <div
             aria-pressed={false}
             className="boolean-primary"
-            id="switch-input-1"
+            id={1}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -215,7 +215,7 @@ exports[`Backend.ProjectCollection.Settings container renders correctly 1`] = `
       >
         <label
           className="form-input-heading toggle above"
-          htmlFor="switch-input-1"
+          htmlFor={1}
         >
           Show on homepage:
         </label>
@@ -225,7 +225,7 @@ exports[`Backend.ProjectCollection.Settings container renders correctly 1`] = `
           <div
             aria-pressed={false}
             className="boolean-primary"
-            id="switch-input-1"
+            id={1}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}

--- a/client/src/backend/containers/project-collection/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/backend/containers/project-collection/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -113,7 +113,7 @@ exports[`Backend.ProjectCollection.Wrapper container renders correctly when no p
       >
         <div
           className="entity-list entity-list--bare"
-          id="entities-list1"
+          id={1}
         >
           <div
             className="entity-list__contents-wrapper"

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Collections-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Collections-test.js.snap
@@ -10,7 +10,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
   />
   <div
     className="entity-list"
-    id="entities-list1"
+    id={1}
   >
     <h2
       className="entity-list__title-block entity-list__title"
@@ -73,13 +73,13 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
             >
               <label
                 className="screen-reader-text"
-                htmlFor="list-search-1"
+                htmlFor={1}
               >
                 Enter Search Criteria
               </label>
               <input
                 className="entity-list-search__keyword-input"
-                id="list-search-1"
+                id={1}
                 onChange={[Function]}
                 placeholder="Search..."
                 type="text"
@@ -133,7 +133,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       >
@@ -174,7 +174,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       >
@@ -215,7 +215,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       />
@@ -250,7 +250,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value="title"
                       >
@@ -384,7 +384,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
                 >
                   <a
                     disabled={true}
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <svg
@@ -420,7 +420,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
                   className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -440,7 +440,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
                   className="list-pagination__page list-pagination__page--ordinal"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -466,7 +466,7 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
                   className="list-pagination__page list-pagination__page--next"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Events-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Events-test.js.snap
@@ -11,7 +11,7 @@ Array [
   <section>
     <div
       className="entity-list"
-      id="entities-list1"
+      id={1}
     >
       <h2
         className="entity-list__title-block entity-list__title"
@@ -74,13 +74,13 @@ Array [
               >
                 <label
                   className="screen-reader-text"
-                  htmlFor="list-search-1"
+                  htmlFor={1}
                 >
                   Enter Search Criteria
                 </label>
                 <input
                   className="entity-list-search__keyword-input"
-                  id="list-search-1"
+                  id={1}
                   onChange={[Function]}
                   placeholder="Search..."
                   type="text"
@@ -134,7 +134,7 @@ Array [
                         className="entity-list-search__select-wrapper"
                       >
                         <select
-                          id="list-search-1"
+                          id={1}
                           onChange={[Function]}
                           value=""
                         >
@@ -403,7 +403,7 @@ Array [
                   >
                     <a
                       disabled={true}
-                      href="#entities-list1"
+                      href="#1"
                       onClick={[Function]}
                     >
                       <svg
@@ -439,7 +439,7 @@ Array [
                     className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                   >
                     <a
-                      href="#entities-list1"
+                      href="#1"
                       onClick={[Function]}
                     >
                       <span
@@ -459,7 +459,7 @@ Array [
                     className="list-pagination__page list-pagination__page--ordinal"
                   >
                     <a
-                      href="#entities-list1"
+                      href="#1"
                       onClick={[Function]}
                     >
                       <span
@@ -485,7 +485,7 @@ Array [
                     className="list-pagination__page list-pagination__page--next"
                   >
                     <a
-                      href="#entities-list1"
+                      href="#1"
                       onClick={[Function]}
                     >
                       <span

--- a/client/src/backend/containers/project/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/General-test.js.snap
@@ -27,13 +27,13 @@ exports[`Backend Project General Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[title]-text-input-1"
+              htmlFor="text-input-1"
             >
               Title
             </label>
             <input
-              aria-describedby="attributes[title]-text-input-1"
-              id="attributes[title]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Enter Project Title"
               type="text"
@@ -46,13 +46,13 @@ exports[`Backend Project General Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[subtitle]-text-input-1"
+              htmlFor="text-input-1"
             >
               Subtitle
             </label>
             <input
-              aria-describedby="attributes[subtitle]-text-input-1"
-              id="attributes[subtitle]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Enter Project Subtitle"
               type="text"
@@ -65,13 +65,13 @@ exports[`Backend Project General Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[slug]-text-input-1"
+              htmlFor="text-input-1"
             >
               Slug
             </label>
             <input
-              aria-describedby="attributes[slug]-text-input-1"
-              id="attributes[slug]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Enter Project Slug"
               type="text"
@@ -98,7 +98,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
           >
             <label
               className="form-input-heading toggle above"
-              htmlFor="switch-input-1"
+              htmlFor={1}
             >
               Draft Mode
             </label>
@@ -108,7 +108,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
               <div
                 aria-pressed={false}
                 className="boolean-primary"
-                id="switch-input-1"
+                id={1}
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -133,7 +133,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
           >
             <label
               className="form-input-heading toggle above"
-              htmlFor="switch-input-1"
+              htmlFor={1}
             >
               Featured
             </label>
@@ -143,7 +143,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
               <div
                 aria-pressed={false}
                 className="boolean-primary"
-                id="switch-input-1"
+                id={1}
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -519,7 +519,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[tagList]-tag-list-1"
+              htmlFor="tag-list-1"
             >
               Tags
             </label>

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Log-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Log-test.js.snap
@@ -3,7 +3,7 @@
 exports[`Backend Project Log Container renders correctly 1`] = `
 <div
   className="entity-list"
-  id="entities-list1"
+  id={1}
 >
   <h2
     className="entity-list__title-block entity-list__title"
@@ -107,7 +107,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
               </span>
               <span
                 className="aria-describedby"
-                id="undefined1-describedby"
+                id="1-describedby"
               >
                 View [object Object]
               </span>
@@ -158,7 +158,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
               </span>
               <span
                 className="aria-describedby"
-                id="undefined1-describedby"
+                id="1-describedby"
               >
                 View [object Object]
               </span>
@@ -196,7 +196,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
               >
                 <a
                   disabled={true}
-                  href="#entities-list1"
+                  href="#1"
                   onClick={[Function]}
                 >
                   <svg
@@ -232,7 +232,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
                 className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
               >
                 <a
-                  href="#entities-list1"
+                  href="#1"
                   onClick={[Function]}
                 >
                   <span
@@ -252,7 +252,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
                 className="list-pagination__page list-pagination__page--ordinal"
               >
                 <a
-                  href="#entities-list1"
+                  href="#1"
                   onClick={[Function]}
                 >
                   <span
@@ -278,7 +278,7 @@ exports[`Backend Project Log Container renders correctly 1`] = `
                 className="list-pagination__page list-pagination__page--next"
               >
                 <a
-                  href="#entities-list1"
+                  href="#1"
                   onClick={[Function]}
                 >
                   <span

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Metadata-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Metadata-test.js.snap
@@ -27,13 +27,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][isbn]-text-input-1"
+              htmlFor="text-input-1"
             >
               isbn
             </label>
             <input
-              aria-describedby="attributes[metadata][isbn]-text-input-1"
-              id="attributes[metadata][isbn]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="International Standard Book Number"
               type="text"
@@ -46,13 +46,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][issn]-text-input-1"
+              htmlFor="text-input-1"
             >
               issn
             </label>
             <input
-              aria-describedby="attributes[metadata][issn]-text-input-1"
-              id="attributes[metadata][issn]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="International Standard Serial Number"
               type="text"
@@ -80,13 +80,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][publisher]-text-input-1"
+              htmlFor="text-input-1"
             >
               publisher
             </label>
             <input
-              aria-describedby="attributes[metadata][publisher]-text-input-1"
-              id="attributes[metadata][publisher]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="The Publisher"
               type="text"
@@ -99,13 +99,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className="has-instructions"
-              htmlFor="attributes[metadata][publisherPlace]-text-input-1"
+              htmlFor="text-input-1"
             >
               publisher place
             </label>
             <input
-              aria-describedby="attributes[metadata][publisherPlace]-text-input-1"
-              id="attributes[metadata][publisherPlace]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Geographic location of the publisher"
               type="text"
@@ -123,13 +123,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][originalPublisher]-text-input-1"
+              htmlFor="text-input-1"
             >
               original publisher
             </label>
             <input
-              aria-describedby="attributes[metadata][originalPublisher]-text-input-1"
-              id="attributes[metadata][originalPublisher]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Original publisher, for items that have been republished by a different publisher"
               type="text"
@@ -142,13 +142,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][originalPublisherPlace]-text-input-1"
+              htmlFor="text-input-1"
             >
               original publisher place
             </label>
             <input
-              aria-describedby="attributes[metadata][originalPublisherPlace]-text-input-1"
-              id="attributes[metadata][originalPublisherPlace]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Geographic location of the original publisher"
               type="text"
@@ -176,13 +176,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className="has-instructions"
-              htmlFor="attributes[metadata][containerTitle]-text-input-1"
+              htmlFor="text-input-1"
             >
               container title
             </label>
             <input
-              aria-describedby="attributes[metadata][containerTitle]-text-input-1"
-              id="attributes[metadata][containerTitle]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Title of the container holding the item"
               type="text"
@@ -200,13 +200,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][version]-text-input-1"
+              htmlFor="text-input-1"
             >
               version
             </label>
             <input
-              aria-describedby="attributes[metadata][version]-text-input-1"
-              id="attributes[metadata][version]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Version of the item"
               type="text"
@@ -219,13 +219,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className="has-instructions"
-              htmlFor="attributes[metadata][edition]-text-input-1"
+              htmlFor="text-input-1"
             >
               edition
             </label>
             <input
-              aria-describedby="attributes[metadata][edition]-text-input-1"
-              id="attributes[metadata][edition]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="(Container) edition holding the item"
               type="text"
@@ -243,13 +243,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className="has-instructions"
-              htmlFor="attributes[metadata][issue]-text-input-1"
+              htmlFor="text-input-1"
             >
               issue
             </label>
             <input
-              aria-describedby="attributes[metadata][issue]-text-input-1"
-              id="attributes[metadata][issue]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="(Container) issue holding the item"
               type="text"
@@ -267,13 +267,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className="has-instructions"
-              htmlFor="attributes[metadata][volume]-text-input-1"
+              htmlFor="text-input-1"
             >
               volume
             </label>
             <input
-              aria-describedby="attributes[metadata][volume]-text-input-1"
-              id="attributes[metadata][volume]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="(Container) volume holding the item "
               type="text"
@@ -291,13 +291,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][originalTitle]-text-input-1"
+              htmlFor="text-input-1"
             >
               original title
             </label>
             <input
-              aria-describedby="attributes[metadata][originalTitle]-text-input-1"
-              id="attributes[metadata][originalTitle]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Title of the original version"
               type="text"
@@ -325,13 +325,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][abstract]-text-input-1"
+              htmlFor="text-input-1"
             >
               abstract
             </label>
             <input
-              aria-describedby="attributes[metadata][abstract]-text-input-1"
-              id="attributes[metadata][abstract]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -344,13 +344,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][archive]-text-input-1"
+              htmlFor="text-input-1"
             >
               archive
             </label>
             <input
-              aria-describedby="attributes[metadata][archive]-text-input-1"
-              id="attributes[metadata][archive]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -363,13 +363,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][archiveLocation]-text-input-1"
+              htmlFor="text-input-1"
             >
               archive location
             </label>
             <input
-              aria-describedby="attributes[metadata][archiveLocation]-text-input-1"
-              id="attributes[metadata][archiveLocation]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -382,13 +382,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][archivePlace]-text-input-1"
+              htmlFor="text-input-1"
             >
               archive place
             </label>
             <input
-              aria-describedby="attributes[metadata][archivePlace]-text-input-1"
-              id="attributes[metadata][archivePlace]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -401,13 +401,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][authority]-text-input-1"
+              htmlFor="text-input-1"
             >
               authority
             </label>
             <input
-              aria-describedby="attributes[metadata][authority]-text-input-1"
-              id="attributes[metadata][authority]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -420,13 +420,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][callNumber]-text-input-1"
+              htmlFor="text-input-1"
             >
               call number
             </label>
             <input
-              aria-describedby="attributes[metadata][callNumber]-text-input-1"
-              id="attributes[metadata][callNumber]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -439,13 +439,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][chapterNumber]-text-input-1"
+              htmlFor="text-input-1"
             >
               chapter number
             </label>
             <input
-              aria-describedby="attributes[metadata][chapterNumber]-text-input-1"
-              id="attributes[metadata][chapterNumber]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -458,13 +458,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][collectionNumber]-text-input-1"
+              htmlFor="text-input-1"
             >
               collection number
             </label>
             <input
-              aria-describedby="attributes[metadata][collectionNumber]-text-input-1"
-              id="attributes[metadata][collectionNumber]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -477,13 +477,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][collectionTitle]-text-input-1"
+              htmlFor="text-input-1"
             >
               collection title
             </label>
             <input
-              aria-describedby="attributes[metadata][collectionTitle]-text-input-1"
-              id="attributes[metadata][collectionTitle]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -496,13 +496,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][dimensions]-text-input-1"
+              htmlFor="text-input-1"
             >
               dimensions
             </label>
             <input
-              aria-describedby="attributes[metadata][dimensions]-text-input-1"
-              id="attributes[metadata][dimensions]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -515,13 +515,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][event]-text-input-1"
+              htmlFor="text-input-1"
             >
               event
             </label>
             <input
-              aria-describedby="attributes[metadata][event]-text-input-1"
-              id="attributes[metadata][event]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -534,13 +534,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][eventPlace]-text-input-1"
+              htmlFor="text-input-1"
             >
               event place
             </label>
             <input
-              aria-describedby="attributes[metadata][eventPlace]-text-input-1"
-              id="attributes[metadata][eventPlace]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -553,13 +553,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][jurisdiction]-text-input-1"
+              htmlFor="text-input-1"
             >
               jurisdiction
             </label>
             <input
-              aria-describedby="attributes[metadata][jurisdiction]-text-input-1"
-              id="attributes[metadata][jurisdiction]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -572,13 +572,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][medium]-text-input-1"
+              htmlFor="text-input-1"
             >
               medium
             </label>
             <input
-              aria-describedby="attributes[metadata][medium]-text-input-1"
-              id="attributes[metadata][medium]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -591,13 +591,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][number]-text-input-1"
+              htmlFor="text-input-1"
             >
               number
             </label>
             <input
-              aria-describedby="attributes[metadata][number]-text-input-1"
-              id="attributes[metadata][number]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -610,13 +610,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][numberOfPages]-text-input-1"
+              htmlFor="text-input-1"
             >
               number of pages
             </label>
             <input
-              aria-describedby="attributes[metadata][numberOfPages]-text-input-1"
-              id="attributes[metadata][numberOfPages]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -629,13 +629,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][numberOfVolumes]-text-input-1"
+              htmlFor="text-input-1"
             >
               number of volumes
             </label>
             <input
-              aria-describedby="attributes[metadata][numberOfVolumes]-text-input-1"
-              id="attributes[metadata][numberOfVolumes]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -648,13 +648,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][pmcid]-text-input-1"
+              htmlFor="text-input-1"
             >
               pmcid
             </label>
             <input
-              aria-describedby="attributes[metadata][pmcid]-text-input-1"
-              id="attributes[metadata][pmcid]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -667,13 +667,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][pmid]-text-input-1"
+              htmlFor="text-input-1"
             >
               pmid
             </label>
             <input
-              aria-describedby="attributes[metadata][pmid]-text-input-1"
-              id="attributes[metadata][pmid]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -686,13 +686,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][reviewedTitle]-text-input-1"
+              htmlFor="text-input-1"
             >
               reviewed title
             </label>
             <input
-              aria-describedby="attributes[metadata][reviewedTitle]-text-input-1"
-              id="attributes[metadata][reviewedTitle]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -705,13 +705,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][section]-text-input-1"
+              htmlFor="text-input-1"
             >
               section
             </label>
             <input
-              aria-describedby="attributes[metadata][section]-text-input-1"
-              id="attributes[metadata][section]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"
@@ -724,13 +724,13 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[metadata][yearSuffix]-text-input-1"
+              htmlFor="text-input-1"
             >
               year suffix
             </label>
             <input
-              aria-describedby="attributes[metadata][yearSuffix]-text-input-1"
-              id="attributes[metadata][yearSuffix]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder={null}
               type="text"

--- a/client/src/backend/containers/project/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/New-test.js.snap
@@ -155,13 +155,13 @@ exports[`Backend Project New Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[title]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Title
                   </label>
                   <input
-                    aria-describedby="attributes[title]-text-input-1"
-                    id="attributes[title]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="Enter Project Title"
                     type="text"
@@ -174,13 +174,13 @@ exports[`Backend Project New Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[subtitle]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Subtitle
                   </label>
                   <input
-                    aria-describedby="attributes[subtitle]-text-input-1"
-                    id="attributes[subtitle]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="Enter Project Subtitle"
                     type="text"

--- a/client/src/backend/containers/project/__tests__/__snapshots__/ProjectPage-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/ProjectPage-test.js.snap
@@ -26,7 +26,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           >
             <label
               className="form-input-heading toggle above"
-              htmlFor="switch-input-1"
+              htmlFor={1}
             >
               Hide Project Activity
             </label>
@@ -36,7 +36,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
               <div
                 aria-pressed={false}
                 className="boolean-primary"
-                id="switch-input-1"
+                id={1}
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
@@ -278,13 +278,13 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           >
             <label
               className="has-instructions"
-              htmlFor="attributes[purchaseUrl]-text-input-1"
+              htmlFor="text-input-1"
             >
               Purchase URL
             </label>
             <input
-              aria-describedby="attributes[purchaseUrl]-text-input-1"
-              id="attributes[purchaseUrl]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Enter Purchase URL"
               type="text"
@@ -302,13 +302,13 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           >
             <label
               className="has-instructions"
-              htmlFor="attributes[purchaseCallToAction]-text-input-1"
+              htmlFor="text-input-1"
             >
               Purchase Call To Action
             </label>
             <input
-              aria-describedby="attributes[purchaseCallToAction]-text-input-1"
-              id="attributes[purchaseCallToAction]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Buy Print Version"
               type="text"
@@ -325,12 +325,12 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           >
             <label
               className="has-instructions"
-              htmlFor="masked-text-1"
+              htmlFor={1}
             >
               Purchase Price
             </label>
             <react-text-mask
-              id="masked-text-1"
+              id={1}
               mask={[Function]}
               onChange={[Function]}
               placeholderChar="_"
@@ -348,13 +348,13 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           >
             <label
               className="has-instructions"
-              htmlFor="attributes[purchasePriceCurrency]-text-input-1"
+              htmlFor="text-input-1"
             >
               Currency
             </label>
             <input
-              aria-describedby="attributes[purchasePriceCurrency]-text-input-1"
-              id="attributes[purchasePriceCurrency]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Enter Purchase Price Currency Code"
               type="text"
@@ -392,13 +392,13 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           >
             <label
               className=""
-              htmlFor="attributes[downloadUrl]-text-input-1"
+              htmlFor="text-input-1"
             >
               Download URL
             </label>
             <input
-              aria-describedby="attributes[downloadUrl]-text-input-1"
-              id="attributes[downloadUrl]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Enter Download URL"
               type="text"
@@ -411,13 +411,13 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
           >
             <label
               className="has-instructions"
-              htmlFor="attributes[downloadCallToAction]-text-input-1"
+              htmlFor="text-input-1"
             >
               Download Call To Action
             </label>
             <input
-              aria-describedby="attributes[downloadCallToAction]-text-input-1"
-              id="attributes[downloadCallToAction]-text-input-1"
+              aria-describedby="text-input-error-1"
+              id="text-input-1"
               onChange={[Function]}
               placeholder="Download eBook"
               type="text"

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Resources-test.js.snap
@@ -10,7 +10,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
   />
   <div
     className="entity-list"
-    id="entities-list1"
+    id={1}
   >
     <h2
       className="entity-list__title-block entity-list__title"
@@ -73,13 +73,13 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
             >
               <label
                 className="screen-reader-text"
-                htmlFor="list-search-1"
+                htmlFor={1}
               >
                 Enter Search Criteria
               </label>
               <input
                 className="entity-list-search__keyword-input"
-                id="list-search-1"
+                id={1}
                 onChange={[Function]}
                 placeholder="Search..."
                 type="text"
@@ -133,7 +133,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       >
@@ -174,7 +174,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       >
@@ -215,7 +215,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       />
@@ -250,7 +250,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value="title"
                       >
@@ -384,7 +384,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
                 >
                   <a
                     disabled={true}
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <svg
@@ -420,7 +420,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
                   className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -440,7 +440,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
                   className="list-pagination__page list-pagination__page--ordinal"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -466,7 +466,7 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
                   className="list-pagination__page list-pagination__page--next"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span

--- a/client/src/backend/containers/project/category/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/backend/containers/project/category/__tests__/__snapshots__/Edit-test.js.snap
@@ -27,13 +27,13 @@ exports[`Backend Project Category Edit Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[title]-text-input-1"
+          htmlFor="text-input-1"
         >
           Title
         </label>
         <input
-          aria-describedby="attributes[title]-text-input-1"
-          id="attributes[title]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="What would you like to call this category?"
           type="text"

--- a/client/src/backend/containers/project/category/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/project/category/__tests__/__snapshots__/New-test.js.snap
@@ -27,13 +27,13 @@ exports[`Backend Project Category New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[title]-text-input-1"
+          htmlFor="text-input-1"
         >
           Title
         </label>
         <input
-          aria-describedby="attributes[title]-text-input-1"
-          id="attributes[title]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="What would you like to call this category?"
           type="text"

--- a/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourceCollectionsList-test.js.snap
+++ b/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourceCollectionsList-test.js.snap
@@ -10,7 +10,7 @@ Array [
   />,
   <div
     className="entity-list"
-    id="entities-list1"
+    id={1}
   >
     <h2
       className="entity-list__title-block entity-list__title"
@@ -73,13 +73,13 @@ Array [
             >
               <label
                 className="screen-reader-text"
-                htmlFor="list-search-1"
+                htmlFor={1}
               >
                 Enter Search Criteria
               </label>
               <input
                 className="entity-list-search__keyword-input"
-                id="list-search-1"
+                id={1}
                 onChange={[Function]}
                 placeholder="Search..."
                 type="text"
@@ -133,7 +133,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value="title"
                       >
@@ -225,7 +225,7 @@ Array [
           className="entity-row entity-list__entity"
         >
           <a
-            aria-describedby="undefined1-describedby"
+            aria-describedby="1-describedby"
             className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
             href="/backend/projects/resource-collection/2"
             onClick={[Function]}
@@ -260,7 +260,7 @@ Array [
                   </span>
                   <span
                     className="aria-describedby"
-                    id="undefined1-describedby"
+                    id="1-describedby"
                   >
                     View Rowan
                   </span>
@@ -287,7 +287,7 @@ Array [
           className="entity-row entity-list__entity"
         >
           <a
-            aria-describedby="undefined1-describedby"
+            aria-describedby="1-describedby"
             className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
             href="/backend/projects/resource-collection/3"
             onClick={[Function]}
@@ -322,7 +322,7 @@ Array [
                   </span>
                   <span
                     className="aria-describedby"
-                    id="undefined1-describedby"
+                    id="1-describedby"
                   >
                     View Rowan
                   </span>
@@ -365,7 +365,7 @@ Array [
                 >
                   <a
                     disabled={true}
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <svg
@@ -401,7 +401,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -421,7 +421,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -447,7 +447,7 @@ Array [
                   className="list-pagination__page list-pagination__page--next"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span

--- a/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourcesList-test.js.snap
+++ b/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourcesList-test.js.snap
@@ -10,7 +10,7 @@ Array [
   />,
   <div
     className="entity-list"
-    id="entities-list1"
+    id={1}
   >
     <h2
       className="entity-list__title-block entity-list__title"
@@ -73,13 +73,13 @@ Array [
             >
               <label
                 className="screen-reader-text"
-                htmlFor="list-search-1"
+                htmlFor={1}
               >
                 Enter Search Criteria
               </label>
               <input
                 className="entity-list-search__keyword-input"
-                id="list-search-1"
+                id={1}
                 onChange={[Function]}
                 placeholder="Search..."
                 type="text"
@@ -133,7 +133,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       >
@@ -174,7 +174,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       >
@@ -215,7 +215,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       />
@@ -250,7 +250,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value="title"
                       >
@@ -367,7 +367,7 @@ Array [
           className="entity-row entity-list__entity"
         >
           <a
-            aria-describedby="undefined1-describedby"
+            aria-describedby="1-describedby"
             className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
             href="/backend/projects/resource/2"
             onClick={[Function]}
@@ -411,7 +411,7 @@ Array [
                   </span>
                   <span
                     className="aria-describedby"
-                    id="undefined1-describedby"
+                    id="1-describedby"
                   >
                     View Image
                   </span>
@@ -433,7 +433,7 @@ Array [
           className="entity-row entity-list__entity"
         >
           <a
-            aria-describedby="undefined1-describedby"
+            aria-describedby="1-describedby"
             className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
             href="/backend/projects/resource/3"
             onClick={[Function]}
@@ -477,7 +477,7 @@ Array [
                   </span>
                   <span
                     className="aria-describedby"
-                    id="undefined1-describedby"
+                    id="1-describedby"
                   >
                     View Image
                   </span>
@@ -515,7 +515,7 @@ Array [
                 >
                   <a
                     disabled={true}
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <svg
@@ -551,7 +551,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -571,7 +571,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -597,7 +597,7 @@ Array [
                   className="list-pagination__page list-pagination__page--next"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span

--- a/client/src/backend/containers/project/social/__tests__/__snapshots__/TwitterQueries-test.js.snap
+++ b/client/src/backend/containers/project/social/__tests__/__snapshots__/TwitterQueries-test.js.snap
@@ -3,7 +3,7 @@
 exports[`Backend Project Social Twitter Queries Container renders correctly 1`] = `
 <div
   className="entity-list"
-  id="entities-list1"
+  id={1}
 >
   <header
     className="entity-list__title-block entity-list__title backend-header"
@@ -60,7 +60,7 @@ exports[`Backend Project Social Twitter Queries Container renders correctly 1`] 
         className="entity-row entity-list__entity"
       >
         <a
-          aria-describedby="undefined1-describedby"
+          aria-describedby="1-describedby"
           className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag entity-row__row-link--is-active"
           href="/backend/projects/1/social/twitter-query/2"
           onClick={[Function]}
@@ -90,7 +90,7 @@ exports[`Backend Project Social Twitter Queries Container renders correctly 1`] 
                 </span>
                 <span
                   className="aria-describedby"
-                  id="undefined1-describedby"
+                  id="1-describedby"
                 >
                   View from:manifoldscholar
                 </span>

--- a/client/src/backend/containers/project/text/ingestion/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/project/text/ingestion/__tests__/__snapshots__/New-test.js.snap
@@ -129,7 +129,7 @@ exports[`Project Text Ingestion New Container renders correctly 1`] = `
             URL
           </label>
           <input
-            aria-describedby="text-input-1"
+            aria-describedby="text-input-error-1"
             id="text-input-1"
             onChange={[Function]}
             type="text"

--- a/client/src/backend/containers/resource-collection/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/resource-collection/__tests__/__snapshots__/General-test.js.snap
@@ -14,13 +14,13 @@ exports[`Backend ResourceCollection General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[title]-text-input-1"
+          htmlFor="text-input-1"
         >
           Title
         </label>
         <input
-          aria-describedby="attributes[title]-text-input-1"
-          id="attributes[title]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Enter a title"
           type="text"

--- a/client/src/backend/containers/resource-collection/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/resource-collection/__tests__/__snapshots__/New-test.js.snap
@@ -127,13 +127,13 @@ exports[`Backend ResourceCollection New Container renders correctly 1`] = `
             >
               <label
                 className=""
-                htmlFor="attributes[title]-text-input-1"
+                htmlFor="text-input-1"
               >
                 Title
               </label>
               <input
-                aria-describedby="attributes[title]-text-input-1"
-                id="attributes[title]-text-input-1"
+                aria-describedby="text-input-error-1"
+                id="text-input-1"
                 onChange={[Function]}
                 placeholder="Enter a title"
                 type="text"

--- a/client/src/backend/containers/resource-collection/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/backend/containers/resource-collection/__tests__/__snapshots__/Resources-test.js.snap
@@ -10,7 +10,7 @@ Array [
   />,
   <div
     className="entity-list"
-    id="entities-list1"
+    id={1}
   >
     <h2
       className="entity-list__title-block entity-list__title"
@@ -88,13 +88,13 @@ Array [
             >
               <label
                 className="screen-reader-text"
-                htmlFor="list-search-1"
+                htmlFor={1}
               >
                 Enter Search Criteria
               </label>
               <input
                 className="entity-list-search__keyword-input"
-                id="list-search-1"
+                id={1}
                 onChange={[Function]}
                 placeholder="Search..."
                 type="text"
@@ -148,7 +148,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       >
@@ -189,7 +189,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       >
@@ -230,7 +230,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       />
@@ -265,7 +265,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value="title"
                       >
@@ -338,7 +338,7 @@ Array [
           className="entity-row entity-list__entity"
         >
           <a
-            aria-describedby="undefined1-describedby"
+            aria-describedby="1-describedby"
             className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
             href="/backend/projects/resource/3"
             onClick={[Function]}
@@ -382,7 +382,7 @@ Array [
                   </span>
                   <span
                     className="aria-describedby"
-                    id="undefined1-describedby"
+                    id="1-describedby"
                   >
                     View Image
                   </span>
@@ -428,7 +428,7 @@ Array [
           className="entity-row entity-list__entity"
         >
           <a
-            aria-describedby="undefined1-describedby"
+            aria-describedby="1-describedby"
             className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
             href="/backend/projects/resource/4"
             onClick={[Function]}
@@ -472,7 +472,7 @@ Array [
                   </span>
                   <span
                     className="aria-describedby"
-                    id="undefined1-describedby"
+                    id="1-describedby"
                   >
                     View Image
                   </span>
@@ -534,7 +534,7 @@ Array [
                 >
                   <a
                     disabled={true}
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <svg
@@ -570,7 +570,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -590,7 +590,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -616,7 +616,7 @@ Array [
                   className="list-pagination__page list-pagination__page--next"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span

--- a/client/src/backend/containers/resource/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/resource/__tests__/__snapshots__/General-test.js.snap
@@ -15,7 +15,7 @@ exports[`Backend Resource General Container renders correctly 1`] = `
           className="form-input"
         >
           <label
-            htmlFor="kind-1"
+            htmlFor={1}
           >
             Kind
           </label>
@@ -39,7 +39,7 @@ exports[`Backend Resource General Container renders correctly 1`] = `
                 />
               </svg>
               <select
-                id="kind-1"
+                id={1}
                 onChange={[Function]}
                 value="image"
               >
@@ -114,13 +114,13 @@ exports[`Backend Resource General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[title]-text-input-1"
+          htmlFor="text-input-1"
         >
           Title
         </label>
         <input
-          aria-describedby="attributes[title]-text-input-1"
-          id="attributes[title]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Enter a title"
           type="text"
@@ -133,13 +133,13 @@ exports[`Backend Resource General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[fingerprint]-text-input-1"
+          htmlFor="text-input-1"
         >
           Fingerprint
         </label>
         <input
-          aria-describedby="attributes[fingerprint]-text-input-1"
-          id="attributes[fingerprint]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Enter fingerprint"
           type="text"
@@ -152,13 +152,13 @@ exports[`Backend Resource General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[slug]-text-input-1"
+          htmlFor="text-input-1"
         >
           Slug
         </label>
         <input
-          aria-describedby="attributes[slug]-text-input-1"
-          id="attributes[slug]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Enter slug"
           type="text"
@@ -171,7 +171,7 @@ exports[`Backend Resource General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[tagList]-tag-list-1"
+          htmlFor="tag-list-1"
         >
           Tags
         </label>

--- a/client/src/backend/containers/resource/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/resource/__tests__/__snapshots__/New-test.js.snap
@@ -128,7 +128,7 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                 className="form-input"
               >
                 <label
-                  htmlFor="kind-1"
+                  htmlFor={1}
                 >
                   Kind
                 </label>
@@ -152,7 +152,7 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                       />
                     </svg>
                     <select
-                      id="kind-1"
+                      id={1}
                       onChange={[Function]}
                       value="image"
                     >
@@ -577,13 +577,13 @@ exports[`Backend Resource New Container renders correctly 1`] = `
             >
               <label
                 className=""
-                htmlFor="attributes[title]-text-input-1"
+                htmlFor="text-input-1"
               >
                 Title
               </label>
               <input
-                aria-describedby="attributes[title]-text-input-1"
-                id="attributes[title]-text-input-1"
+                aria-describedby="text-input-error-1"
+                id="text-input-1"
                 onChange={[Function]}
                 placeholder="Enter a resource title"
                 type="text"

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Email-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Email-test.js.snap
@@ -49,13 +49,13 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][fromAddress]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Email from address
                   </label>
                   <input
-                    aria-describedby="attributes[email][fromAddress]-text-input-1"
-                    id="attributes[email][fromAddress]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="do-not-reply@manifoldapp.org"
                     type="text"
@@ -73,13 +73,13 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][fromName]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Email from name
                   </label>
                   <input
-                    aria-describedby="attributes[email][fromName]-text-input-1"
-                    id="attributes[email][fromName]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="Manifold Scholarship"
                     type="text"
@@ -97,13 +97,13 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][replyToAddress]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Email reply-to address
                   </label>
                   <input
-                    aria-describedby="attributes[email][replyToAddress]-text-input-1"
-                    id="attributes[email][replyToAddress]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="do-not-reply@manifoldapp.org"
                     type="text"
@@ -121,13 +121,13 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][replyToName]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Email reply-to name
                   </label>
                   <input
-                    aria-describedby="attributes[email][replyToName]-text-input-1"
-                    id="attributes[email][replyToName]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -193,7 +193,9 @@ The Manifold Team"
                     className="form-input"
                     style={Object {}}
                   >
-                    <label>
+                    <label
+                      htmlFor="select-1"
+                    >
                       Email Delivery Method
                     </label>
                     <div
@@ -214,6 +216,7 @@ The Manifold Team"
                       </svg>
                       <select
                         aria-describedby="select-error-1"
+                        id="select-1"
                         onChange={[Function]}
                         value=""
                       >
@@ -257,13 +260,13 @@ The Manifold Team"
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][sendmailSettingsLocation]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Sendmail Location
                   </label>
                   <input
-                    aria-describedby="attributes[email][sendmailSettingsLocation]-text-input-1"
-                    id="attributes[email][sendmailSettingsLocation]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -280,13 +283,13 @@ The Manifold Team"
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][sendmailSettingsArguments]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Sendmail Arguments
                   </label>
                   <input
-                    aria-describedby="attributes[email][sendmailSettingsArguments]-text-input-1"
-                    id="attributes[email][sendmailSettingsArguments]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -373,13 +376,13 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][fromAddress]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Email from address
                   </label>
                   <input
-                    aria-describedby="attributes[email][fromAddress]-text-input-1"
-                    id="attributes[email][fromAddress]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="do-not-reply@manifoldapp.org"
                     type="text"
@@ -397,13 +400,13 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][fromName]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Email from name
                   </label>
                   <input
-                    aria-describedby="attributes[email][fromName]-text-input-1"
-                    id="attributes[email][fromName]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="Manifold Scholarship"
                     type="text"
@@ -421,13 +424,13 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][replyToAddress]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Email reply-to address
                   </label>
                   <input
-                    aria-describedby="attributes[email][replyToAddress]-text-input-1"
-                    id="attributes[email][replyToAddress]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="do-not-reply@manifoldapp.org"
                     type="text"
@@ -445,13 +448,13 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][replyToName]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Email reply-to name
                   </label>
                   <input
-                    aria-describedby="attributes[email][replyToName]-text-input-1"
-                    id="attributes[email][replyToName]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -517,7 +520,9 @@ The Manifold Team"
                     className="form-input"
                     style={Object {}}
                   >
-                    <label>
+                    <label
+                      htmlFor="select-1"
+                    >
                       Email Delivery Method
                     </label>
                     <div
@@ -538,6 +543,7 @@ The Manifold Team"
                       </svg>
                       <select
                         aria-describedby="select-error-1"
+                        id="select-1"
                         onChange={[Function]}
                         value=""
                       >
@@ -581,13 +587,13 @@ The Manifold Team"
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][smtpSettingsAddress]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     SMTP Address
                   </label>
                   <input
-                    aria-describedby="attributes[email][smtpSettingsAddress]-text-input-1"
-                    id="attributes[email][smtpSettingsAddress]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -604,13 +610,13 @@ The Manifold Team"
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][smtpSettingsPort]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     SMTP Port
                   </label>
                   <input
-                    aria-describedby="attributes[email][smtpSettingsPort]-text-input-1"
-                    id="attributes[email][smtpSettingsPort]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -627,13 +633,13 @@ The Manifold Team"
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[email][smtpSettingsUserName]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     SMTP Username
                   </label>
                   <input
-                    aria-describedby="attributes[email][smtpSettingsUserName]-text-input-1"
-                    id="attributes[email][smtpSettingsUserName]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -650,13 +656,13 @@ The Manifold Team"
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[secrets][smtpSettingsPassword]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     SMTP Password
                   </label>
                   <input
-                    aria-describedby="attributes[secrets][smtpSettingsPassword]-text-input-1"
-                    id="attributes[secrets][smtpSettingsPassword]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="password"
                     value=""

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/General-test.js.snap
@@ -36,13 +36,13 @@ exports[`Backend Settings General Container renders correctly 1`] = `
             >
               <label
                 className="has-instructions"
-                htmlFor="attributes[general][installationName]-text-input-1"
+                htmlFor="text-input-1"
               >
                 How do you refer to your Manifold installation?
               </label>
               <input
-                aria-describedby="attributes[general][installationName]-text-input-1"
-                id="attributes[general][installationName]-text-input-1"
+                aria-describedby="text-input-error-1"
+                id="text-input-1"
                 onChange={[Function]}
                 placeholder="Manifold"
                 type="text"
@@ -60,13 +60,13 @@ exports[`Backend Settings General Container renders correctly 1`] = `
             >
               <label
                 className="has-instructions"
-                htmlFor="attributes[general][headTitle]-text-input-1"
+                htmlFor="text-input-1"
               >
                 Default Page Title
               </label>
               <input
-                aria-describedby="attributes[general][headTitle]-text-input-1"
-                id="attributes[general][headTitle]-text-input-1"
+                aria-describedby="text-input-error-1"
+                id="text-input-1"
                 onChange={[Function]}
                 placeholder="Enter page title"
                 type="text"
@@ -116,13 +116,13 @@ exports[`Backend Settings General Container renders correctly 1`] = `
             >
               <label
                 className=""
-                htmlFor="attributes[general][defaultPublisher]-text-input-1"
+                htmlFor="text-input-1"
               >
                 Default Publisher
               </label>
               <input
-                aria-describedby="attributes[general][defaultPublisher]-text-input-1"
-                id="attributes[general][defaultPublisher]-text-input-1"
+                aria-describedby="text-input-error-1"
+                id="text-input-1"
                 onChange={[Function]}
                 placeholder="Enter Default Publisher"
                 type="text"
@@ -135,13 +135,13 @@ exports[`Backend Settings General Container renders correctly 1`] = `
             >
               <label
                 className=""
-                htmlFor="attributes[general][defaultPublisherPlace]-text-input-1"
+                htmlFor="text-input-1"
               >
                 Default Place of Publication
               </label>
               <input
-                aria-describedby="attributes[general][defaultPublisherPlace]-text-input-1"
-                id="attributes[general][defaultPublisherPlace]-text-input-1"
+                aria-describedby="text-input-error-1"
+                id="text-input-1"
                 onChange={[Function]}
                 placeholder="Enter Default Place of Publication"
                 type="text"
@@ -154,13 +154,13 @@ exports[`Backend Settings General Container renders correctly 1`] = `
             >
               <label
                 className="has-instructions"
-                htmlFor="attributes[general][copyright]-text-input-1"
+                htmlFor="text-input-1"
               >
                 Copyright
               </label>
               <input
-                aria-describedby="attributes[general][copyright]-text-input-1"
-                id="attributes[general][copyright]-text-input-1"
+                aria-describedby="text-input-error-1"
+                id="text-input-1"
                 onChange={[Function]}
                 placeholder="Enter Copyright Information"
                 type="text"
@@ -178,13 +178,13 @@ exports[`Backend Settings General Container renders correctly 1`] = `
             >
               <label
                 className="has-instructions"
-                htmlFor="attributes[general][socialShareMessage]-text-input-1"
+                htmlFor="text-input-1"
               >
                 Social Sharing Message
               </label>
               <input
-                aria-describedby="attributes[general][socialShareMessage]-text-input-1"
-                id="attributes[general][socialShareMessage]-text-input-1"
+                aria-describedby="text-input-error-1"
+                id="text-input-1"
                 onChange={[Function]}
                 type="text"
                 value=""
@@ -201,13 +201,13 @@ exports[`Backend Settings General Container renders correctly 1`] = `
             >
               <label
                 className="has-instructions"
-                htmlFor="attributes[general][twitter]-text-input-1"
+                htmlFor="text-input-1"
               >
                 Twitter Account
               </label>
               <input
-                aria-describedby="attributes[general][twitter]-text-input-1"
-                id="attributes[general][twitter]-text-input-1"
+                aria-describedby="text-input-error-1"
+                id="text-input-1"
                 onChange={[Function]}
                 placeholder="Enter Twitter account"
                 type="text"
@@ -225,13 +225,13 @@ exports[`Backend Settings General Container renders correctly 1`] = `
             >
               <label
                 className="has-instructions"
-                htmlFor="attributes[general][facebook]-text-input-1"
+                htmlFor="text-input-1"
               >
                 Facebook Page ID
               </label>
               <input
-                aria-describedby="attributes[general][facebook]-text-input-1"
-                id="attributes[general][facebook]-text-input-1"
+                aria-describedby="text-input-error-1"
+                id="text-input-1"
                 onChange={[Function]}
                 placeholder="Enter Facebook ID"
                 type="text"
@@ -249,13 +249,13 @@ exports[`Backend Settings General Container renders correctly 1`] = `
             >
               <label
                 className="has-instructions"
-                htmlFor="attributes[general][contactEmail]-text-input-1"
+                htmlFor="text-input-1"
               >
                 Contact Email
               </label>
               <input
-                aria-describedby="attributes[general][contactEmail]-text-input-1"
-                id="attributes[general][contactEmail]-text-input-1"
+                aria-describedby="text-input-error-1"
+                id="text-input-1"
                 onChange={[Function]}
                 placeholder="Enter an email address"
                 type="text"

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Integrations-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Integrations-test.js.snap
@@ -49,13 +49,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[integrations][facebookAppId]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Facebook App ID
                   </label>
                   <input
-                    aria-describedby="attributes[integrations][facebookAppId]-text-input-1"
-                    id="attributes[integrations][facebookAppId]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -67,13 +67,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[secrets][facebookAppSecret]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Facebook App Secret
                   </label>
                   <input
-                    aria-describedby="attributes[secrets][facebookAppSecret]-text-input-1"
-                    id="attributes[secrets][facebookAppSecret]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="password"
                     value=""
@@ -100,13 +100,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[integrations][twitterAppId]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Twitter Consumer Key
                   </label>
                   <input
-                    aria-describedby="attributes[integrations][twitterAppId]-text-input-1"
-                    id="attributes[integrations][twitterAppId]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -118,13 +118,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[secrets][twitterAppSecret]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Twitter Consumer Secret
                   </label>
                   <input
-                    aria-describedby="attributes[secrets][twitterAppSecret]-text-input-1"
-                    id="attributes[secrets][twitterAppSecret]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="password"
                     value=""
@@ -136,13 +136,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[integrations][twitterAccessToken]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Twitter Access Token
                   </label>
                   <input
-                    aria-describedby="attributes[integrations][twitterAccessToken]-text-input-1"
-                    id="attributes[integrations][twitterAccessToken]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -154,13 +154,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[secrets][twitterAccessTokenSecret]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Twitter Access Token Secret
                   </label>
                   <input
-                    aria-describedby="attributes[secrets][twitterAccessTokenSecret]-text-input-1"
-                    id="attributes[secrets][twitterAccessTokenSecret]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="password"
                     value=""
@@ -293,13 +293,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[integrations][googleProjectId]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Google Project Id
                   </label>
                   <input
-                    aria-describedby="attributes[integrations][googleProjectId]-text-input-1"
-                    id="attributes[integrations][googleProjectId]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -311,13 +311,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[integrations][googlePrivateKeyId]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Google Private Key ID
                   </label>
                   <input
-                    aria-describedby="attributes[integrations][googlePrivateKeyId]-text-input-1"
-                    id="attributes[integrations][googlePrivateKeyId]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -329,13 +329,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[integrations][googleClientEmail]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Google Client Email
                   </label>
                   <input
-                    aria-describedby="attributes[integrations][googleClientEmail]-text-input-1"
-                    id="attributes[integrations][googleClientEmail]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -347,13 +347,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[integrations][googleClientId]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Google Client ID
                   </label>
                   <input
-                    aria-describedby="attributes[integrations][googleClientId]-text-input-1"
-                    id="attributes[integrations][googleClientId]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -380,13 +380,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[integrations][googleOauthClientId]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Google OAuth Client ID
                   </label>
                   <input
-                    aria-describedby="attributes[integrations][googleOauthClientId]-text-input-1"
-                    id="attributes[integrations][googleOauthClientId]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="text"
                     value=""
@@ -398,13 +398,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[secrets][googleOauthClientSecret]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Google Client Secret
                   </label>
                   <input
-                    aria-describedby="attributes[secrets][googleOauthClientSecret]-text-input-1"
-                    id="attributes[secrets][googleOauthClientSecret]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     type="password"
                     value=""
@@ -430,12 +430,12 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="masked-text-1"
+                    htmlFor={1}
                   >
                     Google Analytics Profile ID
                   </label>
                   <react-text-mask
-                    id="masked-text-1"
+                    id={1}
                     mask={
                       Array [
                         "g",
@@ -465,13 +465,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[integrations][gaTrackingId]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Google Analytics Tracking ID
                   </label>
                   <input
-                    aria-describedby="attributes[integrations][gaTrackingId]-text-input-1"
-                    id="attributes[integrations][gaTrackingId]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="UA-000000-00"
                     type="text"

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Placeholder-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Placeholder-test.js.snap
@@ -10,13 +10,13 @@ exports[`Backend Settings Placeholder Container renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor="attributes[aSetting]-text-input-1"
+      htmlFor="text-input-1"
     >
       A All temporary stuff setting
     </label>
     <input
-      aria-describedby="attributes[aSetting]-text-input-1"
-      id="attributes[aSetting]-text-input-1"
+      aria-describedby="text-input-error-1"
+      id="text-input-1"
       onChange={[Function]}
       placeholder="Some setting could go here"
       type="text"
@@ -29,13 +29,13 @@ exports[`Backend Settings Placeholder Container renders correctly 1`] = `
   >
     <label
       className=""
-      htmlFor="attributes[anotherSetting]-text-input-1"
+      htmlFor="text-input-1"
     >
       Another All temporary stuff setting
     </label>
     <input
-      aria-describedby="attributes[anotherSetting]-text-input-1"
-      id="attributes[anotherSetting]-text-input-1"
+      aria-describedby="text-input-error-1"
+      id="text-input-1"
       onChange={[Function]}
       placeholder="Some other setting could go here"
       type="text"

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Theme-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Theme-test.js.snap
@@ -49,13 +49,13 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[general][pressSite]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Press Website URL
                   </label>
                   <input
-                    aria-describedby="attributes[general][pressSite]-text-input-1"
-                    id="attributes[general][pressSite]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="Enter URL"
                     type="text"
@@ -413,13 +413,13 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[theme][logoStyles]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Logo Styles
                   </label>
                   <input
-                    aria-describedby="attributes[theme][logoStyles]-text-input-1"
-                    id="attributes[theme][logoStyles]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="Additional Logo CSS"
                     type="text"
@@ -437,13 +437,13 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
                 >
                   <label
                     className="has-instructions"
-                    htmlFor="attributes[theme][headerOffset]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Header Navigation Offset
                   </label>
                   <input
-                    aria-describedby="attributes[theme][headerOffset]-text-input-1"
-                    id="attributes[theme][headerOffset]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="0"
                     type="text"
@@ -476,13 +476,13 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
                 >
                   <label
                     className=""
-                    htmlFor="attributes[theme][typekitId]-text-input-1"
+                    htmlFor="text-input-1"
                   >
                     Typekit ID
                   </label>
                   <input
-                    aria-describedby="attributes[theme][typekitId]-text-input-1"
-                    id="attributes[theme][typekitId]-text-input-1"
+                    aria-describedby="text-input-error-1"
+                    id="text-input-1"
                     onChange={[Function]}
                     placeholder="Enter Typekit ID"
                     type="text"

--- a/client/src/backend/containers/settings/subjects/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/backend/containers/settings/subjects/__tests__/__snapshots__/Edit-test.js.snap
@@ -58,13 +58,13 @@ exports[`Backend Settings Subjects Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[name]-text-input-1"
+            htmlFor="text-input-1"
           >
             Name
           </label>
           <input
-            aria-describedby="attributes[name]-text-input-1"
-            id="attributes[name]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Name"
             type="text"

--- a/client/src/backend/containers/settings/subjects/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/containers/settings/subjects/__tests__/__snapshots__/List-test.js.snap
@@ -5,7 +5,7 @@ Array [
   <span />,
   <div
     className="entity-list"
-    id="entities-list1"
+    id={1}
   >
     <header
       className="entity-list__title-block backend-header"
@@ -45,7 +45,7 @@ Array [
           className="entity-row entity-list__entity"
         >
           <a
-            aria-describedby="undefined1-describedby"
+            aria-describedby="1-describedby"
             className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
             href="/backend/settings/subjects/1"
             onClick={[Function]}
@@ -66,7 +66,7 @@ Array [
                   </span>
                   <span
                     className="aria-describedby"
-                    id="undefined1-describedby"
+                    id="1-describedby"
                   >
                     View Hip Hop
                   </span>
@@ -95,7 +95,7 @@ Array [
                 >
                   <a
                     disabled={true}
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <svg
@@ -131,7 +131,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -151,7 +151,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -177,7 +177,7 @@ Array [
                   className="list-pagination__page list-pagination__page--next"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span

--- a/client/src/backend/containers/settings/subjects/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/settings/subjects/__tests__/__snapshots__/New-test.js.snap
@@ -27,13 +27,13 @@ exports[`Backend Settings Subjects New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[name]-text-input-1"
+          htmlFor="text-input-1"
         >
           Name
         </label>
         <input
-          aria-describedby="attributes[name]-text-input-1"
-          id="attributes[name]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Enter Subject Name"
           type="text"

--- a/client/src/backend/containers/stylesheet/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/backend/containers/stylesheet/__tests__/__snapshots__/Edit-test.js.snap
@@ -23,22 +23,24 @@ exports[`Backend Stylesheet Edit Container renders correctly 1`] = `
                                     <div className=\\"form-input\\">
                                       <p className=\\"instructions\\" />
                                     </div>
-                                    <Form.TextInput label=\\"Name\\" name=\\"attributes[name]\\" placeholder=\\"Name\\" focusOnMount={false} password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\">
-                                      <HigherOrder.FetchData('Form.BaseInput) label=\\"Name\\" name=\\"attributes[name]\\" placeholder=\\"Name\\" focusOnMount={false} password={false} join={[Function: join]} id=\\"attributes[name]-text-input-1\\" idForError=\\"attributes[name]-text-input-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-stylesheet-create\\" submitKey={{...}} errors={{...}} label=\\"Name\\" name=\\"attributes[name]\\" placeholder=\\"Name\\" focusOnMount={false} password={false} join={[Function: join]} id=\\"attributes[name]-text-input-1\\" idForError=\\"attributes[name]-text-input-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-stylesheet-create\\" submitKey={{...}} errors={{...}} label=\\"Name\\" name=\\"attributes[name]\\" placeholder=\\"Name\\" focusOnMount={false} password={false} join={[Function: join]} id=\\"attributes[name]-text-input-1\\" idForError=\\"attributes[name]-text-input-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                            <Errorable className=\\"form-input\\" name=\\"attributes[name]\\" errors={{...}} label=\\"Name\\" idForError=\\"attributes[name]-text-input-1\\" containerStyle={{...}}>
-                                              <div style={{...}} className=\\"form-input\\">
-                                                <label htmlFor=\\"attributes[name]-text-input-1\\" className=\\"\\">
-                                                  Name
-                                                </label>
-                                                <input id=\\"attributes[name]-text-input-1\\" type=\\"text\\" placeholder=\\"Name\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[name]-text-input-1\\" />
-                                                <Instructions instructions={{...}} />
-                                              </div>
-                                            </Errorable>
-                                          </Form.BaseInput>
-                                        </Form.Setter('Form.BaseInput)>
-                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    <Form.TextInput label=\\"Name\\" name=\\"attributes[name]\\" placeholder=\\"Name\\" focusOnMount={false} password={false} join={[Function: join]}>
+                                      <mockConstructor>
+                                        <HigherOrder.FetchData('Form.BaseInput) label=\\"Name\\" name=\\"attributes[name]\\" placeholder=\\"Name\\" focusOnMount={false} password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-stylesheet-create\\" submitKey={{...}} errors={{...}} label=\\"Name\\" name=\\"attributes[name]\\" placeholder=\\"Name\\" focusOnMount={false} password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                            <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-stylesheet-create\\" submitKey={{...}} errors={{...}} label=\\"Name\\" name=\\"attributes[name]\\" placeholder=\\"Name\\" focusOnMount={false} password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                              <Errorable className=\\"form-input\\" name=\\"attributes[name]\\" errors={{...}} label=\\"Name\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                                <div style={{...}} className=\\"form-input\\">
+                                                  <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                    Name
+                                                  </label>
+                                                  <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Name\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                                  <Instructions instructions={{...}} />
+                                                </div>
+                                              </Errorable>
+                                            </Form.BaseInput>
+                                          </Form.Setter('Form.BaseInput)>
+                                        </HigherOrder.FetchData('Form.BaseInput)>
+                                      </mockConstructor>
                                     </Form.TextInput>
                                     <HigherOrder.FetchData('FormCodeArea) label=\\"Source Styles\\" height=\\"300px\\" mode=\\"css\\" name=\\"attributes[rawStyles]\\" instructions=\\"These are the raw source styles, which can be edited.\\">
                                       <Form.Setter('FormCodeArea) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-stylesheet-create\\" submitKey={{...}} errors={{...}} label=\\"Source Styles\\" height=\\"300px\\" mode=\\"css\\" name=\\"attributes[rawStyles]\\" instructions=\\"These are the raw source styles, which can be edited.\\">

--- a/client/src/backend/containers/text/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/text/__tests__/__snapshots__/General-test.js.snap
@@ -21,13 +21,13 @@ exports[`Backend Text General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[title]-text-input-1"
+          htmlFor="text-input-1"
         >
           Title
         </label>
         <input
-          aria-describedby="attributes[title]-text-input-1"
-          id="attributes[title]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Enter Text Title"
           type="text"
@@ -40,13 +40,13 @@ exports[`Backend Text General Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[subtitle]-text-input-1"
+          htmlFor="text-input-1"
         >
           Subtitle
         </label>
         <input
-          aria-describedby="attributes[subtitle]-text-input-1"
-          id="attributes[subtitle]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Enter Subtitle"
           type="text"
@@ -58,7 +58,7 @@ exports[`Backend Text General Container renders correctly 1`] = `
       >
         <label
           className="form-input-heading toggle above"
-          htmlFor="switch-input-1"
+          htmlFor={1}
         >
           Published?
         </label>
@@ -68,7 +68,7 @@ exports[`Backend Text General Container renders correctly 1`] = `
           <div
             aria-pressed={true}
             className="boolean-primary checked"
-            id="switch-input-1"
+            id={1}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -355,13 +355,13 @@ exports[`Backend Text General Container renders correctly 1`] = `
       >
         <label
           className="has-instructions"
-          htmlFor="attributes[sectionKind]-text-input-1"
+          htmlFor="text-input-1"
         >
           Section Label
         </label>
         <input
-          aria-describedby="attributes[sectionKind]-text-input-1"
-          id="attributes[sectionKind]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Enter a label for sections in this text"
           type="text"

--- a/client/src/backend/containers/text/__tests__/__snapshots__/Metadata-test.js.snap
+++ b/client/src/backend/containers/text/__tests__/__snapshots__/Metadata-test.js.snap
@@ -24,39 +24,43 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                               </header>
                               <Instructions instructions={{...}} />
                               <div className=\\"form-input-group\\">
-                                <Form.TextInput focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][isbn]-text-input-1\\" idForError=\\"attributes[metadata][isbn]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][isbn]-text-input-1\\" idForError=\\"attributes[metadata][isbn]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][isbn]-text-input-1\\" idForError=\\"attributes[metadata][isbn]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][isbn]\\" errors={{...}} label=\\"isbn\\" idForError=\\"attributes[metadata][isbn]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][isbn]-text-input-1\\" className=\\"\\">
-                                              isbn
-                                            </label>
-                                            <input id=\\"attributes[metadata][isbn]-text-input-1\\" type=\\"text\\" placeholder=\\"International Standard Book Number\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][isbn]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][isbn]\\" errors={{...}} label=\\"isbn\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                isbn
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"International Standard Book Number\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][issn]-text-input-1\\" idForError=\\"attributes[metadata][issn]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][issn]-text-input-1\\" idForError=\\"attributes[metadata][issn]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][issn]-text-input-1\\" idForError=\\"attributes[metadata][issn]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][issn]\\" errors={{...}} label=\\"issn\\" idForError=\\"attributes[metadata][issn]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][issn]-text-input-1\\" className=\\"\\">
-                                              issn
-                                            </label>
-                                            <input id=\\"attributes[metadata][issn]-text-input-1\\" type=\\"text\\" placeholder=\\"International Standard Serial Number\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][issn]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][issn]\\" errors={{...}} label=\\"issn\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                issn
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"International Standard Serial Number\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
                               </div>
                             </div>
@@ -70,77 +74,85 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                               </header>
                               <Instructions instructions={{...}} />
                               <div className=\\"form-input-group\\">
-                                <Form.TextInput focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][publisher]-text-input-1\\" idForError=\\"attributes[metadata][publisher]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][publisher]-text-input-1\\" idForError=\\"attributes[metadata][publisher]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][publisher]-text-input-1\\" idForError=\\"attributes[metadata][publisher]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][publisher]\\" errors={{...}} label=\\"publisher\\" idForError=\\"attributes[metadata][publisher]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][publisher]-text-input-1\\" className=\\"\\">
-                                              publisher
-                                            </label>
-                                            <input id=\\"attributes[metadata][publisher]-text-input-1\\" type=\\"text\\" placeholder=\\"The Publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][publisher]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][publisher]\\" errors={{...}} label=\\"publisher\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                publisher
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"The Publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][publisherPlace]-text-input-1\\" idForError=\\"attributes[metadata][publisherPlace]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][publisherPlace]-text-input-1\\" idForError=\\"attributes[metadata][publisherPlace]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][publisherPlace]-text-input-1\\" idForError=\\"attributes[metadata][publisherPlace]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][publisherPlace]\\" errors={{...}} label=\\"publisher place\\" idForError=\\"attributes[metadata][publisherPlace]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][publisherPlace]-text-input-1\\" className=\\"has-instructions\\">
-                                              publisher place
-                                            </label>
-                                            <input id=\\"attributes[metadata][publisherPlace]-text-input-1\\" type=\\"text\\" placeholder=\\"Geographic location of the publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][publisherPlace]-text-input-1\\" />
-                                            <Instructions instructions=\\"e.g \\"Minneapolis, MN\\"\\">
-                                              <span className=\\"instructions\\">
-                                                e.g &quot;Minneapolis, MN&quot;
-                                              </span>
-                                            </Instructions>
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][publisherPlace]\\" errors={{...}} label=\\"publisher place\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
+                                                publisher place
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Geographic location of the publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions=\\"e.g \\"Minneapolis, MN\\"\\">
+                                                <span className=\\"instructions\\">
+                                                  e.g &quot;Minneapolis, MN&quot;
+                                                </span>
+                                              </Instructions>
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][originalPublisher]-text-input-1\\" idForError=\\"attributes[metadata][originalPublisher]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][originalPublisher]-text-input-1\\" idForError=\\"attributes[metadata][originalPublisher]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][originalPublisher]-text-input-1\\" idForError=\\"attributes[metadata][originalPublisher]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalPublisher]\\" errors={{...}} label=\\"original publisher\\" idForError=\\"attributes[metadata][originalPublisher]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][originalPublisher]-text-input-1\\" className=\\"\\">
-                                              original publisher
-                                            </label>
-                                            <input id=\\"attributes[metadata][originalPublisher]-text-input-1\\" type=\\"text\\" placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][originalPublisher]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalPublisher]\\" errors={{...}} label=\\"original publisher\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                original publisher
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][originalPublisherPlace]-text-input-1\\" idForError=\\"attributes[metadata][originalPublisherPlace]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][originalPublisherPlace]-text-input-1\\" idForError=\\"attributes[metadata][originalPublisherPlace]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][originalPublisherPlace]-text-input-1\\" idForError=\\"attributes[metadata][originalPublisherPlace]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalPublisherPlace]\\" errors={{...}} label=\\"original publisher place\\" idForError=\\"attributes[metadata][originalPublisherPlace]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][originalPublisherPlace]-text-input-1\\" className=\\"\\">
-                                              original publisher place
-                                            </label>
-                                            <input id=\\"attributes[metadata][originalPublisherPlace]-text-input-1\\" type=\\"text\\" placeholder=\\"Geographic location of the original publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][originalPublisherPlace]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalPublisherPlace]\\" errors={{...}} label=\\"original publisher place\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                original publisher place
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Geographic location of the original publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
                               </div>
                             </div>
@@ -154,123 +166,135 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                               </header>
                               <Instructions instructions={{...}} />
                               <div className=\\"form-input-group\\">
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][containerTitle]-text-input-1\\" idForError=\\"attributes[metadata][containerTitle]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][containerTitle]-text-input-1\\" idForError=\\"attributes[metadata][containerTitle]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][containerTitle]-text-input-1\\" idForError=\\"attributes[metadata][containerTitle]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][containerTitle]\\" errors={{...}} label=\\"container title\\" idForError=\\"attributes[metadata][containerTitle]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][containerTitle]-text-input-1\\" className=\\"has-instructions\\">
-                                              container title
-                                            </label>
-                                            <input id=\\"attributes[metadata][containerTitle]-text-input-1\\" type=\\"text\\" placeholder=\\"Title of the container holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][containerTitle]-text-input-1\\" />
-                                            <Instructions instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\">
-                                              <span className=\\"instructions\\">
-                                                e.g. the book title for a book chapter, the journal title for a journal article
-                                              </span>
-                                            </Instructions>
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][containerTitle]\\" errors={{...}} label=\\"container title\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
+                                                container title
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Title of the container holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\">
+                                                <span className=\\"instructions\\">
+                                                  e.g. the book title for a book chapter, the journal title for a journal article
+                                                </span>
+                                              </Instructions>
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][version]-text-input-1\\" idForError=\\"attributes[metadata][version]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][version]-text-input-1\\" idForError=\\"attributes[metadata][version]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][version]-text-input-1\\" idForError=\\"attributes[metadata][version]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][version]\\" errors={{...}} label=\\"version\\" idForError=\\"attributes[metadata][version]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][version]-text-input-1\\" className=\\"\\">
-                                              version
-                                            </label>
-                                            <input id=\\"attributes[metadata][version]-text-input-1\\" type=\\"text\\" placeholder=\\"Version of the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][version]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][version]\\" errors={{...}} label=\\"version\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                version
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Version of the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][edition]-text-input-1\\" idForError=\\"attributes[metadata][edition]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][edition]-text-input-1\\" idForError=\\"attributes[metadata][edition]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][edition]-text-input-1\\" idForError=\\"attributes[metadata][edition]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][edition]\\" errors={{...}} label=\\"edition\\" idForError=\\"attributes[metadata][edition]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][edition]-text-input-1\\" className=\\"has-instructions\\">
-                                              edition
-                                            </label>
-                                            <input id=\\"attributes[metadata][edition]-text-input-1\\" type=\\"text\\" placeholder=\\"(Container) edition holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][edition]-text-input-1\\" />
-                                            <Instructions instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\">
-                                              <span className=\\"instructions\\">
-                                                e.g. &quot;3&quot; when citing a chapter in the third edition of a book
-                                              </span>
-                                            </Instructions>
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][edition]\\" errors={{...}} label=\\"edition\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
+                                                edition
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"(Container) edition holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\">
+                                                <span className=\\"instructions\\">
+                                                  e.g. &quot;3&quot; when citing a chapter in the third edition of a book
+                                                </span>
+                                              </Instructions>
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][issue]-text-input-1\\" idForError=\\"attributes[metadata][issue]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][issue]-text-input-1\\" idForError=\\"attributes[metadata][issue]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][issue]-text-input-1\\" idForError=\\"attributes[metadata][issue]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][issue]\\" errors={{...}} label=\\"issue\\" idForError=\\"attributes[metadata][issue]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][issue]-text-input-1\\" className=\\"has-instructions\\">
-                                              issue
-                                            </label>
-                                            <input id=\\"attributes[metadata][issue]-text-input-1\\" type=\\"text\\" placeholder=\\"(Container) issue holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][issue]-text-input-1\\" />
-                                            <Instructions instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\">
-                                              <span className=\\"instructions\\">
-                                                e.g. &quot;5&quot; when citing a journal article from journal volume 2, issue 5
-                                              </span>
-                                            </Instructions>
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][issue]\\" errors={{...}} label=\\"issue\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
+                                                issue
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"(Container) issue holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\">
+                                                <span className=\\"instructions\\">
+                                                  e.g. &quot;5&quot; when citing a journal article from journal volume 2, issue 5
+                                                </span>
+                                              </Instructions>
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][volume]-text-input-1\\" idForError=\\"attributes[metadata][volume]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][volume]-text-input-1\\" idForError=\\"attributes[metadata][volume]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][volume]-text-input-1\\" idForError=\\"attributes[metadata][volume]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][volume]\\" errors={{...}} label=\\"volume\\" idForError=\\"attributes[metadata][volume]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][volume]-text-input-1\\" className=\\"has-instructions\\">
-                                              volume
-                                            </label>
-                                            <input id=\\"attributes[metadata][volume]-text-input-1\\" type=\\"text\\" placeholder=\\"(Container) volume holding the item \\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][volume]-text-input-1\\" />
-                                            <Instructions instructions=\\"e.g. “2” when citing a chapter from book volume 2\\">
-                                              <span className=\\"instructions\\">
-                                                e.g. “2” when citing a chapter from book volume 2
-                                              </span>
-                                            </Instructions>
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][volume]\\" errors={{...}} label=\\"volume\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
+                                                volume
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"(Container) volume holding the item \\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions=\\"e.g. “2” when citing a chapter from book volume 2\\">
+                                                <span className=\\"instructions\\">
+                                                  e.g. “2” when citing a chapter from book volume 2
+                                                </span>
+                                              </Instructions>
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][originalTitle]-text-input-1\\" idForError=\\"attributes[metadata][originalTitle]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][originalTitle]-text-input-1\\" idForError=\\"attributes[metadata][originalTitle]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][originalTitle]-text-input-1\\" idForError=\\"attributes[metadata][originalTitle]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalTitle]\\" errors={{...}} label=\\"original title\\" idForError=\\"attributes[metadata][originalTitle]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][originalTitle]-text-input-1\\" className=\\"\\">
-                                              original title
-                                            </label>
-                                            <input id=\\"attributes[metadata][originalTitle]-text-input-1\\" type=\\"text\\" placeholder=\\"Title of the original version\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][originalTitle]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalTitle]\\" errors={{...}} label=\\"original title\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                original title
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Title of the original version\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
                               </div>
                             </div>
@@ -284,379 +308,423 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                               </header>
                               <Instructions instructions={{...}} />
                               <div className=\\"form-input-group\\">
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][abstract]-text-input-1\\" idForError=\\"attributes[metadata][abstract]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][abstract]-text-input-1\\" idForError=\\"attributes[metadata][abstract]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][abstract]-text-input-1\\" idForError=\\"attributes[metadata][abstract]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][abstract]\\" errors={{...}} label=\\"abstract\\" idForError=\\"attributes[metadata][abstract]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][abstract]-text-input-1\\" className=\\"\\">
-                                              abstract
-                                            </label>
-                                            <input id=\\"attributes[metadata][abstract]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][abstract]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][abstract]\\" errors={{...}} label=\\"abstract\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                abstract
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][archive]-text-input-1\\" idForError=\\"attributes[metadata][archive]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][archive]-text-input-1\\" idForError=\\"attributes[metadata][archive]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][archive]-text-input-1\\" idForError=\\"attributes[metadata][archive]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archive]\\" errors={{...}} label=\\"archive\\" idForError=\\"attributes[metadata][archive]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][archive]-text-input-1\\" className=\\"\\">
-                                              archive
-                                            </label>
-                                            <input id=\\"attributes[metadata][archive]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][archive]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archive]\\" errors={{...}} label=\\"archive\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                archive
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][archiveLocation]-text-input-1\\" idForError=\\"attributes[metadata][archiveLocation]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][archiveLocation]-text-input-1\\" idForError=\\"attributes[metadata][archiveLocation]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][archiveLocation]-text-input-1\\" idForError=\\"attributes[metadata][archiveLocation]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archiveLocation]\\" errors={{...}} label=\\"archive location\\" idForError=\\"attributes[metadata][archiveLocation]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][archiveLocation]-text-input-1\\" className=\\"\\">
-                                              archive location
-                                            </label>
-                                            <input id=\\"attributes[metadata][archiveLocation]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][archiveLocation]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archiveLocation]\\" errors={{...}} label=\\"archive location\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                archive location
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][archivePlace]-text-input-1\\" idForError=\\"attributes[metadata][archivePlace]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][archivePlace]-text-input-1\\" idForError=\\"attributes[metadata][archivePlace]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][archivePlace]-text-input-1\\" idForError=\\"attributes[metadata][archivePlace]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archivePlace]\\" errors={{...}} label=\\"archive place\\" idForError=\\"attributes[metadata][archivePlace]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][archivePlace]-text-input-1\\" className=\\"\\">
-                                              archive place
-                                            </label>
-                                            <input id=\\"attributes[metadata][archivePlace]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][archivePlace]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archivePlace]\\" errors={{...}} label=\\"archive place\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                archive place
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][authority]-text-input-1\\" idForError=\\"attributes[metadata][authority]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][authority]-text-input-1\\" idForError=\\"attributes[metadata][authority]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][authority]-text-input-1\\" idForError=\\"attributes[metadata][authority]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][authority]\\" errors={{...}} label=\\"authority\\" idForError=\\"attributes[metadata][authority]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][authority]-text-input-1\\" className=\\"\\">
-                                              authority
-                                            </label>
-                                            <input id=\\"attributes[metadata][authority]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][authority]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][authority]\\" errors={{...}} label=\\"authority\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                authority
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][callNumber]-text-input-1\\" idForError=\\"attributes[metadata][callNumber]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][callNumber]-text-input-1\\" idForError=\\"attributes[metadata][callNumber]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][callNumber]-text-input-1\\" idForError=\\"attributes[metadata][callNumber]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][callNumber]\\" errors={{...}} label=\\"call number\\" idForError=\\"attributes[metadata][callNumber]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][callNumber]-text-input-1\\" className=\\"\\">
-                                              call number
-                                            </label>
-                                            <input id=\\"attributes[metadata][callNumber]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][callNumber]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][callNumber]\\" errors={{...}} label=\\"call number\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                call number
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][chapterNumber]-text-input-1\\" idForError=\\"attributes[metadata][chapterNumber]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][chapterNumber]-text-input-1\\" idForError=\\"attributes[metadata][chapterNumber]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][chapterNumber]-text-input-1\\" idForError=\\"attributes[metadata][chapterNumber]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][chapterNumber]\\" errors={{...}} label=\\"chapter number\\" idForError=\\"attributes[metadata][chapterNumber]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][chapterNumber]-text-input-1\\" className=\\"\\">
-                                              chapter number
-                                            </label>
-                                            <input id=\\"attributes[metadata][chapterNumber]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][chapterNumber]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][chapterNumber]\\" errors={{...}} label=\\"chapter number\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                chapter number
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][collectionNumber]-text-input-1\\" idForError=\\"attributes[metadata][collectionNumber]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][collectionNumber]-text-input-1\\" idForError=\\"attributes[metadata][collectionNumber]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][collectionNumber]-text-input-1\\" idForError=\\"attributes[metadata][collectionNumber]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][collectionNumber]\\" errors={{...}} label=\\"collection number\\" idForError=\\"attributes[metadata][collectionNumber]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][collectionNumber]-text-input-1\\" className=\\"\\">
-                                              collection number
-                                            </label>
-                                            <input id=\\"attributes[metadata][collectionNumber]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][collectionNumber]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][collectionNumber]\\" errors={{...}} label=\\"collection number\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                collection number
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][collectionTitle]-text-input-1\\" idForError=\\"attributes[metadata][collectionTitle]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][collectionTitle]-text-input-1\\" idForError=\\"attributes[metadata][collectionTitle]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][collectionTitle]-text-input-1\\" idForError=\\"attributes[metadata][collectionTitle]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][collectionTitle]\\" errors={{...}} label=\\"collection title\\" idForError=\\"attributes[metadata][collectionTitle]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][collectionTitle]-text-input-1\\" className=\\"\\">
-                                              collection title
-                                            </label>
-                                            <input id=\\"attributes[metadata][collectionTitle]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][collectionTitle]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][collectionTitle]\\" errors={{...}} label=\\"collection title\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                collection title
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][dimensions]-text-input-1\\" idForError=\\"attributes[metadata][dimensions]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][dimensions]-text-input-1\\" idForError=\\"attributes[metadata][dimensions]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][dimensions]-text-input-1\\" idForError=\\"attributes[metadata][dimensions]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][dimensions]\\" errors={{...}} label=\\"dimensions\\" idForError=\\"attributes[metadata][dimensions]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][dimensions]-text-input-1\\" className=\\"\\">
-                                              dimensions
-                                            </label>
-                                            <input id=\\"attributes[metadata][dimensions]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][dimensions]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][dimensions]\\" errors={{...}} label=\\"dimensions\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                dimensions
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][event]-text-input-1\\" idForError=\\"attributes[metadata][event]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][event]-text-input-1\\" idForError=\\"attributes[metadata][event]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][event]-text-input-1\\" idForError=\\"attributes[metadata][event]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][event]\\" errors={{...}} label=\\"event\\" idForError=\\"attributes[metadata][event]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][event]-text-input-1\\" className=\\"\\">
-                                              event
-                                            </label>
-                                            <input id=\\"attributes[metadata][event]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][event]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][event]\\" errors={{...}} label=\\"event\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                event
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][eventPlace]-text-input-1\\" idForError=\\"attributes[metadata][eventPlace]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][eventPlace]-text-input-1\\" idForError=\\"attributes[metadata][eventPlace]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][eventPlace]-text-input-1\\" idForError=\\"attributes[metadata][eventPlace]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][eventPlace]\\" errors={{...}} label=\\"event place\\" idForError=\\"attributes[metadata][eventPlace]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][eventPlace]-text-input-1\\" className=\\"\\">
-                                              event place
-                                            </label>
-                                            <input id=\\"attributes[metadata][eventPlace]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][eventPlace]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][eventPlace]\\" errors={{...}} label=\\"event place\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                event place
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][jurisdiction]-text-input-1\\" idForError=\\"attributes[metadata][jurisdiction]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][jurisdiction]-text-input-1\\" idForError=\\"attributes[metadata][jurisdiction]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][jurisdiction]-text-input-1\\" idForError=\\"attributes[metadata][jurisdiction]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][jurisdiction]\\" errors={{...}} label=\\"jurisdiction\\" idForError=\\"attributes[metadata][jurisdiction]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][jurisdiction]-text-input-1\\" className=\\"\\">
-                                              jurisdiction
-                                            </label>
-                                            <input id=\\"attributes[metadata][jurisdiction]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][jurisdiction]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][jurisdiction]\\" errors={{...}} label=\\"jurisdiction\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                jurisdiction
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][medium]-text-input-1\\" idForError=\\"attributes[metadata][medium]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][medium]-text-input-1\\" idForError=\\"attributes[metadata][medium]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][medium]-text-input-1\\" idForError=\\"attributes[metadata][medium]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][medium]\\" errors={{...}} label=\\"medium\\" idForError=\\"attributes[metadata][medium]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][medium]-text-input-1\\" className=\\"\\">
-                                              medium
-                                            </label>
-                                            <input id=\\"attributes[metadata][medium]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][medium]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][medium]\\" errors={{...}} label=\\"medium\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                medium
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][number]-text-input-1\\" idForError=\\"attributes[metadata][number]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][number]-text-input-1\\" idForError=\\"attributes[metadata][number]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][number]-text-input-1\\" idForError=\\"attributes[metadata][number]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][number]\\" errors={{...}} label=\\"number\\" idForError=\\"attributes[metadata][number]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][number]-text-input-1\\" className=\\"\\">
-                                              number
-                                            </label>
-                                            <input id=\\"attributes[metadata][number]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][number]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][number]\\" errors={{...}} label=\\"number\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                number
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][numberOfPages]-text-input-1\\" idForError=\\"attributes[metadata][numberOfPages]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][numberOfPages]-text-input-1\\" idForError=\\"attributes[metadata][numberOfPages]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][numberOfPages]-text-input-1\\" idForError=\\"attributes[metadata][numberOfPages]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][numberOfPages]\\" errors={{...}} label=\\"number of pages\\" idForError=\\"attributes[metadata][numberOfPages]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][numberOfPages]-text-input-1\\" className=\\"\\">
-                                              number of pages
-                                            </label>
-                                            <input id=\\"attributes[metadata][numberOfPages]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][numberOfPages]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][numberOfPages]\\" errors={{...}} label=\\"number of pages\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                number of pages
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][numberOfVolumes]-text-input-1\\" idForError=\\"attributes[metadata][numberOfVolumes]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][numberOfVolumes]-text-input-1\\" idForError=\\"attributes[metadata][numberOfVolumes]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][numberOfVolumes]-text-input-1\\" idForError=\\"attributes[metadata][numberOfVolumes]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][numberOfVolumes]\\" errors={{...}} label=\\"number of volumes\\" idForError=\\"attributes[metadata][numberOfVolumes]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][numberOfVolumes]-text-input-1\\" className=\\"\\">
-                                              number of volumes
-                                            </label>
-                                            <input id=\\"attributes[metadata][numberOfVolumes]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][numberOfVolumes]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][numberOfVolumes]\\" errors={{...}} label=\\"number of volumes\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                number of volumes
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][pmcid]-text-input-1\\" idForError=\\"attributes[metadata][pmcid]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][pmcid]-text-input-1\\" idForError=\\"attributes[metadata][pmcid]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][pmcid]-text-input-1\\" idForError=\\"attributes[metadata][pmcid]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][pmcid]\\" errors={{...}} label=\\"pmcid\\" idForError=\\"attributes[metadata][pmcid]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][pmcid]-text-input-1\\" className=\\"\\">
-                                              pmcid
-                                            </label>
-                                            <input id=\\"attributes[metadata][pmcid]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][pmcid]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][pmcid]\\" errors={{...}} label=\\"pmcid\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                pmcid
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][pmid]-text-input-1\\" idForError=\\"attributes[metadata][pmid]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][pmid]-text-input-1\\" idForError=\\"attributes[metadata][pmid]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][pmid]-text-input-1\\" idForError=\\"attributes[metadata][pmid]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][pmid]\\" errors={{...}} label=\\"pmid\\" idForError=\\"attributes[metadata][pmid]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][pmid]-text-input-1\\" className=\\"\\">
-                                              pmid
-                                            </label>
-                                            <input id=\\"attributes[metadata][pmid]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][pmid]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][pmid]\\" errors={{...}} label=\\"pmid\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                pmid
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][reviewedTitle]-text-input-1\\" idForError=\\"attributes[metadata][reviewedTitle]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][reviewedTitle]-text-input-1\\" idForError=\\"attributes[metadata][reviewedTitle]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][reviewedTitle]-text-input-1\\" idForError=\\"attributes[metadata][reviewedTitle]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][reviewedTitle]\\" errors={{...}} label=\\"reviewed title\\" idForError=\\"attributes[metadata][reviewedTitle]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][reviewedTitle]-text-input-1\\" className=\\"\\">
-                                              reviewed title
-                                            </label>
-                                            <input id=\\"attributes[metadata][reviewedTitle]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][reviewedTitle]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][reviewedTitle]\\" errors={{...}} label=\\"reviewed title\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                reviewed title
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][section]-text-input-1\\" idForError=\\"attributes[metadata][section]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][section]-text-input-1\\" idForError=\\"attributes[metadata][section]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][section]-text-input-1\\" idForError=\\"attributes[metadata][section]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][section]\\" errors={{...}} label=\\"section\\" idForError=\\"attributes[metadata][section]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][section]-text-input-1\\" className=\\"\\">
-                                              section
-                                            </label>
-                                            <input id=\\"attributes[metadata][section]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][section]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][section]\\" errors={{...}} label=\\"section\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                section
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" disabled={false}>
-                                  <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][yearSuffix]-text-input-1\\" idForError=\\"attributes[metadata][yearSuffix]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                    <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][yearSuffix]-text-input-1\\" idForError=\\"attributes[metadata][yearSuffix]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} id=\\"attributes[metadata][yearSuffix]-text-input-1\\" idForError=\\"attributes[metadata][yearSuffix]-text-input-1\\" disabled={false} inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                        <Errorable className=\\"form-input\\" name=\\"attributes[metadata][yearSuffix]\\" errors={{...}} label=\\"year suffix\\" idForError=\\"attributes[metadata][yearSuffix]-text-input-1\\" containerStyle={{...}}>
-                                          <div style={{...}} className=\\"form-input\\">
-                                            <label htmlFor=\\"attributes[metadata][yearSuffix]-text-input-1\\" className=\\"\\">
-                                              year suffix
-                                            </label>
-                                            <input id=\\"attributes[metadata][yearSuffix]-text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"attributes[metadata][yearSuffix]-text-input-1\\" />
-                                            <Instructions instructions={{...}} />
-                                          </div>
-                                        </Errorable>
-                                      </Form.BaseInput>
-                                    </Form.Setter('Form.BaseInput)>
-                                  </HigherOrder.FetchData('Form.BaseInput)>
+                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} disabled={false}>
+                                  <mockConstructor>
+                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][yearSuffix]\\" errors={{...}} label=\\"year suffix\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                            <div style={{...}} className=\\"form-input\\">
+                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                year suffix
+                                              </label>
+                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1\\" />
+                                              <Instructions instructions={{...}} />
+                                            </div>
+                                          </Errorable>
+                                        </Form.BaseInput>
+                                      </Form.Setter('Form.BaseInput)>
+                                    </HigherOrder.FetchData('Form.BaseInput)>
+                                  </mockConstructor>
                                 </Form.TextInput>
                               </div>
                             </div>

--- a/client/src/backend/containers/text/ingestion/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/text/ingestion/__tests__/__snapshots__/New-test.js.snap
@@ -129,7 +129,7 @@ exports[`Backend Text Ingestion New Container renders correctly 1`] = `
             URL
           </label>
           <input
-            aria-describedby="text-input-1"
+            aria-describedby="text-input-error-1"
             id="text-input-1"
             onChange={[Function]}
             type="text"

--- a/client/src/backend/containers/twitter-query/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/backend/containers/twitter-query/__tests__/__snapshots__/Edit-test.js.snap
@@ -49,13 +49,13 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[query]-text-input-1"
+            htmlFor="text-input-1"
           >
             Query
           </label>
           <input
-            aria-describedby="attributes[query]-text-input-1"
-            id="attributes[query]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Enter query"
             type="text"
@@ -83,7 +83,9 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
             className="form-input"
             style={Object {}}
           >
-            <label>
+            <label
+              htmlFor="select-1"
+            >
               Fetch tweets by:
             </label>
             <div
@@ -104,6 +106,7 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
               </svg>
               <select
                 aria-describedby="select-error-1"
+                id="select-1"
                 onChange={[Function]}
                 value=""
               >
@@ -126,7 +129,7 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
         >
           <label
             className="form-input-heading toggle above"
-            htmlFor="switch-input-1"
+            htmlFor={1}
           >
             Active
           </label>
@@ -136,7 +139,7 @@ exports[`Backend TwitterQuery Edit Container renders correctly 1`] = `
             <div
               aria-pressed={true}
               className="boolean-primary checked"
-              id="switch-input-1"
+              id={1}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}

--- a/client/src/backend/containers/twitter-query/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/twitter-query/__tests__/__snapshots__/New-test.js.snap
@@ -41,13 +41,13 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[query]-text-input-1"
+          htmlFor="text-input-1"
         >
           Query
         </label>
         <input
-          aria-describedby="attributes[query]-text-input-1"
-          id="attributes[query]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Enter query"
           type="text"
@@ -75,7 +75,9 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
           className="form-input"
           style={Object {}}
         >
-          <label>
+          <label
+            htmlFor="select-1"
+          >
             Fetch tweets by:
           </label>
           <div
@@ -96,6 +98,7 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
             </svg>
             <select
               aria-describedby="select-error-1"
+              id="select-1"
               onChange={[Function]}
               value=""
             >
@@ -118,7 +121,7 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
       >
         <label
           className="form-input-heading toggle above"
-          htmlFor="switch-input-1"
+          htmlFor={1}
         >
           Active
         </label>
@@ -128,7 +131,7 @@ exports[`Backend TwitterQuery New Container renders correctly 1`] = `
           <div
             aria-pressed={true}
             className="boolean-primary checked"
-            id="switch-input-1"
+            id={1}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}

--- a/client/src/backend/containers/users/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/backend/containers/users/__tests__/__snapshots__/Edit-test.js.snap
@@ -107,13 +107,13 @@ exports[`Backend People Users Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[email]-text-input-1"
+            htmlFor="text-input-1"
           >
             Email
           </label>
           <input
-            aria-describedby="attributes[email]-text-input-1"
-            id="attributes[email]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Email"
             type="text"
@@ -126,13 +126,13 @@ exports[`Backend People Users Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[firstName]-text-input-1"
+            htmlFor="text-input-1"
           >
             First Name
           </label>
           <input
-            aria-describedby="attributes[firstName]-text-input-1"
-            id="attributes[firstName]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="First Name"
             type="text"
@@ -145,13 +145,13 @@ exports[`Backend People Users Edit Container renders correctly 1`] = `
         >
           <label
             className=""
-            htmlFor="attributes[lastName]-text-input-1"
+            htmlFor="text-input-1"
           >
             Last Name
           </label>
           <input
-            aria-describedby="attributes[lastName]-text-input-1"
-            id="attributes[lastName]-text-input-1"
+            aria-describedby="text-input-error-1"
+            id="text-input-1"
             onChange={[Function]}
             placeholder="Last Name"
             type="text"
@@ -165,7 +165,9 @@ exports[`Backend People Users Edit Container renders correctly 1`] = `
             className="form-input"
             style={Object {}}
           >
-            <label>
+            <label
+              htmlFor="select-1"
+            >
               Role
             </label>
             <div
@@ -186,6 +188,7 @@ exports[`Backend People Users Edit Container renders correctly 1`] = `
               </svg>
               <select
                 aria-describedby="select-error-1"
+                id="select-1"
                 onChange={[Function]}
                 value="admin"
               >

--- a/client/src/backend/containers/users/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/containers/users/__tests__/__snapshots__/List-test.js.snap
@@ -11,7 +11,7 @@ Array [
   <span />,
   <div
     className="entity-list"
-    id="entities-list1"
+    id={1}
   >
     <header
       className="entity-list__title-block backend-header"
@@ -73,13 +73,13 @@ Array [
             >
               <label
                 className="screen-reader-text"
-                htmlFor="list-search-1"
+                htmlFor={1}
               >
                 Enter Search Criteria
               </label>
               <input
                 className="entity-list-search__keyword-input"
-                id="list-search-1"
+                id={1}
                 onChange={[Function]}
                 placeholder="Search..."
                 type="text"
@@ -133,7 +133,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value=""
                       >
@@ -199,7 +199,7 @@ Array [
                       className="entity-list-search__select-wrapper"
                     >
                       <select
-                        id="list-search-1"
+                        id={1}
                         onChange={[Function]}
                         value="last_name"
                       >
@@ -296,7 +296,7 @@ Array [
           className="entity-row entity-list__entity"
         >
           <a
-            aria-describedby="undefined1-describedby"
+            aria-describedby="1-describedby"
             className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
             href="/backend/records/users/1"
             onClick={[Function]}
@@ -342,7 +342,7 @@ Array [
                   </span>
                   <span
                     className="aria-describedby"
-                    id="undefined1-describedby"
+                    id="1-describedby"
                   >
                     View Rowan Ida
                   </span>
@@ -371,7 +371,7 @@ Array [
                 >
                   <a
                     disabled={true}
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <svg
@@ -407,7 +407,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -427,7 +427,7 @@ Array [
                   className="list-pagination__page list-pagination__page--ordinal"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span
@@ -453,7 +453,7 @@ Array [
                   className="list-pagination__page list-pagination__page--next"
                 >
                   <a
-                    href="#entities-list1"
+                    href="#1"
                     onClick={[Function]}
                   >
                     <span

--- a/client/src/backend/containers/users/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/users/__tests__/__snapshots__/New-test.js.snap
@@ -27,13 +27,13 @@ exports[`Backend Users New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[email]-text-input-1"
+          htmlFor="text-input-1"
         >
           Email
         </label>
         <input
-          aria-describedby="attributes[email]-text-input-1"
-          id="attributes[email]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Email"
           type="text"
@@ -47,7 +47,9 @@ exports[`Backend Users New Container renders correctly 1`] = `
           className="form-input"
           style={Object {}}
         >
-          <label>
+          <label
+            htmlFor="select-1"
+          >
             Role
           </label>
           <div
@@ -68,6 +70,7 @@ exports[`Backend Users New Container renders correctly 1`] = `
             </svg>
             <select
               aria-describedby="select-error-1"
+              id="select-1"
               onChange={[Function]}
               value="reader"
             >
@@ -106,13 +109,13 @@ exports[`Backend Users New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[firstName]-text-input-1"
+          htmlFor="text-input-1"
         >
           First Name
         </label>
         <input
-          aria-describedby="attributes[firstName]-text-input-1"
-          id="attributes[firstName]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="First Name"
           type="text"
@@ -125,13 +128,13 @@ exports[`Backend Users New Container renders correctly 1`] = `
       >
         <label
           className=""
-          htmlFor="attributes[lastName]-text-input-1"
+          htmlFor="text-input-1"
         >
           Last Name
         </label>
         <input
-          aria-describedby="attributes[lastName]-text-input-1"
-          id="attributes[lastName]-text-input-1"
+          aria-describedby="text-input-error-1"
+          id="text-input-1"
           onChange={[Function]}
           placeholder="Last Name"
           type="text"
@@ -174,7 +177,6 @@ exports[`Backend Users New Container renders correctly 1`] = `
           </span>
         </span>
         <input
-          aria-describedby="generated-password-error-1"
           id="generated-password-1"
           onChange={[Function]}
           placeholder="Enter a password"

--- a/client/src/frontend/components/project-collection/Filters.js
+++ b/client/src/frontend/components/project-collection/Filters.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import omitBy from "lodash/omitBy";
-import uniqueId from "lodash/uniqueId";
+import { UID } from "react-uid";
 import isEmpty from "lodash/isEmpty";
 import Utility from "global/components/utility";
 
@@ -12,12 +12,7 @@ export class ProjectCollectionFilters extends Component {
 
   static propTypes = {
     filterChangeHandler: PropTypes.func.isRequired,
-    initialFilterState: PropTypes.object,
-    searchId: PropTypes.string
-  };
-
-  static defaultProps = {
-    searchId: uniqueId("filters-search-")
+    initialFilterState: PropTypes.object
   };
 
   constructor(props) {
@@ -40,6 +35,10 @@ export class ProjectCollectionFilters extends Component {
 
   get resetMessage() {
     return "Search and filters reset.";
+  }
+
+  get idPrefix() {
+    return "filters-search";
   }
 
   setFilters = (event, label) => {
@@ -86,17 +85,23 @@ export class ProjectCollectionFilters extends Component {
               size={20}
             />
           </button>
-          <label htmlFor={this.props.searchId} className="screen-reader-text">
-            Enter Search Criteria
-          </label>
-          <input
-            ref={this.searchInput}
-            value={this.state.filters.keyword || ""}
-            type="text"
-            id={this.props.searchId}
-            onChange={event => this.setFilters(event, "keyword")}
-            placeholder="Search…"
-          />
+          <UID name={id => `${this.idPrefix}-${id}`}>
+            {id => (
+              <React.Fragment>
+                <label htmlFor={id} className="screen-reader-text">
+                  Enter Search Criteria
+                </label>
+                <input
+                  ref={this.searchInput}
+                  value={this.state.filters.keyword || ""}
+                  type="text"
+                  id={id}
+                  onChange={event => this.setFilters(event, "keyword")}
+                  placeholder="Search…"
+                />
+              </React.Fragment>
+            )}
+          </UID>
         </div>
         <div className="select-group inline">
           <div className="select">

--- a/client/src/frontend/components/project-collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/project-collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -75,12 +75,12 @@ exports[`Frontend.ProjectCollection.Detail component renders correctly 1`] = `
         </button>
         <label
           className="screen-reader-text"
-          htmlFor="filters-search-1"
+          htmlFor={1}
         >
           Enter Search Criteria
         </label>
         <input
-          id="filters-search-1"
+          id={1}
           onChange={[Function]}
           placeholder="Search…"
           type="text"

--- a/client/src/frontend/components/project-collection/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/frontend/components/project-collection/__tests__/__snapshots__/Filters-test.js.snap
@@ -40,12 +40,12 @@ Array [
       </button>
       <label
         className="screen-reader-text"
-        htmlFor="filters-search-1"
+        htmlFor={1}
       >
         Enter Search Criteria
       </label>
       <input
-        id="filters-search-1"
+        id={1}
         onChange={[Function]}
         placeholder="Search…"
         type="text"

--- a/client/src/frontend/components/project-list/Filters.js
+++ b/client/src/frontend/components/project-list/Filters.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import omitBy from "lodash/omitBy";
-import uniqueId from "lodash/uniqueId";
+import { UID } from "react-uid";
 import isEmpty from "lodash/isEmpty";
 import Utility from "global/components/utility";
 
@@ -14,12 +14,7 @@ export class ProjectListFilters extends Component {
     filterChangeHandler: PropTypes.func,
     initialFilterState: PropTypes.object,
     subjects: PropTypes.array,
-    hideFeatured: PropTypes.bool,
-    searchId: PropTypes.string
-  };
-
-  static defaultProps = {
-    searchId: uniqueId("filters-search-")
+    hideFeatured: PropTypes.bool
   };
 
   constructor(props) {
@@ -42,6 +37,10 @@ export class ProjectListFilters extends Component {
 
   get resetMessage() {
     return "Search and filters reset.";
+  }
+
+  get idPrefix() {
+    return "filters-search";
   }
 
   setFilters = (event, label) => {
@@ -118,17 +117,23 @@ export class ProjectListFilters extends Component {
             size={20}
           />
         </button>
-        <label htmlFor={this.props.searchId} className="screen-reader-text">
-          Enter Search Criteria
-        </label>
-        <input
-          ref={this.searchInput}
-          value={this.state.filters.keyword || ""}
-          type="text"
-          id={this.props.searchId}
-          onChange={event => this.setFilters(event, "keyword")}
-          placeholder="Search…"
-        />
+        <UID name={id => `${this.idPrefix}-${id}`}>
+          {id => (
+            <React.Fragment>
+              <label htmlFor={id} className="screen-reader-text">
+                Enter Search Criteria
+              </label>
+              <input
+                ref={this.searchInput}
+                value={this.state.filters.keyword || ""}
+                type="text"
+                id={id}
+                onChange={event => this.setFilters(event, "keyword")}
+                placeholder="Search…"
+              />
+            </React.Fragment>
+          )}
+        </UID>
       </div>
     );
   }

--- a/client/src/frontend/components/project-list/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/frontend/components/project-list/__tests__/__snapshots__/Filters-test.js.snap
@@ -40,12 +40,12 @@ Array [
       </button>
       <label
         className="screen-reader-text"
-        htmlFor="filters-search-1"
+        htmlFor={1}
       >
         Enter Search Criteria
       </label>
       <input
-        id="filters-search-1"
+        id={1}
         onChange={[Function]}
         placeholder="Search…"
         type="text"

--- a/client/src/frontend/components/project-list/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/frontend/components/project-list/__tests__/__snapshots__/Following-test.js.snap
@@ -75,12 +75,12 @@ exports[`Frontend.ProjectList.Following component renders correctly 1`] = `
         </button>
         <label
           className="screen-reader-text"
-          htmlFor="filters-search-1"
+          htmlFor={1}
         >
           Enter Search Criteria
         </label>
         <input
-          id="filters-search-1"
+          id={1}
           onChange={[Function]}
           placeholder="Search…"
           type="text"

--- a/client/src/frontend/components/project/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/frontend/components/project/__tests__/__snapshots__/Resources-test.js.snap
@@ -73,12 +73,12 @@ exports[`Frontend.Project.Resources component renders correctly 1`] = `
         </button>
         <label
           className="screen-reader-text"
-          htmlFor="filters-search-1"
+          htmlFor={1}
         >
           Enter Search Criteria
         </label>
         <input
-          id="filters-search-1"
+          id={1}
           onChange={[Function]}
           placeholder="Search"
           type="text"

--- a/client/src/frontend/components/resource-collection/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/resource-collection/__tests__/__snapshots__/Detail-test.js.snap
@@ -411,12 +411,12 @@ exports[`Frontend.ResourceCollection.Detail Component renders correctly 1`] = `
         </button>
         <label
           className="screen-reader-text"
-          htmlFor="filters-search-1"
+          htmlFor={1}
         >
           Enter Search Criteria
         </label>
         <input
-          id="filters-search-1"
+          id={1}
           onChange={[Function]}
           placeholder="Search"
           type="text"

--- a/client/src/frontend/components/resource-list/Filters.js
+++ b/client/src/frontend/components/resource-list/Filters.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import capitalize from "lodash/capitalize";
 import omitBy from "lodash/omitBy";
 import isEmpty from "lodash/isEmpty";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 import Utility from "global/components/utility";
 
 import withScreenReaderStatus from "hoc/with-screen-reader-status";
@@ -15,12 +15,7 @@ export class ResourceListFilters extends Component {
     kinds: PropTypes.array,
     tags: PropTypes.array,
     filterChangeHandler: PropTypes.func.isRequired,
-    initialFilterState: PropTypes.object,
-    searchId: PropTypes.string
-  };
-
-  static defaultProps = {
-    searchId: labelId("filters-search-")
+    initialFilterState: PropTypes.object
   };
 
   constructor(props) {
@@ -43,6 +38,10 @@ export class ResourceListFilters extends Component {
 
   get resetMessage() {
     return "Search and filters reset.";
+  }
+
+  get idPrefix() {
+    return "filters-search";
   }
 
   setFilters = (event, label) => {
@@ -89,17 +88,23 @@ export class ResourceListFilters extends Component {
               size={20}
             />
           </button>
-          <label htmlFor={this.props.searchId} className="screen-reader-text">
-            Enter Search Criteria
-          </label>
-          <input
-            ref={this.searchInput}
-            value={this.state.filters.keyword || ""}
-            type="text"
-            id={this.props.searchId}
-            onChange={event => this.setFilters(event, "keyword")}
-            placeholder="Search"
-          />
+          <UID name={id => `${this.idPrefix}-${id}`}>
+            {id => (
+              <React.Fragment>
+                <label htmlFor={id} className="screen-reader-text">
+                  Enter Search Criteria
+                </label>
+                <input
+                  ref={this.searchInput}
+                  value={this.state.filters.keyword || ""}
+                  type="text"
+                  id={id}
+                  onChange={event => this.setFilters(event, "keyword")}
+                  placeholder="Search"
+                />
+              </React.Fragment>
+            )}
+          </UID>
         </div>
         <div className="select-group inline">
           <div className="select">

--- a/client/src/frontend/components/resource-list/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/frontend/components/resource-list/__tests__/__snapshots__/Filters-test.js.snap
@@ -40,12 +40,12 @@ Array [
       </button>
       <label
         className="screen-reader-text"
-        htmlFor="filters-search-1"
+        htmlFor={1}
       >
         Enter Search Criteria
       </label>
       <input
-        id="filters-search-1"
+        id={1}
         onChange={[Function]}
         placeholder="Search"
         type="text"

--- a/client/src/frontend/components/resource-player/Audio.js
+++ b/client/src/frontend/components/resource-player/Audio.js
@@ -3,18 +3,11 @@ import PropTypes from "prop-types";
 import classnames from "classnames";
 import debounce from "lodash/debounce";
 import throttle from "lodash/throttle";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 
 export default class ResourcePlayerAudio extends Component {
   static propTypes = {
-    resource: PropTypes.object,
-    progressBarId: PropTypes.string,
-    volumeBarId: PropTypes.string
-  };
-
-  static defaultProps = {
-    progressBarId: labelId("progress-bar-"),
-    volumeBarId: labelId("volume-bar-")
+    resource: PropTypes.object
   };
 
   constructor() {
@@ -47,6 +40,14 @@ export default class ResourcePlayerAudio extends Component {
     this.audio.destroy();
     this.audio = null;
     window.removeEventListener("resize", this.debouncedResize);
+  }
+
+  get progressBarIdPrefix() {
+    return "progress-bar";
+  }
+
+  get volumeBarIdPrefix() {
+    return "volume-bar";
   }
 
   setVolume = event => {
@@ -243,20 +244,23 @@ export default class ResourcePlayerAudio extends Component {
                   left: `calc(${this.state.percent}% - 10px)`
                 }}
               />
-              <label
-                htmlFor={this.props.progressBarId}
-                className="screen-reader-text"
-              >
-                Progress Bar
-              </label>
-              <input
-                id={this.props.progressBarId}
-                type="range"
-                min="0"
-                max="100"
-                value={this.state.percent}
-                onChange={this.handleProgressClick}
-              />
+              <UID name={id => `${this.progressBarIdPrefix}-${id}`}>
+                {id => (
+                  <React.Fragment>
+                    <label htmlFor={id} className="screen-reader-text">
+                      Progress Bar
+                    </label>
+                    <input
+                      id={id}
+                      type="range"
+                      min="0"
+                      max="100"
+                      value={this.state.percent}
+                      onChange={this.handleProgressClick}
+                    />
+                  </React.Fragment>
+                )}
+              </UID>
             </div>
             <div className="time duration">{this.state.durationFormatted}</div>
           </div>
@@ -274,20 +278,23 @@ export default class ResourcePlayerAudio extends Component {
                   left: `${volume * 0.7 - 10}px`
                 }}
               />
-              <label
-                htmlFor={this.props.volumeBarId}
-                className="screen-reader-text"
-              >
-                Adjust Volume
-              </label>
-              <input
-                id={this.props.volumeBarId}
-                type="range"
-                min="0"
-                max="100"
-                value={volume}
-                onChange={this.setVolume}
-              />
+              <UID name={id => `${this.volumeBarIdPrefix}-${id}`}>
+                {id => (
+                  <React.Fragment>
+                    <label htmlFor={id} className="screen-reader-text">
+                      Adjust Volume
+                    </label>
+                    <input
+                      id={id}
+                      type="range"
+                      min="0"
+                      max="100"
+                      value={volume}
+                      onChange={this.setVolume}
+                    />
+                  </React.Fragment>
+                )}
+              </UID>
             </div>
           </div>
         </div>

--- a/client/src/frontend/components/utility/Toggle.js
+++ b/client/src/frontend/components/utility/Toggle.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 import classNames from "classnames";
 import IconComposer from "global/components/utility/IconComposer";
 
@@ -10,7 +10,6 @@ export default class Toggle extends Component {
   static propTypes = {
     handleToggle: PropTypes.func.isRequired,
     label: PropTypes.string.isRequired,
-    id: PropTypes.string.isRequired,
     optionOne: PropTypes.shape({
       icon: PropTypes.string,
       label: PropTypes.string
@@ -20,10 +19,6 @@ export default class Toggle extends Component {
       label: PropTypes.string
     }).isRequired,
     selected: PropTypes.string
-  };
-
-  static defaultProps = {
-    id: labelId("button-switch-")
   };
 
   get selected() {
@@ -39,6 +34,10 @@ export default class Toggle extends Component {
       option => this.selected !== option.label
     );
     return unselected ? unselected.label : null;
+  }
+
+  get idPrefix() {
+    return "button-switch";
   }
 
   handleClick = event => {
@@ -65,22 +64,26 @@ export default class Toggle extends Component {
     const options = [this.props.optionOne, this.props.optionTwo];
 
     return (
-      <div className="button-switch-primary">
-        <button
-          className="button-switch-primary__button"
-          onClick={this.handleClick}
-          aria-describedby={this.props.id}
-        >
-          <div className="button-switch-primary__wrapper">
-            {options.map(option => {
-              return this.renderOption(option);
-            })}
+      <UID name={id => `${this.idPrefix}-${id}`}>
+        {id => (
+          <div className="button-switch-primary">
+            <button
+              className="button-switch-primary__button"
+              onClick={this.handleClick}
+              aria-describedby={id}
+            >
+              <div className="button-switch-primary__wrapper">
+                {options.map(option => {
+                  return this.renderOption(option);
+                })}
+              </div>
+            </button>
+            <span id={id} className="aria-describedby">
+              {`Toggle ${this.props.label} to ${this.unselected}`}
+            </span>
           </div>
-        </button>
-        <span id={this.props.id} className="aria-describedby">
-          {`Toggle ${this.props.label} to ${this.unselected}`}
-        </span>
-      </div>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/frontend/components/utility/__tests__/__snapshots__/Toggle-test.js.snap
+++ b/client/src/frontend/components/utility/__tests__/__snapshots__/Toggle-test.js.snap
@@ -5,7 +5,7 @@ exports[`Frontend.Utility.Toggle component renders correctly 1`] = `
   className="button-switch-primary"
 >
   <button
-    aria-describedby="button-switch-1"
+    aria-describedby={1}
     className="button-switch-primary__button"
     onClick={[Function]}
   >
@@ -34,7 +34,7 @@ exports[`Frontend.Utility.Toggle component renders correctly 1`] = `
   </button>
   <span
     className="aria-describedby"
-    id="button-switch-1"
+    id={1}
   >
     Toggle options to collection
   </span>

--- a/client/src/frontend/containers/Featured/__tests__/__snapshots__/Featured-test.js.snap
+++ b/client/src/frontend/containers/Featured/__tests__/__snapshots__/Featured-test.js.snap
@@ -87,12 +87,12 @@ exports[`Frontend Featured Container renders correctly 1`] = `
           </button>
           <label
             className="screen-reader-text"
-            htmlFor="filters-search-1"
+            htmlFor={1}
           >
             Enter Search Criteria
           </label>
           <input
-            id="filters-search-1"
+            id={1}
             onChange={[Function]}
             placeholder="Search…"
             type="text"

--- a/client/src/frontend/containers/Following/__tests__/__snapshots__/Following-test.js.snap
+++ b/client/src/frontend/containers/Following/__tests__/__snapshots__/Following-test.js.snap
@@ -81,12 +81,12 @@ exports[`Frontend Following Container renders correctly 1`] = `
           </button>
           <label
             className="screen-reader-text"
-            htmlFor="filters-search-1"
+            htmlFor={1}
           >
             Enter Search Criteria
           </label>
           <input
-            id="filters-search-1"
+            id={1}
             onChange={[Function]}
             placeholder="Search…"
             type="text"

--- a/client/src/frontend/containers/ProjectCollectionDetail/__tests__/__snapshots__/ProjectCollectionDetail-test.js.snap
+++ b/client/src/frontend/containers/ProjectCollectionDetail/__tests__/__snapshots__/ProjectCollectionDetail-test.js.snap
@@ -113,12 +113,12 @@ exports[`Frontend ProjectCollection Detail Container renders correctly 1`] = `
           </button>
           <label
             className="screen-reader-text"
-            htmlFor="filters-search-2"
+            htmlFor={1}
           >
             Enter Search Criteria
           </label>
           <input
-            id="filters-search-2"
+            id={1}
             onChange={[Function]}
             placeholder="Search…"
             type="text"

--- a/client/src/frontend/containers/ProjectResources/__tests__/__snapshots__/ProjectResources-test.js.snap
+++ b/client/src/frontend/containers/ProjectResources/__tests__/__snapshots__/ProjectResources-test.js.snap
@@ -117,12 +117,12 @@ exports[`Frontend ProjectResources Container renders correctly 1`] = `
           </button>
           <label
             className="screen-reader-text"
-            htmlFor="filters-search-1"
+            htmlFor={1}
           >
             Enter Search Criteria
           </label>
           <input
-            id="filters-search-1"
+            id={1}
             onChange={[Function]}
             placeholder="Search"
             type="text"

--- a/client/src/frontend/containers/ResourceCollectionDetail/__tests__/__snapshots__/ResourceCollectionDetail-test.js.snap
+++ b/client/src/frontend/containers/ResourceCollectionDetail/__tests__/__snapshots__/ResourceCollectionDetail-test.js.snap
@@ -446,12 +446,12 @@ exports[`Frontend ResourceCollectionDetail Container renders correctly 1`] = `
           </button>
           <label
             className="screen-reader-text"
-            htmlFor="filters-search-1"
+            htmlFor={1}
           >
             Enter Search Criteria
           </label>
           <input
-            id="filters-search-1"
+            id={1}
             onChange={[Function]}
             placeholder="Search"
             type="text"

--- a/client/src/frontend/containers/Search/__tests__/__snapshots__/Search-test.js.snap
+++ b/client/src/frontend/containers/Search/__tests__/__snapshots__/Search-test.js.snap
@@ -27,13 +27,13 @@ exports[`Frontend SearchContainer renders correctly 1`] = `
         >
           <label
             className="screen-reader-text"
-            htmlFor="query-search-1"
+            htmlFor={1}
           >
             Enter Search Criteria
           </label>
           <input
             autoFocus={true}
-            id="query-search-1"
+            id={1}
             onChange={[Function]}
             placeholder="Search…"
             type="text"

--- a/client/src/global/components/search/__tests__/__snapshots__/menu-test.js.snap
+++ b/client/src/global/components/search/__tests__/__snapshots__/menu-test.js.snap
@@ -22,13 +22,13 @@ exports[`Reader.Search.Menu component renders correctly when search is visible 1
       >
         <label
           className="screen-reader-text"
-          htmlFor="query-search-1"
+          htmlFor={1}
         >
           Enter Search Criteria
         </label>
         <input
           autoFocus={true}
-          id="query-search-1"
+          id={1}
           onChange={[Function]}
           placeholder="Search…"
           type="text"

--- a/client/src/global/components/search/query/Form.js
+++ b/client/src/global/components/search/query/Form.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 import isEqual from "lodash/isEqual";
 import Utility from "global/components/utility";
 
@@ -15,7 +15,6 @@ export default class SearchQueryForm extends PureComponent {
     scopes: PropTypes.array,
     description: PropTypes.string,
     searchType: PropTypes.string,
-    searchId: PropTypes.string,
     searchOnScopeChange: PropTypes.bool,
     projectId: PropTypes.string,
     textId: PropTypes.string,
@@ -33,8 +32,7 @@ export default class SearchQueryForm extends PureComponent {
       );
       console.warn("Current SearchQuery State");
       console.warn(state);
-    },
-    searchId: labelId("query-search-")
+    }
   };
   /* eslint-enable no-console */
 
@@ -131,6 +129,10 @@ export default class SearchQueryForm extends PureComponent {
 
   get allFacetsSelected() {
     return isEqual(this.availableFacetValues, this.selectedFacets);
+  }
+
+  get searchIdPrefix() {
+    return "query-search";
   }
 
   internalStateFromIncomingState(initialState) {
@@ -237,17 +239,23 @@ export default class SearchQueryForm extends PureComponent {
     return (
       <form className="search-query" onSubmit={this.doSearch}>
         <div className="input-magnify">
-          <label htmlFor={this.props.searchId} className="screen-reader-text">
-            Enter Search Criteria
-          </label>
-          <input
-            type="text"
-            id={this.props.searchId}
-            autoFocus
-            onChange={this.setKeyword}
-            value={this.state.keyword}
-            placeholder={"Search…"}
-          />
+          <UID name={id => `${this.searchIdPrefix}-${id}`}>
+            {id => (
+              <React.Fragment>
+                <label htmlFor={id} className="screen-reader-text">
+                  Enter Search Criteria
+                </label>
+                <input
+                  type="text"
+                  id={id}
+                  autoFocus
+                  onChange={this.setKeyword}
+                  value={this.state.keyword}
+                  placeholder={"Search…"}
+                />
+              </React.Fragment>
+            )}
+          </UID>
           <button type="submit" className="search-submit">
             <Utility.IconComposer
               iconClass="search-icon"

--- a/client/src/global/containers/comment/Editor.js
+++ b/client/src/global/containers/comment/Editor.js
@@ -7,7 +7,7 @@ import { entityStoreActions, uiVisibilityActions } from "actions";
 import { singularEntityName } from "utils/entityUtils";
 import { bindActionCreators } from "redux";
 import { commentsAPI } from "api";
-import labelId from "helpers/labelId";
+import { UID } from "react-uid";
 import IconComposer from "global/components/utility/IconComposer";
 
 const { request } = entityStoreActions;
@@ -33,15 +33,11 @@ export class CommentEditor extends PureComponent {
     onSuccess: PropTypes.func,
     subject: PropTypes.object.isRequired,
     parentId: PropTypes.string,
-    focus: PropTypes.bool,
-    id: PropTypes.string,
-    idForError: PropTypes.string
+    focus: PropTypes.bool
   };
 
   static defaultProps = {
-    focus: true,
-    id: labelId("comment-textarea-"),
-    idForError: labelId("comment-textarea-error-")
+    focus: true
   };
 
   constructor(props) {
@@ -62,6 +58,14 @@ export class CommentEditor extends PureComponent {
       body,
       errors: []
     };
+  }
+
+  get idPrefix() {
+    return "comment-textarea";
+  }
+
+  get idForErrorPrefix() {
+    return "comment-textarea-error";
   }
 
   submitOnReturnKey = event => {
@@ -188,50 +192,57 @@ export class CommentEditor extends PureComponent {
         </Authorize>
         <Authorize kind="any">
           <form onSubmit={this.handleSubmit}>
-            <GlobalForm.Errorable
-              name="attributes[body]"
-              errors={this.state.errors}
-              idForError={this.props.idForError}
-            >
-              <label htmlFor={this.props.id} className="screen-reader-text">
-                {this.placeholder(this.props)}
-              </label>
-              <textarea
-                ref={ci => {
-                  this.ci = ci;
-                }}
-                id={this.props.id}
-                onKeyDown={this.submitOnReturnKey}
-                className={textClass}
-                placeholder={this.placeholder(this.props)}
-                onChange={this.handleBodyChange}
-                value={this.state.body}
-                aria-describedby={this.props.idForError}
-              />
-              <div className="utility">
-                <div className="buttons">
-                  <button
-                    type="button"
-                    onClick={this.props.cancel}
-                    className="button-secondary button-secondary--dull"
+            <UID>
+              {id => (
+                <GlobalForm.Errorable
+                  name="attributes[body]"
+                  errors={this.state.errors}
+                  idForError={`${this.idForErrorPrefix}-${id}`}
+                >
+                  <label
+                    htmlFor={`${this.idPrefix}-${id}`}
+                    className="screen-reader-text"
                   >
-                    Cancel
-                  </button>
-                  <button
-                    className="button-secondary"
-                    disabled={!this.state.body}
-                  >
-                    <i
-                      className="manicon manicon-word-bubble-lines"
-                      aria-hidden="true"
-                    />
-                    <span className="button-secondary__text">
-                      {this.buttonLabel(this.props)}
-                    </span>
-                  </button>
-                </div>
-              </div>
-            </GlobalForm.Errorable>
+                    {this.placeholder(this.props)}
+                  </label>
+                  <textarea
+                    ref={ci => {
+                      this.ci = ci;
+                    }}
+                    id={`${this.idPrefix}-${id}`}
+                    onKeyDown={this.submitOnReturnKey}
+                    className={textClass}
+                    placeholder={this.placeholder(this.props)}
+                    onChange={this.handleBodyChange}
+                    value={this.state.body}
+                    aria-describedby={`${this.idForErrorPrefix}-${id}`}
+                  />
+                  <div className="utility">
+                    <div className="buttons">
+                      <button
+                        type="button"
+                        onClick={this.props.cancel}
+                        className="button-secondary button-secondary--dull"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="button-secondary"
+                        disabled={!this.state.body}
+                      >
+                        <i
+                          className="manicon manicon-word-bubble-lines"
+                          aria-hidden="true"
+                        />
+                        <span className="button-secondary__text">
+                          {this.buttonLabel(this.props)}
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </GlobalForm.Errorable>
+              )}
+            </UID>
           </form>
         </Authorize>
       </div>

--- a/client/src/helpers/__mocks__/labelId.js
+++ b/client/src/helpers/__mocks__/labelId.js
@@ -1,1 +1,0 @@
-export default prefix => `${prefix}1`;

--- a/client/src/helpers/labelId.js
+++ b/client/src/helpers/labelId.js
@@ -1,5 +1,0 @@
-import uniqueId from "lodash/uniqueId";
-
-export default function labelId(prefix = "") {
-  return uniqueId(prefix);
-}

--- a/client/src/reader/containers/Search/__tests__/__snapshots__/Search-test.js.snap
+++ b/client/src/reader/containers/Search/__tests__/__snapshots__/Search-test.js.snap
@@ -79,13 +79,13 @@ exports[`Reader SearchContainer renders correctly 1`] = `
           >
             <label
               className="screen-reader-text"
-              htmlFor="query-search-1"
+              htmlFor={1}
             >
               Enter Search Criteria
             </label>
             <input
               autoFocus={true}
-              id="query-search-1"
+              id={1}
               onChange={[Function]}
               placeholder="Search…"
               type="text"

--- a/client/src/reader/containers/notation/__tests__/__snapshots__/Picker-test.js.snap
+++ b/client/src/reader/containers/notation/__tests__/__snapshots__/Picker-test.js.snap
@@ -19,7 +19,7 @@ Array [
         className="button-switch-primary"
       >
         <button
-          aria-describedby="button-switch-1"
+          aria-describedby={1}
           className="button-switch-primary__button"
           onClick={[Function]}
         >
@@ -74,14 +74,14 @@ Array [
         </button>
         <span
           className="aria-describedby"
-          id="button-switch-1"
+          id={1}
         >
           Toggle options to collections
         </span>
       </div>
       <div
         className="entity-list"
-        id="entities-list1"
+        id={1}
       >
         <div
           className="entity-list__contents-wrapper"
@@ -122,13 +122,13 @@ Array [
                 >
                   <label
                     className="screen-reader-text"
-                    htmlFor="list-search-1"
+                    htmlFor={1}
                   >
                     Enter Search Criteria
                   </label>
                   <input
                     className="entity-list-search__keyword-input"
-                    id="list-search-1"
+                    id={1}
                     onChange={[Function]}
                     placeholder="Search..."
                     type="text"
@@ -154,7 +154,7 @@ Array [
               className="entity-row entity-list__entity"
             >
               <a
-                aria-describedby="undefined1-describedby"
+                aria-describedby="1-describedby"
                 className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
                 href="/backend/projects/resource/1"
                 onClick={[Function]}
@@ -198,7 +198,7 @@ Array [
                       </span>
                       <span
                         className="aria-describedby"
-                        id="undefined1-describedby"
+                        id="1-describedby"
                       >
                         View Image
                       </span>
@@ -220,7 +220,7 @@ Array [
               className="entity-row entity-list__entity"
             >
               <a
-                aria-describedby="undefined1-describedby"
+                aria-describedby="1-describedby"
                 className="entity-row__row-link entity-row__row-link--block entity-row__row-link--atag"
                 href="/backend/projects/resource/2"
                 onClick={[Function]}
@@ -264,7 +264,7 @@ Array [
                       </span>
                       <span
                         className="aria-describedby"
-                        id="undefined1-describedby"
+                        id="1-describedby"
                       >
                         View Image
                       </span>
@@ -302,7 +302,7 @@ Array [
                     >
                       <a
                         disabled={true}
-                        href="#entities-list1"
+                        href="#1"
                         onClick={[Function]}
                       >
                         <svg
@@ -338,7 +338,7 @@ Array [
                       className="list-pagination__page list-pagination__page--ordinal list-pagination__page--disabled"
                     >
                       <a
-                        href="#entities-list1"
+                        href="#1"
                         onClick={[Function]}
                       >
                         <span
@@ -358,7 +358,7 @@ Array [
                       className="list-pagination__page list-pagination__page--ordinal"
                     >
                       <a
-                        href="#entities-list1"
+                        href="#1"
                         onClick={[Function]}
                       >
                         <span
@@ -384,7 +384,7 @@ Array [
                       className="list-pagination__page list-pagination__page--next"
                     >
                       <a
-                        href="#entities-list1"
+                        href="#1"
                         onClick={[Function]}
                       >
                         <span

--- a/client/src/test/setup.js
+++ b/client/src/test/setup.js
@@ -13,6 +13,11 @@ jest.mock("date-fns/distance_in_words", () => {
 });
 
 jest.mock("focus-trap-react", () => "focus-trap-react");
+jest.mock("react-uid", () => {
+  return {
+    UID: jest.fn(props => props.children(1))
+  };
+});
 
 // Mocked fetchData is a noop component that renders its child.
 // see src/components/global/HigherOrder/__mocks__/fetchData.js
@@ -25,5 +30,4 @@ jest.mock("hoc/with-form-context");
 // To mock returned data or collection responses, adjust src/api/__mocks__/client.js
 jest.mock("api/client");
 
-jest.mock("helpers/labelId");
 jest.mock("services/plugin/initializer");

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -12764,6 +12764,11 @@ react-typekit@^1.0.8:
     lodash "^4.17.4"
     prop-types "^15.5.10"
 
+react-uid@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.2.0.tgz#0f77e1e0594fbf29fc4fe528cc9aa415c5bf9159"
+  integrity sha512-z+g5+hFOQ08hCfrGcJ1PNs+cmvH8Uq2CVzCmPeWBsUi5A4W4NWXR5jouledzy3oSKGMU9HOzf8zFuGi15TXJoQ==
+
 react@^15.5.4:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"


### PR DESCRIPTION
This PR fixes two issues with how unique IDs were being generated to associate HTML form elements with their corresponding label or "describedby" element. Use of `labelId` as a `defaultProp` was generating the same ID for all rendered instances of a component on a given page. In other places, use of `labelId` in the render method was generating a different ID on every re-render, which wasn't necessarily a problem in this context, but wasn't ideal. Both of these issues are resolved by wrapping form elements in react-uid's renderless `UID` component, which creates a unique ID for each instance that doesn't change on re-render.

This PR also adds a mock for react-uid to the test suite, and updates test snapshots.