### PR TITLE
[B] Fix text-wrapping in search filters

### DIFF
--- a/client/src/theme/styles/components/backend/list/entity/_entity-list-search.scss
+++ b/client/src/theme/styles/components/backend/list/entity/_entity-list-search.scss
@@ -145,11 +145,14 @@
       height: $inputHeight;
       padding-right: 32px;
       padding-left: 13px;
+      overflow: hidden;
       font-size: 16px;
       font-weight: $regular;
       color: $neutral20;
+      text-overflow: ellipsis;
       text-transform: none;
       letter-spacing: normal;
+      white-space: nowrap;
       border: 1px solid $neutral80;
       border-radius: 8px;
       transition: border-color $duration $timing;

--- a/client/src/theme/styles/components/global/forms/_list-filter.scss
+++ b/client/src/theme/styles/components/global/forms/_list-filter.scss
@@ -153,8 +153,11 @@
         height: $inputHeight;
         padding-right: 32px;
         padding-left: 13px;
+        overflow: hidden;
         font-size: 14px;
         color: $neutral50;
+        text-overflow: ellipsis;
+        white-space: nowrap;
         border: 2px solid $neutral30;
         transition: border-color $duration $timing;
 


### PR DESCRIPTION
Resolves #2209

Applies `text-overflow: ellipsis` for supporting browsers (Safari, Firefox).