### PR TITLE
[B] Group related form controls

### DIFF
--- a/client/src/backend/components/content-block/Builder/index.js
+++ b/client/src/backend/components/content-block/Builder/index.js
@@ -10,6 +10,7 @@ import lh from "helpers/linkHandler";
 import { entityStoreActions } from "actions";
 import configHelper from "../helpers/configurations";
 import cloneDeep from "lodash/cloneDeep";
+import { UID } from "react-uid";
 
 const { request } = entityStoreActions;
 
@@ -178,23 +179,34 @@ export class ProjectContent extends PureComponent {
   render() {
     return (
       <section className="backend-project-content">
-        <div className="form-secondary">
-          <DragDropContext
-            onDragStart={this.onDragStart}
-            onDragEnd={this.onDragEnd}
-          >
-            <AvailableSection
-              onClickAdd={this.handleAddEntity}
-              currentBlocks={this.currentBlocks}
-            />
-            <CurrentSection
-              activeDraggableType={this.state.activeDraggableType}
-              entityCallbacks={this.entityCallbacks}
-              currentBlocks={this.currentBlocks}
-            />
-          </DragDropContext>
-          {this.props.children(this.drawerCloseCallback, this.pendingBlock)}
-        </div>
+        <UID name={id => `content-block-builder-${id}`}>
+          {id => (
+            <div
+              className="form-secondary"
+              role="group"
+              aria-labelledby={`${id}-header`}
+              aria-describedby={`${id}-instructions`}
+            >
+              <DragDropContext
+                onDragStart={this.onDragStart}
+                onDragEnd={this.onDragEnd}
+              >
+                <AvailableSection
+                  onClickAdd={this.handleAddEntity}
+                  currentBlocks={this.currentBlocks}
+                  headerId={`${id}-header`}
+                  instructionsId={`${id}-instructions`}
+                />
+                <CurrentSection
+                  activeDraggableType={this.state.activeDraggableType}
+                  entityCallbacks={this.entityCallbacks}
+                  currentBlocks={this.currentBlocks}
+                />
+              </DragDropContext>
+              {this.props.children(this.drawerCloseCallback, this.pendingBlock)}
+            </div>
+          )}
+        </UID>
       </section>
     );
   }

--- a/client/src/backend/components/content-block/Builder/sections/Available.js
+++ b/client/src/backend/components/content-block/Builder/sections/Available.js
@@ -10,7 +10,9 @@ export default class ProjectContentSectionsAvailable extends PureComponent {
 
   static propTypes = {
     currentBlocks: PropTypes.array.isRequired,
-    onClickAdd: PropTypes.func
+    onClickAdd: PropTypes.func,
+    headerId: PropTypes.string,
+    instructionsId: PropTypes.string
   };
 
   static defaultProps = {
@@ -24,7 +26,12 @@ export default class ProjectContentSectionsAvailable extends PureComponent {
   render() {
     return (
       <div className="form-section">
-        <Header title="Content Blocks" subtitle="Blocks:">
+        <Header
+          title="Content Blocks"
+          subtitle="Blocks:"
+          headerId={this.props.headerId}
+          instructionsId={this.props.instructionsId}
+        >
           Customize the rest of the content on your project page. Add, delete,
           and reorder content blocks, edit settings, and toggle visibility.
         </Header>

--- a/client/src/backend/components/content-block/Builder/sections/parts/Header.js
+++ b/client/src/backend/components/content-block/Builder/sections/parts/Header.js
@@ -7,7 +7,9 @@ export default class ProjectContentSectionsPartsHeader extends PureComponent {
   static propTypes = {
     title: PropTypes.string,
     children: PropTypes.string,
-    subtitle: PropTypes.string
+    subtitle: PropTypes.string,
+    headerId: PropTypes.string,
+    instructionsId: PropTypes.string
   };
 
   render() {
@@ -15,11 +17,13 @@ export default class ProjectContentSectionsPartsHeader extends PureComponent {
       <React.Fragment>
         {this.props.title && (
           <header className="form-section-label">
-            <h2>{this.props.title}</h2>
+            <h2 id={this.props.headerId}>{this.props.title}</h2>
           </header>
         )}
         {this.props.children && (
-          <span className="instructions">{this.props.children}</span>
+          <span id={this.props.instructionsId} className="instructions">
+            {this.props.children}
+          </span>
         )}
         {this.props.subtitle && (
           <header className="form-subsection-label">

--- a/client/src/backend/components/form/FieldGroup.js
+++ b/client/src/backend/components/form/FieldGroup.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import isString from "lodash/isString";
 import classNames from "classnames";
+import { UID } from "react-uid";
 import Instructions from "./Instructions";
 
 export default class FieldGroup extends PureComponent {
@@ -45,17 +46,30 @@ export default class FieldGroup extends PureComponent {
     });
 
     return (
-      <div className={classes} key="group">
-        {isString(this.props.label) ? (
-          <header className="form-section-label">
-            <h2>{this.props.label}</h2>
-          </header>
-        ) : null}
-        <Instructions instructions={this.props.instructions} />
-        <div className="form-input-group">
-          {this.renderChildren(this.props)}
-        </div>
-      </div>
+      <UID name={id => `field-group-${id}`}>
+        {id => (
+          <div
+            className={classes}
+            key="group"
+            role="group"
+            aria-labelledby={`${id}-header`}
+            aria-describedby={`${id}-instructions`}
+          >
+            {isString(this.props.label) ? (
+              <header className="form-section-label">
+                <h2 id={`${id}-header`}>{this.props.label}</h2>
+              </header>
+            ) : null}
+            <Instructions
+              id={`${id}-instructions`}
+              instructions={this.props.instructions}
+            />
+            <div className="form-input-group">
+              {this.renderChildren(this.props)}
+            </div>
+          </div>
+        )}
+      </UID>
     );
   }
 }

--- a/client/src/backend/components/form/__tests__/__snapshots__/FieldGroup-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/FieldGroup-test.js.snap
@@ -2,7 +2,10 @@
 
 exports[`Backend.Form.FieldGroup component renders correctly 1`] = `
 <div
+  aria-describedby="1-instructions"
+  aria-labelledby="1-header"
   className="form-section"
+  role="group"
 >
   <div
     className="form-input-group"

--- a/client/src/backend/components/form/__tests__/__snapshots__/SwitchArray-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/SwitchArray-test.js.snap
@@ -6,12 +6,17 @@ exports[`Backend.Form.SwitchArray component renders correctly 1`] = `
   style={Object {}}
 >
   <div
+    aria-describedby="1-instructions"
+    aria-labelledby="1-header"
     className="form-section horizontal"
+    role="group"
   >
     <header
       className="form-section-label"
     >
-      <h2>
+      <h2
+        id="1-header"
+      >
         Label this
       </h2>
     </header>

--- a/client/src/backend/components/list/EntitiesList/List/Search.js
+++ b/client/src/backend/components/list/EntitiesList/List/Search.js
@@ -221,26 +221,39 @@ export default class ListEntitiesListSearch extends PureComponent {
         )}
         {this.hasOptions && (
           <Collapse isOpened={this.state.open}>
-            <div>
-              <div className={this.classNameWithStyle(`${baseClass}__options`)}>
-                {this.filterParams.map((param, i) => (
+            <UID name={id => `${this.idPrefix}-${id}`}>
+              {id => (
+                <div role="group" aria-labelledby={`${id}-header`}>
+                  <p id={`${id}-header`} className="screen-reader-text">
+                    Search options
+                  </p>
                   <div
-                    key={i}
-                    className={this.classNameWithStyle(`${baseClass}__option`)}
+                    className={this.classNameWithStyle(`${baseClass}__options`)}
                   >
-                    <div className={`${baseClass}__option-inner`}>
-                      <span
-                        className={`${baseClass}__options-label ${
-                          i > 0 ? `${baseClass}__options-label--empty` : ""
-                        }`}
+                    {this.filterParams.map((param, i) => (
+                      <div
+                        key={i}
+                        className={this.classNameWithStyle(
+                          `${baseClass}__option`
+                        )}
                       >
-                        {i === 0 ? "Filter Results:" : "\u00A0"}
-                      </span>
-                      <div className={`${baseClass}__select-wrapper`}>
-                        <UID name={id => `${this.idPrefix}-${id}`}>
-                          {id => (
+                        <div className={`${baseClass}__option-inner`}>
+                          <span
+                            className={`${baseClass}__options-label ${
+                              i > 0 ? `${baseClass}__options-label--empty` : ""
+                            }`}
+                          >
+                            {i === 0 ? "Filter Results:" : "\u00A0"}
+                          </span>
+                          <div className={`${baseClass}__select-wrapper`}>
+                            <label
+                              htmlFor={`${id}-filter-${i}`}
+                              className="screen-reader-text"
+                            >
+                              {`Filter results by ${param.label}`}
+                            </label>
                             <select
-                              id={id}
+                              id={`${id}-filter-${i}`}
                               onChange={e => this.setParam(e, param)}
                               value={this.paramValue(param)}
                             >
@@ -255,26 +268,30 @@ export default class ListEntitiesListSearch extends PureComponent {
                                 )
                               )}
                             </select>
-                          )}
-                        </UID>
-                        <Utility.IconComposer icon="disclosureDown24" />
+                            <Utility.IconComposer icon="disclosureDown24" />
+                          </div>
+                        </div>
                       </div>
-                    </div>
-                  </div>
-                ))}
-                {this.hasOrderParam && (
-                  <div
-                    className={this.classNameWithStyle(`${baseClass}__option`)}
-                  >
-                    <div className={`${baseClass}__option-inner`}>
-                      <span className={`${baseClass}__options-label`}>
-                        Order Results:
-                      </span>
-                      <div className={`${baseClass}__select-wrapper`}>
-                        <UID name={id => `${this.idPrefix}-${id}`}>
-                          {id => (
+                    ))}
+                    {this.hasOrderParam && (
+                      <div
+                        className={this.classNameWithStyle(
+                          `${baseClass}__option`
+                        )}
+                      >
+                        <div className={`${baseClass}__option-inner`}>
+                          <span className={`${baseClass}__options-label`}>
+                            Order Results:
+                          </span>
+                          <div className={`${baseClass}__select-wrapper`}>
+                            <label
+                              htmlFor={`${id}-order`}
+                              className="screen-reader-text"
+                            >
+                              {`Order results`}
+                            </label>
                             <select
-                              id={id}
+                              id={`${id}-order`}
                               onChange={e => this.setParam(e, this.orderParam)}
                               value={this.paramValue(this.orderParam)}
                             >
@@ -289,15 +306,15 @@ export default class ListEntitiesListSearch extends PureComponent {
                                 )
                               )}
                             </select>
-                          )}
-                        </UID>
-                        <Utility.IconComposer icon="disclosureDown24" />
+                            <Utility.IconComposer icon="disclosureDown24" />
+                          </div>
+                        </div>
                       </div>
-                    </div>
+                    )}
                   </div>
-                )}
-              </div>
-            </div>
+                </div>
+              )}
+            </UID>
           </Collapse>
         )}
       </div>

--- a/client/src/backend/components/project/hero/Builder/index.js
+++ b/client/src/backend/components/project/hero/Builder/index.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
+import { UID } from "react-uid";
 import Block from "./Block";
 import Forms from "./forms";
 import Drawer from "global/containers/drawer";
@@ -63,42 +64,51 @@ export default class Builder extends PureComponent {
     return (
       <React.Fragment>
         <section className="hero-builder form-secondary">
-          <div className="form-section">
-            <header className="form-section-label">
-              <h2>Hero Block</h2>
-            </header>
-            <span className="instructions">
-              The Hero Block is the top of your project page. Customize its
-              content, layout, and settings here.
-            </span>
+          <UID name={id => `hero-builder-${id}`}>
+            {id => (
+              <div
+                className="form-section"
+                role="group"
+                aria-labelledby={`${id}-header`}
+                aria-describedby={`${id}-instructions`}
+              >
+                <header className="form-section-label">
+                  <h2 id={`${id}-header`}>Hero Block</h2>
+                </header>
+                <span id={`${id}-instructions`} className="instructions">
+                  The Hero Block is the top of your project page. Customize its
+                  content, layout, and settings here.
+                </span>
 
-            <Block
-              title="Description + Images"
-              description="Description Text, Cover Art, and Background Image"
-              onEdit={this.openDescriptionDrawer}
-            />
-            <Block
-              title="Calls-to-Action"
-              description="Buttons and links to related resources"
-              onEdit={this.toggleActionCallouts}
-              open={this.isActionCalloutsOpen}
-            >
-              {this.props.actionCallouts && (
-                <ActionCallouts
-                  refresh={this.props.refresh}
-                  dispatch={this.props.dispatch}
-                  project={this.props.project}
-                  actionCallouts={this.props.actionCallouts}
-                  actionCalloutsResponse={this.props.actionCalloutsResponse}
+                <Block
+                  title="Description + Images"
+                  description="Description Text, Cover Art, and Background Image"
+                  onEdit={this.openDescriptionDrawer}
                 />
-              )}
-            </Block>
-            <Block
-              title="Social Links"
-              description="Links to social platforms and hashtag"
-              onEdit={this.openSocialDrawer}
-            />
-          </div>
+                <Block
+                  title="Calls-to-Action"
+                  description="Buttons and links to related resources"
+                  onEdit={this.toggleActionCallouts}
+                  open={this.isActionCalloutsOpen}
+                >
+                  {this.props.actionCallouts && (
+                    <ActionCallouts
+                      refresh={this.props.refresh}
+                      dispatch={this.props.dispatch}
+                      project={this.props.project}
+                      actionCallouts={this.props.actionCallouts}
+                      actionCalloutsResponse={this.props.actionCalloutsResponse}
+                    />
+                  )}
+                </Block>
+                <Block
+                  title="Social Links"
+                  description="Links to social platforms and hashtag"
+                  onEdit={this.openSocialDrawer}
+                />
+              </div>
+            )}
+          </UID>
         </section>
         <Drawer.Wrapper
           lockScroll="always"

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Variants-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Variants-test.js.snap
@@ -2,7 +2,10 @@
 
 exports[`Backend.Resource.Form.Variants component renders correctly 1`] = `
 <div
+  aria-describedby="1-instructions"
+  aria-labelledby="1-header"
   className="form-section"
+  role="group"
 >
   <div
     className="form-input-group"

--- a/client/src/backend/containers/dashboards/__tests__/__snapshots__/Admin-test.js.snap
+++ b/client/src/backend/containers/dashboards/__tests__/__snapshots__/Admin-test.js.snap
@@ -145,7 +145,16 @@ Array [
                         <div
                           className="ReactCollapse--content"
                         >
-                          <div>
+                          <div
+                            aria-labelledby="1-header"
+                            role="group"
+                          >
+                            <p
+                              className="screen-reader-text"
+                              id="1-header"
+                            >
+                              Search options
+                            </p>
                             <div
                               className="entity-list-search__options entity-list-search__options--vertical"
                             >
@@ -163,8 +172,14 @@ Array [
                                   <div
                                     className="entity-list-search__select-wrapper"
                                   >
+                                    <label
+                                      className="screen-reader-text"
+                                      htmlFor="1-filter-0"
+                                    >
+                                      Filter results by Draft
+                                    </label>
                                     <select
-                                      id={1}
+                                      id="1-filter-0"
                                       onChange={[Function]}
                                       value=""
                                     >
@@ -214,8 +229,14 @@ Array [
                                   <div
                                     className="entity-list-search__select-wrapper"
                                   >
+                                    <label
+                                      className="screen-reader-text"
+                                      htmlFor="1-filter-1"
+                                    >
+                                      Filter results by Creator
+                                    </label>
                                     <select
-                                      id={1}
+                                      id="1-filter-1"
                                       onChange={[Function]}
                                       value=""
                                     >
@@ -260,8 +281,14 @@ Array [
                                   <div
                                     className="entity-list-search__select-wrapper"
                                   >
+                                    <label
+                                      className="screen-reader-text"
+                                      htmlFor="1-order"
+                                    >
+                                      Order results
+                                    </label>
                                     <select
-                                      id={1}
+                                      id="1-order"
                                       onChange={[Function]}
                                       value="updated_at DESC"
                                     >

--- a/client/src/backend/containers/makers/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/containers/makers/__tests__/__snapshots__/List-test.js.snap
@@ -114,7 +114,16 @@ Array [
           <div
             className="ReactCollapse--content"
           >
-            <div>
+            <div
+              aria-labelledby="1-header"
+              role="group"
+            >
+              <p
+                className="screen-reader-text"
+                id="1-header"
+              >
+                Search options
+              </p>
               <div
                 className="entity-list-search__options entity-list-search__options--horizontal"
               >
@@ -132,8 +141,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-order"
+                      >
+                        Order results
+                      </label>
                       <select
-                        id={1}
+                        id="1-order"
                         onChange={[Function]}
                         value="last_name"
                       >

--- a/client/src/backend/containers/permission/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/backend/containers/permission/__tests__/__snapshots__/Edit-test.js.snap
@@ -55,12 +55,17 @@ exports[`Backend Permission Edit Container renders correctly 1`] = `
           style={Object {}}
         >
           <div
+            aria-describedby="1-instructions"
+            aria-labelledby="1-header"
             className="form-section horizontal"
+            role="group"
           >
             <header
               className="form-section-label"
             >
-              <h2>
+              <h2
+                id="1-header"
+              >
                 Permissions
               </h2>
             </header>

--- a/client/src/backend/containers/permission/__tests__/__snapshots__/Form-test.js.snap
+++ b/client/src/backend/containers/permission/__tests__/__snapshots__/Form-test.js.snap
@@ -45,12 +45,17 @@ exports[`Backend Permission Form Container renders correctly 1`] = `
         style={Object {}}
       >
         <div
+          aria-describedby="1-instructions"
+          aria-labelledby="1-header"
           className="form-section horizontal"
+          role="group"
         >
           <header
             className="form-section-label"
           >
-            <h2>
+            <h2
+              id="1-header"
+            >
               Permissions
             </h2>
           </header>

--- a/client/src/backend/containers/permission/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/permission/__tests__/__snapshots__/New-test.js.snap
@@ -59,12 +59,17 @@ exports[`Backend Permission New Container renders correctly 1`] = `
           style={Object {}}
         >
           <div
+            aria-describedby="1-instructions"
+            aria-labelledby="1-header"
             className="form-section horizontal"
+            role="group"
           >
             <header
               className="form-section-label"
             >
-              <h2>
+              <h2
+                id="1-header"
+              >
                 Permissions
               </h2>
             </header>

--- a/client/src/backend/containers/project-collection/__tests__/__snapshots__/ManageProjects-test.js.snap
+++ b/client/src/backend/containers/project-collection/__tests__/__snapshots__/ManageProjects-test.js.snap
@@ -129,7 +129,16 @@ Array [
           <div
             className="ReactCollapse--content"
           >
-            <div>
+            <div
+              aria-labelledby="1-header"
+              role="group"
+            >
+              <p
+                className="screen-reader-text"
+                id="1-header"
+              >
+                Search options
+              </p>
               <div
                 className="entity-list-search__options entity-list-search__options--horizontal"
               >
@@ -147,8 +156,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-filter-0"
+                      >
+                        Filter results by Draft
+                      </label>
                       <select
-                        id={1}
+                        id="1-filter-0"
                         onChange={[Function]}
                         value=""
                       >
@@ -198,8 +213,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-filter-1"
+                      >
+                        Filter results by Creator
+                      </label>
                       <select
-                        id={1}
+                        id="1-filter-1"
                         onChange={[Function]}
                         value=""
                       >
@@ -244,8 +265,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-order"
+                      >
+                        Order results
+                      </label>
                       <select
-                        id={1}
+                        id="1-order"
                         onChange={[Function]}
                         value="updated_at DESC"
                       >

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Collections-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Collections-test.js.snap
@@ -114,7 +114,16 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
           <div
             className="ReactCollapse--content"
           >
-            <div>
+            <div
+              aria-labelledby="1-header"
+              role="group"
+            >
+              <p
+                className="screen-reader-text"
+                id="1-header"
+              >
+                Search options
+              </p>
               <div
                 className="entity-list-search__options entity-list-search__options--horizontal"
               >
@@ -132,8 +141,14 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-filter-0"
+                      >
+                        Filter results by Tag
+                      </label>
                       <select
-                        id={1}
+                        id="1-filter-0"
                         onChange={[Function]}
                         value=""
                       >
@@ -173,8 +188,14 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-filter-1"
+                      >
+                        Filter results by Kind
+                      </label>
                       <select
-                        id={1}
+                        id="1-filter-1"
                         onChange={[Function]}
                         value=""
                       >
@@ -214,8 +235,14 @@ exports[`Backend Project Collections Container renders correctly 1`] = `
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-order"
+                      >
+                        Order results
+                      </label>
                       <select
-                        id={1}
+                        id="1-order"
                         onChange={[Function]}
                         value="title"
                       >

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Events-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Events-test.js.snap
@@ -115,7 +115,16 @@ Array [
             <div
               className="ReactCollapse--content"
             >
-              <div>
+              <div
+                aria-labelledby="1-header"
+                role="group"
+              >
+                <p
+                  className="screen-reader-text"
+                  id="1-header"
+                >
+                  Search options
+                </p>
                 <div
                   className="entity-list-search__options entity-list-search__options--horizontal"
                 >
@@ -133,8 +142,14 @@ Array [
                       <div
                         className="entity-list-search__select-wrapper"
                       >
+                        <label
+                          className="screen-reader-text"
+                          htmlFor="1-filter-0"
+                        >
+                          Filter results by Type
+                        </label>
                         <select
-                          id={1}
+                          id="1-filter-0"
                           onChange={[Function]}
                           value=""
                         >

--- a/client/src/backend/containers/project/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/General-test.js.snap
@@ -9,12 +9,17 @@ exports[`Backend Project General Container renders correctly 1`] = `
       onSubmit={[Function]}
     >
       <div
+        aria-describedby="1-instructions"
+        aria-labelledby="1-header"
         className="form-section"
+        role="group"
       >
         <header
           className="form-section-label"
         >
-          <h2>
+          <h2
+            id="1-header"
+          >
             Title
           </h2>
         </header>
@@ -81,12 +86,17 @@ exports[`Backend Project General Container renders correctly 1`] = `
         </div>
       </div>
       <div
+        aria-describedby="1-instructions"
+        aria-labelledby="1-header"
         className="form-section"
+        role="group"
       >
         <header
           className="form-section-label"
         >
-          <h2>
+          <h2
+            id="1-header"
+          >
             Visibility
           </h2>
         </header>
@@ -170,12 +180,17 @@ exports[`Backend Project General Container renders correctly 1`] = `
         </div>
       </div>
       <div
+        aria-describedby="1-instructions"
+        aria-labelledby="1-header"
         className="form-section"
+        role="group"
       >
         <header
           className="form-section-label"
         >
-          <h2>
+          <h2
+            id="1-header"
+          >
             Other
           </h2>
         </header>

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Metadata-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Metadata-test.js.snap
@@ -9,12 +9,17 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
       onSubmit={[Function]}
     >
       <div
+        aria-describedby="1-instructions"
+        aria-labelledby="1-header"
         className="form-section"
+        role="group"
       >
         <header
           className="form-section-label"
         >
-          <h2>
+          <h2
+            id="1-header"
+          >
             Identity
           </h2>
         </header>
@@ -62,12 +67,17 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         </div>
       </div>
       <div
+        aria-describedby="1-instructions"
+        aria-labelledby="1-header"
         className="form-section"
+        role="group"
       >
         <header
           className="form-section-label"
         >
-          <h2>
+          <h2
+            id="1-header"
+          >
             Publisher
           </h2>
         </header>
@@ -159,12 +169,17 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         </div>
       </div>
       <div
+        aria-describedby="1-instructions"
+        aria-labelledby="1-header"
         className="form-section"
+        role="group"
       >
         <header
           className="form-section-label"
         >
-          <h2>
+          <h2
+            id="1-header"
+          >
             Bibliographic
           </h2>
         </header>
@@ -312,12 +327,17 @@ exports[`Backend Project Metadata Container renders correctly 1`] = `
         </div>
       </div>
       <div
+        aria-describedby="1-instructions"
+        aria-labelledby="1-header"
         className="form-section"
+        role="group"
       >
         <header
           className="form-section-label"
         >
-          <h2>
+          <h2
+            id="1-header"
+          >
             Other
           </h2>
         </header>

--- a/client/src/backend/containers/project/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/New-test.js.snap
@@ -137,12 +137,17 @@ exports[`Backend Project New Container renders correctly 1`] = `
             onSubmit={[Function]}
           >
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Title and Description
                 </h2>
               </header>
@@ -216,12 +221,17 @@ exports[`Backend Project New Container renders correctly 1`] = `
               </div>
             </div>
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Layout
                 </h2>
               </header>

--- a/client/src/backend/containers/project/__tests__/__snapshots__/ProjectPage-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/ProjectPage-test.js.snap
@@ -9,12 +9,17 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
       onSubmit={[Function]}
     >
       <div
+        aria-describedby="1-instructions"
+        aria-labelledby="1-header"
         className="form-section"
+        role="group"
       >
         <header
           className="form-section-label"
         >
-          <h2>
+          <h2
+            id="1-header"
+          >
             Appearance
           </h2>
         </header>
@@ -265,12 +270,17 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
         </div>
       </div>
       <div
+        aria-describedby="1-instructions"
+        aria-labelledby="1-header"
         className="form-section"
+        role="group"
       >
         <header
           className="form-section-label"
         >
-          <h2>
+          <h2
+            id="1-header"
+          >
             Purchase Options
           </h2>
         </header>
@@ -379,17 +389,23 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
         </div>
       </div>
       <div
+        aria-describedby="1-instructions"
+        aria-labelledby="1-header"
         className="form-section"
+        role="group"
       >
         <header
           className="form-section-label"
         >
-          <h2>
+          <h2
+            id="1-header"
+          >
             Download Options
           </h2>
         </header>
         <span
           className="instructions"
+          id="1-instructions"
         >
           If a URL or file is provided, a button to download the file will appear on the project page.  A file takes precedence over a URL.
         </span>

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Resources-test.js.snap
@@ -114,7 +114,16 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
           <div
             className="ReactCollapse--content"
           >
-            <div>
+            <div
+              aria-labelledby="1-header"
+              role="group"
+            >
+              <p
+                className="screen-reader-text"
+                id="1-header"
+              >
+                Search options
+              </p>
               <div
                 className="entity-list-search__options entity-list-search__options--horizontal"
               >
@@ -132,8 +141,14 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-filter-0"
+                      >
+                        Filter results by Tag
+                      </label>
                       <select
-                        id={1}
+                        id="1-filter-0"
                         onChange={[Function]}
                         value=""
                       >
@@ -173,8 +188,14 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-filter-1"
+                      >
+                        Filter results by Kind
+                      </label>
                       <select
-                        id={1}
+                        id="1-filter-1"
                         onChange={[Function]}
                         value=""
                       >
@@ -214,8 +235,14 @@ exports[`Backend Project Resources Container renders correctly 1`] = `
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-order"
+                      >
+                        Order results
+                      </label>
                       <select
-                        id={1}
+                        id="1-order"
                         onChange={[Function]}
                         value="title"
                       >

--- a/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourceCollectionsList-test.js.snap
+++ b/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourceCollectionsList-test.js.snap
@@ -114,7 +114,16 @@ Array [
           <div
             className="ReactCollapse--content"
           >
-            <div>
+            <div
+              aria-labelledby="1-header"
+              role="group"
+            >
+              <p
+                className="screen-reader-text"
+                id="1-header"
+              >
+                Search options
+              </p>
               <div
                 className="entity-list-search__options entity-list-search__options--horizontal"
               >
@@ -132,8 +141,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-order"
+                      >
+                        Order results
+                      </label>
                       <select
-                        id={1}
+                        id="1-order"
                         onChange={[Function]}
                         value="title"
                       >

--- a/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourcesList-test.js.snap
+++ b/client/src/backend/containers/project/resource/__tests__/__snapshots__/ResourcesList-test.js.snap
@@ -114,7 +114,16 @@ Array [
           <div
             className="ReactCollapse--content"
           >
-            <div>
+            <div
+              aria-labelledby="1-header"
+              role="group"
+            >
+              <p
+                className="screen-reader-text"
+                id="1-header"
+              >
+                Search options
+              </p>
               <div
                 className="entity-list-search__options entity-list-search__options--horizontal"
               >
@@ -132,8 +141,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-filter-0"
+                      >
+                        Filter results by Tag
+                      </label>
                       <select
-                        id={1}
+                        id="1-filter-0"
                         onChange={[Function]}
                         value=""
                       >
@@ -173,8 +188,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-filter-1"
+                      >
+                        Filter results by Kind
+                      </label>
                       <select
-                        id={1}
+                        id="1-filter-1"
                         onChange={[Function]}
                         value=""
                       >
@@ -214,8 +235,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-order"
+                      >
+                        Order results
+                      </label>
                       <select
-                        id={1}
+                        id="1-order"
                         onChange={[Function]}
                         value="title"
                       >

--- a/client/src/backend/containers/resource-collection/__tests__/__snapshots__/Resources-test.js.snap
+++ b/client/src/backend/containers/resource-collection/__tests__/__snapshots__/Resources-test.js.snap
@@ -129,7 +129,16 @@ Array [
           <div
             className="ReactCollapse--content"
           >
-            <div>
+            <div
+              aria-labelledby="1-header"
+              role="group"
+            >
+              <p
+                className="screen-reader-text"
+                id="1-header"
+              >
+                Search options
+              </p>
               <div
                 className="entity-list-search__options entity-list-search__options--horizontal"
               >
@@ -147,8 +156,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-filter-0"
+                      >
+                        Filter results by Tag
+                      </label>
                       <select
-                        id={1}
+                        id="1-filter-0"
                         onChange={[Function]}
                         value=""
                       >
@@ -188,8 +203,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-filter-1"
+                      >
+                        Filter results by Kind
+                      </label>
                       <select
-                        id={1}
+                        id="1-filter-1"
                         onChange={[Function]}
                         value=""
                       >
@@ -229,8 +250,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-order"
+                      >
+                        Order results
+                      </label>
                       <select
-                        id={1}
+                        id="1-order"
                         onChange={[Function]}
                         value="title"
                       >

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Email-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Email-test.js.snap
@@ -31,12 +31,17 @@ exports[`Backend Settings Email Container when delivery method is sendmail rende
             onSubmit={[Function]}
           >
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Message Settings
                 </h2>
               </header>
@@ -179,12 +184,17 @@ The Manifold Team"
               </div>
             </div>
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Email Delivery Method
                 </h2>
               </header>
@@ -247,12 +257,17 @@ The Manifold Team"
               </div>
             </div>
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Sendmail Configuration
                 </h2>
               </header>
@@ -365,12 +380,17 @@ exports[`Backend Settings Email Container when delivery method is smtp renders c
             onSubmit={[Function]}
           >
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Message Settings
                 </h2>
               </header>
@@ -513,12 +533,17 @@ The Manifold Team"
               </div>
             </div>
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Email Delivery Method
                 </h2>
               </header>
@@ -581,12 +606,17 @@ The Manifold Team"
               </div>
             </div>
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   SMTP Configuration
                 </h2>
               </header>

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Integrations-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Integrations-test.js.snap
@@ -31,12 +31,17 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
             onSubmit={[Function]}
           >
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Facebook
                 </h2>
               </header>
@@ -82,12 +87,17 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
               </div>
             </div>
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Twitter
                 </h2>
               </header>
@@ -169,12 +179,17 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
               </div>
             </div>
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Google Services Integration
                 </h2>
               </header>
@@ -362,12 +377,17 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
               </div>
             </div>
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Google OAuth
                 </h2>
               </header>
@@ -413,12 +433,17 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
               </div>
             </div>
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Google Analytics
                 </h2>
               </header>

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Theme-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Theme-test.js.snap
@@ -31,12 +31,17 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
             onSubmit={[Function]}
           >
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Branding
                 </h2>
               </header>
@@ -465,12 +470,17 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
               </div>
             </div>
             <div
+              aria-describedby="1-instructions"
+              aria-labelledby="1-header"
               className="form-section"
+              role="group"
             >
               <header
                 className="form-section-label"
               >
-                <h2>
+                <h2
+                  id="1-header"
+                >
                   Typography
                 </h2>
               </header>

--- a/client/src/backend/containers/text/__tests__/__snapshots__/Metadata-test.js.snap
+++ b/client/src/backend/containers/text/__tests__/__snapshots__/Metadata-test.js.snap
@@ -16,718 +16,726 @@ exports[`Backend Text Metadata Container renders correctly 1`] = `
                         <Prompt when={false} message=\\"You may have unsaved changes. Do you want to leave without saving your changes?\\" />
                         <form onSubmit={[Function]} className=\\"form-secondary\\" data-id=\\"submit\\">
                           <FieldGroup label=\\"Identity\\" disabled={false} horizontal={false} wide={false} instructions={{...}}>
-                            <div className=\\"form-section\\">
-                              <header className=\\"form-section-label\\">
-                                <h2>
-                                  Identity
-                                </h2>
-                              </header>
-                              <Instructions instructions={{...}} />
-                              <div className=\\"form-input-group\\">
-                                <Form.TextInput focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][isbn]\\" errors={{...}} label=\\"isbn\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                isbn
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"International Standard Book Number\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][issn]\\" errors={{...}} label=\\"issn\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                issn
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"International Standard Serial Number\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
+                            <mockConstructor name={[Function: name]}>
+                              <div className=\\"form-section\\" role=\\"group\\" aria-labelledby=\\"1-header\\" aria-describedby=\\"1-instructions\\">
+                                <header className=\\"form-section-label\\">
+                                  <h2 id=\\"1-header\\">
+                                    Identity
+                                  </h2>
+                                </header>
+                                <Instructions id=\\"1-instructions\\" instructions={{...}} />
+                                <div className=\\"form-input-group\\">
+                                  <Form.TextInput focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={true} placeholder=\\"International Standard Book Number\\" instructions={[undefined]} label=\\"isbn\\" name=\\"attributes[metadata][isbn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][isbn]\\" errors={{...}} label=\\"isbn\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  isbn
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"International Standard Book Number\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"International Standard Serial Number\\" instructions={[undefined]} label=\\"issn\\" name=\\"attributes[metadata][issn]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][issn]\\" errors={{...}} label=\\"issn\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  issn
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"International Standard Serial Number\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                </div>
                               </div>
-                            </div>
+                            </mockConstructor>
                           </FieldGroup>
                           <FieldGroup label=\\"Publisher\\" disabled={false} horizontal={false} wide={false} instructions={{...}}>
-                            <div className=\\"form-section\\">
-                              <header className=\\"form-section-label\\">
-                                <h2>
-                                  Publisher
-                                </h2>
-                              </header>
-                              <Instructions instructions={{...}} />
-                              <div className=\\"form-input-group\\">
-                                <Form.TextInput focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][publisher]\\" errors={{...}} label=\\"publisher\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                publisher
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"The Publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][publisherPlace]\\" errors={{...}} label=\\"publisher place\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
-                                                publisher place
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Geographic location of the publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions=\\"e.g \\"Minneapolis, MN\\"\\" id=\\"text-input-instructions-1\\">
-                                                <span className=\\"instructions\\" id=\\"text-input-instructions-1\\">
-                                                  e.g &quot;Minneapolis, MN&quot;
-                                                </span>
-                                              </Instructions>
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalPublisher]\\" errors={{...}} label=\\"original publisher\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                original publisher
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalPublisherPlace]\\" errors={{...}} label=\\"original publisher place\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                original publisher place
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Geographic location of the original publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
+                            <mockConstructor name={[Function: name]}>
+                              <div className=\\"form-section\\" role=\\"group\\" aria-labelledby=\\"1-header\\" aria-describedby=\\"1-instructions\\">
+                                <header className=\\"form-section-label\\">
+                                  <h2 id=\\"1-header\\">
+                                    Publisher
+                                  </h2>
+                                </header>
+                                <Instructions id=\\"1-instructions\\" instructions={{...}} />
+                                <div className=\\"form-input-group\\">
+                                  <Form.TextInput focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"The Publisher\\" instructions={[undefined]} label=\\"publisher\\" name=\\"attributes[metadata][publisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][publisher]\\" errors={{...}} label=\\"publisher\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  publisher
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"The Publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the publisher\\" instructions=\\"e.g \\"Minneapolis, MN\\"\\" label=\\"publisher place\\" name=\\"attributes[metadata][publisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][publisherPlace]\\" errors={{...}} label=\\"publisher place\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
+                                                  publisher place
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Geographic location of the publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions=\\"e.g \\"Minneapolis, MN\\"\\" id=\\"text-input-instructions-1\\">
+                                                  <span className=\\"instructions\\" id=\\"text-input-instructions-1\\">
+                                                    e.g &quot;Minneapolis, MN&quot;
+                                                  </span>
+                                                </Instructions>
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" instructions={[undefined]} label=\\"original publisher\\" name=\\"attributes[metadata][originalPublisher]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalPublisher]\\" errors={{...}} label=\\"original publisher\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  original publisher
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Original publisher, for items that have been republished by a different publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Geographic location of the original publisher\\" instructions={[undefined]} label=\\"original publisher place\\" name=\\"attributes[metadata][originalPublisherPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalPublisherPlace]\\" errors={{...}} label=\\"original publisher place\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  original publisher place
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Geographic location of the original publisher\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                </div>
                               </div>
-                            </div>
+                            </mockConstructor>
                           </FieldGroup>
                           <FieldGroup label=\\"Bibliographic\\" disabled={false} horizontal={false} wide={false} instructions={{...}}>
-                            <div className=\\"form-section\\">
-                              <header className=\\"form-section-label\\">
-                                <h2>
-                                  Bibliographic
-                                </h2>
-                              </header>
-                              <Instructions instructions={{...}} />
-                              <div className=\\"form-input-group\\">
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][containerTitle]\\" errors={{...}} label=\\"container title\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
-                                                container title
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Title of the container holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" id=\\"text-input-instructions-1\\">
-                                                <span className=\\"instructions\\" id=\\"text-input-instructions-1\\">
-                                                  e.g. the book title for a book chapter, the journal title for a journal article
-                                                </span>
-                                              </Instructions>
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][version]\\" errors={{...}} label=\\"version\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                version
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Version of the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][edition]\\" errors={{...}} label=\\"edition\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
-                                                edition
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"(Container) edition holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" id=\\"text-input-instructions-1\\">
-                                                <span className=\\"instructions\\" id=\\"text-input-instructions-1\\">
-                                                  e.g. &quot;3&quot; when citing a chapter in the third edition of a book
-                                                </span>
-                                              </Instructions>
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][issue]\\" errors={{...}} label=\\"issue\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
-                                                issue
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"(Container) issue holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" id=\\"text-input-instructions-1\\">
-                                                <span className=\\"instructions\\" id=\\"text-input-instructions-1\\">
-                                                  e.g. &quot;5&quot; when citing a journal article from journal volume 2, issue 5
-                                                </span>
-                                              </Instructions>
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][volume]\\" errors={{...}} label=\\"volume\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
-                                                volume
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"(Container) volume holding the item \\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" id=\\"text-input-instructions-1\\">
-                                                <span className=\\"instructions\\" id=\\"text-input-instructions-1\\">
-                                                  e.g. “2” when citing a chapter from book volume 2
-                                                </span>
-                                              </Instructions>
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalTitle]\\" errors={{...}} label=\\"original title\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                original title
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Title of the original version\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
+                            <mockConstructor name={[Function: name]}>
+                              <div className=\\"form-section\\" role=\\"group\\" aria-labelledby=\\"1-header\\" aria-describedby=\\"1-instructions\\">
+                                <header className=\\"form-section-label\\">
+                                  <h2 id=\\"1-header\\">
+                                    Bibliographic
+                                  </h2>
+                                </header>
+                                <Instructions id=\\"1-instructions\\" instructions={{...}} />
+                                <div className=\\"form-input-group\\">
+                                  <Form.TextInput focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the container holding the item\\" instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" label=\\"container title\\" name=\\"attributes[metadata][containerTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][containerTitle]\\" errors={{...}} label=\\"container title\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
+                                                  container title
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Title of the container holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions=\\"e.g. the book title for a book chapter, the journal title for a journal article\\" id=\\"text-input-instructions-1\\">
+                                                  <span className=\\"instructions\\" id=\\"text-input-instructions-1\\">
+                                                    e.g. the book title for a book chapter, the journal title for a journal article
+                                                  </span>
+                                                </Instructions>
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Version of the item\\" instructions={[undefined]} label=\\"version\\" name=\\"attributes[metadata][version]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][version]\\" errors={{...}} label=\\"version\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  version
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Version of the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) edition holding the item\\" instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" label=\\"edition\\" name=\\"attributes[metadata][edition]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][edition]\\" errors={{...}} label=\\"edition\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
+                                                  edition
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"(Container) edition holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions=\\"e.g. \\"3\\" when citing a chapter in the third edition of a book\\" id=\\"text-input-instructions-1\\">
+                                                  <span className=\\"instructions\\" id=\\"text-input-instructions-1\\">
+                                                    e.g. &quot;3&quot; when citing a chapter in the third edition of a book
+                                                  </span>
+                                                </Instructions>
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) issue holding the item\\" instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" label=\\"issue\\" name=\\"attributes[metadata][issue]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][issue]\\" errors={{...}} label=\\"issue\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
+                                                  issue
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"(Container) issue holding the item\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions=\\"e.g. \\"5\\" when citing a journal article from journal volume 2, issue 5\\" id=\\"text-input-instructions-1\\">
+                                                  <span className=\\"instructions\\" id=\\"text-input-instructions-1\\">
+                                                    e.g. &quot;5&quot; when citing a journal article from journal volume 2, issue 5
+                                                  </span>
+                                                </Instructions>
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"(Container) volume holding the item \\" instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" label=\\"volume\\" name=\\"attributes[metadata][volume]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][volume]\\" errors={{...}} label=\\"volume\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"has-instructions\\">
+                                                  volume
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"(Container) volume holding the item \\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions=\\"e.g. “2” when citing a chapter from book volume 2\\" id=\\"text-input-instructions-1\\">
+                                                  <span className=\\"instructions\\" id=\\"text-input-instructions-1\\">
+                                                    e.g. “2” when citing a chapter from book volume 2
+                                                  </span>
+                                                </Instructions>
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder=\\"Title of the original version\\" instructions={[undefined]} label=\\"original title\\" name=\\"attributes[metadata][originalTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][originalTitle]\\" errors={{...}} label=\\"original title\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  original title
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder=\\"Title of the original version\\" onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                </div>
                               </div>
-                            </div>
+                            </mockConstructor>
                           </FieldGroup>
                           <FieldGroup label=\\"Other\\" disabled={false} horizontal={false} wide={false} instructions={{...}}>
-                            <div className=\\"form-section\\">
-                              <header className=\\"form-section-label\\">
-                                <h2>
-                                  Other
-                                </h2>
-                              </header>
-                              <Instructions instructions={{...}} />
-                              <div className=\\"form-input-group\\">
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][abstract]\\" errors={{...}} label=\\"abstract\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                abstract
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archive]\\" errors={{...}} label=\\"archive\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                archive
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archiveLocation]\\" errors={{...}} label=\\"archive location\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                archive location
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archivePlace]\\" errors={{...}} label=\\"archive place\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                archive place
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][authority]\\" errors={{...}} label=\\"authority\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                authority
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][callNumber]\\" errors={{...}} label=\\"call number\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                call number
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][chapterNumber]\\" errors={{...}} label=\\"chapter number\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                chapter number
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][collectionNumber]\\" errors={{...}} label=\\"collection number\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                collection number
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][collectionTitle]\\" errors={{...}} label=\\"collection title\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                collection title
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][dimensions]\\" errors={{...}} label=\\"dimensions\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                dimensions
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][event]\\" errors={{...}} label=\\"event\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                event
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][eventPlace]\\" errors={{...}} label=\\"event place\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                event place
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][jurisdiction]\\" errors={{...}} label=\\"jurisdiction\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                jurisdiction
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][medium]\\" errors={{...}} label=\\"medium\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                medium
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][number]\\" errors={{...}} label=\\"number\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                number
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][numberOfPages]\\" errors={{...}} label=\\"number of pages\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                number of pages
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][numberOfVolumes]\\" errors={{...}} label=\\"number of volumes\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                number of volumes
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][pmcid]\\" errors={{...}} label=\\"pmcid\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                pmcid
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][pmid]\\" errors={{...}} label=\\"pmid\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                pmid
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][reviewedTitle]\\" errors={{...}} label=\\"reviewed title\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                reviewed title
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][section]\\" errors={{...}} label=\\"section\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                section
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
-                                <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} disabled={false}>
-                                  <mockConstructor>
-                                    <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                      <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
-                                        <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
-                                          <Errorable className=\\"form-input\\" name=\\"attributes[metadata][yearSuffix]\\" errors={{...}} label=\\"year suffix\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
-                                            <div style={{...}} className=\\"form-input\\">
-                                              <label htmlFor=\\"text-input-1\\" className=\\"\\">
-                                                year suffix
-                                              </label>
-                                              <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
-                                              <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
-                                            </div>
-                                          </Errorable>
-                                        </Form.BaseInput>
-                                      </Form.Setter('Form.BaseInput)>
-                                    </HigherOrder.FetchData('Form.BaseInput)>
-                                  </mockConstructor>
-                                </Form.TextInput>
+                            <mockConstructor name={[Function: name]}>
+                              <div className=\\"form-section\\" role=\\"group\\" aria-labelledby=\\"1-header\\" aria-describedby=\\"1-instructions\\">
+                                <header className=\\"form-section-label\\">
+                                  <h2 id=\\"1-header\\">
+                                    Other
+                                  </h2>
+                                </header>
+                                <Instructions id=\\"1-instructions\\" instructions={{...}} />
+                                <div className=\\"form-input-group\\">
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"abstract\\" name=\\"attributes[metadata][abstract]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][abstract]\\" errors={{...}} label=\\"abstract\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  abstract
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive\\" name=\\"attributes[metadata][archive]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archive]\\" errors={{...}} label=\\"archive\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  archive
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive location\\" name=\\"attributes[metadata][archiveLocation]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archiveLocation]\\" errors={{...}} label=\\"archive location\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  archive location
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"archive place\\" name=\\"attributes[metadata][archivePlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][archivePlace]\\" errors={{...}} label=\\"archive place\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  archive place
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"authority\\" name=\\"attributes[metadata][authority]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][authority]\\" errors={{...}} label=\\"authority\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  authority
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"call number\\" name=\\"attributes[metadata][callNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][callNumber]\\" errors={{...}} label=\\"call number\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  call number
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"chapter number\\" name=\\"attributes[metadata][chapterNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][chapterNumber]\\" errors={{...}} label=\\"chapter number\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  chapter number
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection number\\" name=\\"attributes[metadata][collectionNumber]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][collectionNumber]\\" errors={{...}} label=\\"collection number\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  collection number
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"collection title\\" name=\\"attributes[metadata][collectionTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][collectionTitle]\\" errors={{...}} label=\\"collection title\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  collection title
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"dimensions\\" name=\\"attributes[metadata][dimensions]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][dimensions]\\" errors={{...}} label=\\"dimensions\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  dimensions
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event\\" name=\\"attributes[metadata][event]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][event]\\" errors={{...}} label=\\"event\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  event
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"event place\\" name=\\"attributes[metadata][eventPlace]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][eventPlace]\\" errors={{...}} label=\\"event place\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  event place
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"jurisdiction\\" name=\\"attributes[metadata][jurisdiction]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][jurisdiction]\\" errors={{...}} label=\\"jurisdiction\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  jurisdiction
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"medium\\" name=\\"attributes[metadata][medium]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][medium]\\" errors={{...}} label=\\"medium\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  medium
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number\\" name=\\"attributes[metadata][number]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][number]\\" errors={{...}} label=\\"number\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  number
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of pages\\" name=\\"attributes[metadata][numberOfPages]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][numberOfPages]\\" errors={{...}} label=\\"number of pages\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  number of pages
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"number of volumes\\" name=\\"attributes[metadata][numberOfVolumes]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][numberOfVolumes]\\" errors={{...}} label=\\"number of volumes\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  number of volumes
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmcid\\" name=\\"attributes[metadata][pmcid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][pmcid]\\" errors={{...}} label=\\"pmcid\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  pmcid
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"pmid\\" name=\\"attributes[metadata][pmid]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][pmid]\\" errors={{...}} label=\\"pmid\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  pmid
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"reviewed title\\" name=\\"attributes[metadata][reviewedTitle]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][reviewedTitle]\\" errors={{...}} label=\\"reviewed title\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  reviewed title
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"section\\" name=\\"attributes[metadata][section]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][section]\\" errors={{...}} label=\\"section\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  section
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                  <Form.TextInput focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} disabled={false}>
+                                    <mockConstructor>
+                                      <HigherOrder.FetchData('Form.BaseInput) focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                        <Form.Setter('Form.BaseInput) actions={{...}} dirtyModel={{...}} sourceModel={{...}} getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]}>
+                                          <Form.BaseInput getModelValue={[Function: getModelValue]} sessionKey=\\"backend-project-general\\" submitKey={{...}} errors={{...}} focusOnMount={false} placeholder={{...}} instructions={{...}} label=\\"year suffix\\" name=\\"attributes[metadata][yearSuffix]\\" password={false} join={[Function: join]} disabled={false} id=\\"text-input-1\\" idForError=\\"text-input-error-1\\" idForInstructions=\\"text-input-instructions-1\\" inputType=\\"text\\" renderValue={[Function]} onChange={[Function]} set={[Function]} setOther={[Function]} value={[undefined]} initialValue={[undefined]}>
+                                            <Errorable className=\\"form-input\\" name=\\"attributes[metadata][yearSuffix]\\" errors={{...}} label=\\"year suffix\\" idForError=\\"text-input-error-1\\" containerStyle={{...}}>
+                                              <div style={{...}} className=\\"form-input\\">
+                                                <label htmlFor=\\"text-input-1\\" className=\\"\\">
+                                                  year suffix
+                                                </label>
+                                                <input id=\\"text-input-1\\" type=\\"text\\" placeholder={{...}} onChange={[Function]} value=\\"\\" aria-describedby=\\"text-input-error-1 text-input-instructions-1\\" />
+                                                <Instructions instructions={{...}} id=\\"text-input-instructions-1\\" />
+                                              </div>
+                                            </Errorable>
+                                          </Form.BaseInput>
+                                        </Form.Setter('Form.BaseInput)>
+                                      </HigherOrder.FetchData('Form.BaseInput)>
+                                    </mockConstructor>
+                                  </Form.TextInput>
+                                </div>
                               </div>
-                            </div>
+                            </mockConstructor>
                           </FieldGroup>
                           <Form.Save text=\\"Save Metadata\\">
                             <div className=\\"form-input submit wide\\">

--- a/client/src/backend/containers/users/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/backend/containers/users/__tests__/__snapshots__/List-test.js.snap
@@ -114,7 +114,16 @@ Array [
           <div
             className="ReactCollapse--content"
           >
-            <div>
+            <div
+              aria-labelledby="1-header"
+              role="group"
+            >
+              <p
+                className="screen-reader-text"
+                id="1-header"
+              >
+                Search options
+              </p>
               <div
                 className="entity-list-search__options entity-list-search__options--horizontal"
               >
@@ -132,8 +141,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-filter-0"
+                      >
+                        Filter results by Role
+                      </label>
                       <select
-                        id={1}
+                        id="1-filter-0"
                         onChange={[Function]}
                         value=""
                       >
@@ -198,8 +213,14 @@ Array [
                     <div
                       className="entity-list-search__select-wrapper"
                     >
+                      <label
+                        className="screen-reader-text"
+                        htmlFor="1-order"
+                      >
+                        Order results
+                      </label>
                       <select
-                        id={1}
+                        id="1-order"
                         onChange={[Function]}
                         value="last_name"
                       >

--- a/client/src/frontend/containers/Search/__tests__/__snapshots__/Search-test.js.snap
+++ b/client/src/frontend/containers/Search/__tests__/__snapshots__/Search-test.js.snap
@@ -64,10 +64,13 @@ exports[`Frontend SearchContainer renders correctly 1`] = `
           </button>
         </div>
         <div
+          aria-labelledby="show-results-for-header"
           className="filters"
+          role="group"
         >
           <h4
             className="group-label"
+            id="show-results-for-header"
           >
             Show Results For:
           </h4>

--- a/client/src/frontend/containers/Subscriptions/__tests__/__snapshots__/Subscriptions-test.js.snap
+++ b/client/src/frontend/containers/Subscriptions/__tests__/__snapshots__/Subscriptions-test.js.snap
@@ -26,159 +26,173 @@ exports[`Frontend Subscriptions Container renders correctly 1`] = `
       <div
         className="subscriptions"
       >
-        <h2
-          className="section-heading-secondary"
-        >
-          Project Activity
-        </h2>
         <div
-          className="form-group"
+          aria-describedby="1-instructions"
+          aria-labelledby="1-header"
+          role="group"
         >
+          <h2
+            className="section-heading-secondary"
+            id="1-header"
+          >
+            Project Activity
+          </h2>
           <div
-            className="form-input"
+            className="form-group"
           >
-            <span
-              className="instructions"
+            <div
+              className="form-input"
             >
-              Manifold can send you a daily or weekly email with information about texts,
-            resources, and resource collections that have been added to projects.
-            </span>
+              <span
+                className="instructions"
+                id="1-instructions"
+              >
+                Manifold can send you a daily or weekly email with information about texts,
+                  resources, and resource collections that have been added to projects.
+              </span>
+            </div>
+            <fieldset
+              className="subscriptions__radio-group form-input"
+            >
+              <legend
+                className="subscriptions__legend"
+              >
+                How often would you like to be notified?
+              </legend>
+              <label
+                className="form-toggle radio inline"
+              >
+                <input
+                  checked={false}
+                  name="digest"
+                  onChange={[Function]}
+                  type="radio"
+                  value="never"
+                />
+                <span
+                  className="toggle-indicator"
+                />
+                <span
+                  className="toggle-label"
+                >
+                  Never
+                </span>
+              </label>
+              <label
+                className="form-toggle radio inline checked"
+              >
+                <input
+                  checked={true}
+                  name="digest"
+                  onChange={[Function]}
+                  type="radio"
+                  value="daily"
+                />
+                <span
+                  className="toggle-indicator"
+                >
+                  <i
+                    className="manicon"
+                  />
+                </span>
+                <span
+                  className="toggle-label"
+                >
+                  Daily
+                </span>
+              </label>
+              <label
+                className="form-toggle radio inline"
+              >
+                <input
+                  checked={false}
+                  name="digest"
+                  onChange={[Function]}
+                  type="radio"
+                  value="weekly"
+                />
+                <span
+                  className="toggle-indicator"
+                />
+                <span
+                  className="toggle-label"
+                >
+                  Weekly
+                </span>
+              </label>
+            </fieldset>
           </div>
-          <fieldset
-            className="subscriptions__radio-group form-input"
-          >
-            <legend
-              className="subscriptions__legend"
-            >
-              How often would you like to be notified?
-            </legend>
-            <label
-              className="form-toggle radio inline"
-            >
-              <input
-                checked={false}
-                name="digest"
-                onChange={[Function]}
-                type="radio"
-                value="never"
-              />
-              <span
-                className="toggle-indicator"
-              />
-              <span
-                className="toggle-label"
-              >
-                Never
-              </span>
-            </label>
-            <label
-              className="form-toggle radio inline checked"
-            >
-              <input
-                checked={true}
-                name="digest"
-                onChange={[Function]}
-                type="radio"
-                value="daily"
-              />
-              <span
-                className="toggle-indicator"
-              >
-                <i
-                  className="manicon"
-                />
-              </span>
-              <span
-                className="toggle-label"
-              >
-                Daily
-              </span>
-            </label>
-            <label
-              className="form-toggle radio inline"
-            >
-              <input
-                checked={false}
-                name="digest"
-                onChange={[Function]}
-                type="radio"
-                value="weekly"
-              />
-              <span
-                className="toggle-indicator"
-              />
-              <span
-                className="toggle-label"
-              >
-                Weekly
-              </span>
-            </label>
-          </fieldset>
         </div>
-        <h2
-          className="section-heading-secondary"
-        >
-          Other Activity
-        </h2>
         <div
-          className="form-group"
+          aria-labelledby="1-header"
+          role="group"
         >
-          <fieldset
-            className="subscriptions__radio-group form-input"
+          <h2
+            className="section-heading-secondary"
+            id="1-header"
           >
-            <legend
-              className="subscriptions__legend"
+            Other Activity
+          </h2>
+          <div
+            className="form-group"
+          >
+            <fieldset
+              className="subscriptions__radio-group form-input"
             >
-              Notify you when someone replies to you?
-            </legend>
-            <span
-              className="instructions"
-            >
-              Manifold will send you an email when a reply is posted to your annotations or comments.
-            </span>
-            <label
-              className="form-toggle radio inline"
-            >
-              <input
-                checked={false}
-                name="repliesToMe"
-                onChange={[Function]}
-                type="radio"
-                value="never"
-              />
-              <span
-                className="toggle-indicator"
-              />
-              <span
-                className="toggle-label"
+              <legend
+                className="subscriptions__legend"
               >
-                No
+                Notify you when someone replies to you?
+              </legend>
+              <span
+                className="instructions"
+              >
+                Manifold will send you an email when a reply is posted to your annotations or comments.
               </span>
-            </label>
-            <label
-              className="form-toggle radio inline checked"
-            >
-              <input
-                checked={true}
-                name="repliesToMe"
-                onChange={[Function]}
-                type="radio"
-                value="always"
-              />
-              <span
-                className="toggle-indicator"
+              <label
+                className="form-toggle radio inline"
               >
-                <i
-                  className="manicon"
+                <input
+                  checked={false}
+                  name="repliesToMe"
+                  onChange={[Function]}
+                  type="radio"
+                  value="never"
                 />
-              </span>
-              <span
-                className="toggle-label"
+                <span
+                  className="toggle-indicator"
+                />
+                <span
+                  className="toggle-label"
+                >
+                  No
+                </span>
+              </label>
+              <label
+                className="form-toggle radio inline checked"
               >
-                Yes
-              </span>
-            </label>
-          </fieldset>
+                <input
+                  checked={true}
+                  name="repliesToMe"
+                  onChange={[Function]}
+                  type="radio"
+                  value="always"
+                />
+                <span
+                  className="toggle-indicator"
+                >
+                  <i
+                    className="manicon"
+                  />
+                </span>
+                <span
+                  className="toggle-label"
+                >
+                  Yes
+                </span>
+              </label>
+            </fieldset>
+          </div>
         </div>
         <button
           className="utility-button"

--- a/client/src/global/components/preferences/NotificationsForm.js
+++ b/client/src/global/components/preferences/NotificationsForm.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import config from "config";
 import { Collapse } from "react-collapse";
 import classNames from "classnames";
+import { UID } from "react-uid";
 
 export default class NotificationsForm extends Component {
   static propTypes = {
@@ -21,23 +22,43 @@ export default class NotificationsForm extends Component {
 
     return (
       <div className="subscriptions">
-        <h2 className="section-heading-secondary">Project Activity</h2>
-        <div className="form-group">
-          <div className="form-input">
-            <span className="instructions">
-              {`Manifold can send you a daily or weekly email with information about texts,
-            resources, and resource collections that have been added to projects.`}
-            </span>
-          </div>
-          {this.renderDigestFrequency(preferences)}
-          <Collapse isOpened={digestOpen}>
-            {this.renderDigestContent(preferences, digestOpen)}
-          </Collapse>
-        </div>
-        <h2 className="section-heading-secondary">Other Activity</h2>
-        <div className="form-group">
-          {this.renderNotificationContent(preferences)}
-        </div>
+        <UID name={id => `project-activity-${id}`}>
+          {id => (
+            <div
+              role="group"
+              aria-labelledby={`${id}-header`}
+              aria-describedby={`${id}-instructions`}
+            >
+              <h2 id={`${id}-header`} className="section-heading-secondary">
+                Project Activity
+              </h2>
+              <div className="form-group">
+                <div className="form-input">
+                  <span id={`${id}-instructions`} className="instructions">
+                    {`Manifold can send you a daily or weekly email with information about texts,
+                  resources, and resource collections that have been added to projects.`}
+                  </span>
+                </div>
+                {this.renderDigestFrequency(preferences)}
+                <Collapse isOpened={digestOpen}>
+                  {this.renderDigestContent(preferences, digestOpen)}
+                </Collapse>
+              </div>
+            </div>
+          )}
+        </UID>
+        <UID name={id => `other-activity-${id}`}>
+          {id => (
+            <div role="group" aria-labelledby={`${id}-header`}>
+              <h2 id={`${id}-header`} className="section-heading-secondary">
+                Other Activity
+              </h2>
+              <div className="form-group">
+                {this.renderNotificationContent(preferences)}
+              </div>
+            </div>
+          )}
+        </UID>
         <button
           className="utility-button"
           onClick={this.props.unsubscribeAllHandler}

--- a/client/src/global/components/preferences/__tests__/__snapshots__/NotificationsForm-test.js.snap
+++ b/client/src/global/components/preferences/__tests__/__snapshots__/NotificationsForm-test.js.snap
@@ -4,159 +4,173 @@ exports[`Global.Preferences.NotificationsForm component renders correctly 1`] = 
 <div
   className="subscriptions"
 >
-  <h2
-    className="section-heading-secondary"
-  >
-    Project Activity
-  </h2>
   <div
-    className="form-group"
+    aria-describedby="1-instructions"
+    aria-labelledby="1-header"
+    role="group"
   >
+    <h2
+      className="section-heading-secondary"
+      id="1-header"
+    >
+      Project Activity
+    </h2>
     <div
-      className="form-input"
+      className="form-group"
     >
-      <span
-        className="instructions"
+      <div
+        className="form-input"
       >
-        Manifold can send you a daily or weekly email with information about texts,
-            resources, and resource collections that have been added to projects.
-      </span>
+        <span
+          className="instructions"
+          id="1-instructions"
+        >
+          Manifold can send you a daily or weekly email with information about texts,
+                  resources, and resource collections that have been added to projects.
+        </span>
+      </div>
+      <fieldset
+        className="subscriptions__radio-group form-input"
+      >
+        <legend
+          className="subscriptions__legend"
+        >
+          How often would you like to be notified?
+        </legend>
+        <label
+          className="form-toggle radio inline"
+        >
+          <input
+            checked={false}
+            name="digest"
+            onChange={[MockFunction]}
+            type="radio"
+            value="never"
+          />
+          <span
+            className="toggle-indicator"
+          />
+          <span
+            className="toggle-label"
+          >
+            Never
+          </span>
+        </label>
+        <label
+          className="form-toggle radio inline checked"
+        >
+          <input
+            checked={true}
+            name="digest"
+            onChange={[MockFunction]}
+            type="radio"
+            value="daily"
+          />
+          <span
+            className="toggle-indicator"
+          >
+            <i
+              className="manicon"
+            />
+          </span>
+          <span
+            className="toggle-label"
+          >
+            Daily
+          </span>
+        </label>
+        <label
+          className="form-toggle radio inline"
+        >
+          <input
+            checked={false}
+            name="digest"
+            onChange={[MockFunction]}
+            type="radio"
+            value="weekly"
+          />
+          <span
+            className="toggle-indicator"
+          />
+          <span
+            className="toggle-label"
+          >
+            Weekly
+          </span>
+        </label>
+      </fieldset>
     </div>
-    <fieldset
-      className="subscriptions__radio-group form-input"
-    >
-      <legend
-        className="subscriptions__legend"
-      >
-        How often would you like to be notified?
-      </legend>
-      <label
-        className="form-toggle radio inline"
-      >
-        <input
-          checked={false}
-          name="digest"
-          onChange={[MockFunction]}
-          type="radio"
-          value="never"
-        />
-        <span
-          className="toggle-indicator"
-        />
-        <span
-          className="toggle-label"
-        >
-          Never
-        </span>
-      </label>
-      <label
-        className="form-toggle radio inline checked"
-      >
-        <input
-          checked={true}
-          name="digest"
-          onChange={[MockFunction]}
-          type="radio"
-          value="daily"
-        />
-        <span
-          className="toggle-indicator"
-        >
-          <i
-            className="manicon"
-          />
-        </span>
-        <span
-          className="toggle-label"
-        >
-          Daily
-        </span>
-      </label>
-      <label
-        className="form-toggle radio inline"
-      >
-        <input
-          checked={false}
-          name="digest"
-          onChange={[MockFunction]}
-          type="radio"
-          value="weekly"
-        />
-        <span
-          className="toggle-indicator"
-        />
-        <span
-          className="toggle-label"
-        >
-          Weekly
-        </span>
-      </label>
-    </fieldset>
   </div>
-  <h2
-    className="section-heading-secondary"
-  >
-    Other Activity
-  </h2>
   <div
-    className="form-group"
+    aria-labelledby="1-header"
+    role="group"
   >
-    <fieldset
-      className="subscriptions__radio-group form-input"
+    <h2
+      className="section-heading-secondary"
+      id="1-header"
     >
-      <legend
-        className="subscriptions__legend"
+      Other Activity
+    </h2>
+    <div
+      className="form-group"
+    >
+      <fieldset
+        className="subscriptions__radio-group form-input"
       >
-        Notify you when someone replies to you?
-      </legend>
-      <span
-        className="instructions"
-      >
-        Manifold will send you an email when a reply is posted to your annotations or comments.
-      </span>
-      <label
-        className="form-toggle radio inline checked"
-      >
-        <input
-          checked={true}
-          name="repliesToMe"
-          onChange={[MockFunction]}
-          type="radio"
-          value="never"
-        />
-        <span
-          className="toggle-indicator"
+        <legend
+          className="subscriptions__legend"
         >
-          <i
-            className="manicon"
+          Notify you when someone replies to you?
+        </legend>
+        <span
+          className="instructions"
+        >
+          Manifold will send you an email when a reply is posted to your annotations or comments.
+        </span>
+        <label
+          className="form-toggle radio inline checked"
+        >
+          <input
+            checked={true}
+            name="repliesToMe"
+            onChange={[MockFunction]}
+            type="radio"
+            value="never"
           />
-        </span>
-        <span
-          className="toggle-label"
+          <span
+            className="toggle-indicator"
+          >
+            <i
+              className="manicon"
+            />
+          </span>
+          <span
+            className="toggle-label"
+          >
+            No
+          </span>
+        </label>
+        <label
+          className="form-toggle radio inline"
         >
-          No
-        </span>
-      </label>
-      <label
-        className="form-toggle radio inline"
-      >
-        <input
-          checked={false}
-          name="repliesToMe"
-          onChange={[MockFunction]}
-          type="radio"
-          value="always"
-        />
-        <span
-          className="toggle-indicator"
-        />
-        <span
-          className="toggle-label"
-        >
-          Yes
-        </span>
-      </label>
-    </fieldset>
+          <input
+            checked={false}
+            name="repliesToMe"
+            onChange={[MockFunction]}
+            type="radio"
+            value="always"
+          />
+          <span
+            className="toggle-indicator"
+          />
+          <span
+            className="toggle-label"
+          >
+            Yes
+          </span>
+        </label>
+      </fieldset>
+    </div>
   </div>
   <button
     className="utility-button"

--- a/client/src/global/components/search/query/Form.js
+++ b/client/src/global/components/search/query/Form.js
@@ -266,13 +266,21 @@ export default class SearchQueryForm extends PureComponent {
           </button>
         </div>
         {this.availableScopes.length > 0 ? (
-          <div className="filters">
+          <div
+            role="group"
+            aria-labelledby="search-within-header"
+            className="filters"
+          >
             {this.props.searchType !== "reader" ? (
-              <h4 className="group-label">{"Search within:"}</h4>
+              <h4 id="search-within-header" className="group-label">
+                {"Search within:"}
+              </h4>
             ) : null}
             <div className="checkbox-group">
               {this.props.searchType === "reader" ? (
-                <h4 className="group-label">{"Search within:"}</h4>
+                <h4 id="search-within-header" className="group-label">
+                  {"Search within:"}
+                </h4>
               ) : null}
               {this.availableScopes.map((scope, index) => {
                 const filterCheckboxId = scope.value + "-" + index;
@@ -305,8 +313,14 @@ export default class SearchQueryForm extends PureComponent {
         ) : null}
 
         {this.props.facets.length > 0 ? (
-          <div className="filters">
-            <h4 className="group-label">{"Show Results For:"}</h4>
+          <div
+            role="group"
+            aria-labelledby="show-results-for-header"
+            className="filters"
+          >
+            <h4 id="show-results-for-header" className="group-label">
+              {"Show Results For:"}
+            </h4>
             <div className="checkbox-group">
               <label htmlFor="all-filters" key={"all"} className="checkbox">
                 <input

--- a/client/src/reader/components/control-menu/VisibilityMenuBody.js
+++ b/client/src/reader/components/control-menu/VisibilityMenuBody.js
@@ -42,17 +42,21 @@ export default class VisibilityMenuBody extends PureComponent {
 
     return (
       <li key={`visibility-${format}`}>
-        <IconComposer
-          icon={this.groupIcon(format)}
-          size={30.667}
-          iconClass="visibility-menu__group-icon"
-        />
-        <span>{label}</span>
-        <div className="filters">
-          {Object.keys(filterState).map((key, index) => {
-            return this.renderCheckbox(key, filterState, format, index);
-          })}
-        </div>
+        <fieldset className="visibility-menu__group">
+          <legend className="visibility-menu__legend">
+            <IconComposer
+              icon={this.groupIcon(format)}
+              size={30.667}
+              iconClass="visibility-menu__group-icon"
+            />
+            <span>{label}</span>
+          </legend>
+          <div className="visibility-menu__filters">
+            {Object.keys(filterState).map((key, index) => {
+              return this.renderCheckbox(key, filterState, format, index);
+            })}
+          </div>
+        </fieldset>
       </li>
     );
   }

--- a/client/src/reader/components/control-menu/__tests__/__snapshots__/VisibilityMenuBody-test.js.snap
+++ b/client/src/reader/components/control-menu/__tests__/__snapshots__/VisibilityMenuBody-test.js.snap
@@ -6,300 +6,324 @@ exports[`Reader.ControlMenu.VisibilityMenuBody Component renders correctly 1`] =
 >
   <ul>
     <li>
-      <svg
-        className="manicon-svg visibility-menu__group-icon svg-icon--"
-        height={30.667}
-        style={
-          Object {
-            "backgroundColor": "yellow",
-          }
-        }
-        viewBox="0 0 64 64"
-        width={30.667}
-        xmlns="http://www.w3.org/2000/svg"
+      <fieldset
+        className="visibility-menu__group"
       >
-        <g
-          fill="none"
-          fillRule="evenodd"
+        <legend
+          className="visibility-menu__legend"
         >
-          <path
-            d="M34.599464,6.55235632 L59.0158347,51.5697026 C59.8057661,53.0261278 59.2654662,54.8471596 57.809041,55.6370911 C57.369926,55.8752569 56.8782883,56 56.3787436,56 L7.61867231,56 C5.96181806,56 4.61867231,54.6568542 4.61867231,53 C4.61867231,52.5017228 4.74278339,52.0112922 4.97979802,51.5729953 L29.3234986,6.555649 C30.1116116,5.09823897 31.9319676,4.55566648 33.3893777,5.34377943 C33.90146,5.62069444 34.32191,6.04062003 34.599464,6.55235632 Z M32,49 C33.6568542,49 35,47.6568542 35,46 C35,44.3431458 33.6568542,43 32,43 C30.3431458,43 29,44.3431458 29,46 C29,47.6568542 30.3431458,49 32,49 Z M32.982486,40 L36,24 L28,24 L30.9870897,40 L32.982486,40 Z"
-            fill="#39ff14"
-            fillRule="nonzero"
-          />
-          <path
-            d="M34.599464,6.55235632 L59.0158347,51.5697026 C59.8057661,53.0261278 59.2654662,54.8471596 57.809041,55.6370911 C57.369926,55.8752569 56.8782883,56 56.3787436,56 L7.61867231,56 C5.96181806,56 4.61867231,54.6568542 4.61867231,53 C4.61867231,52.5017228 4.74278339,52.0112922 4.97979802,51.5729953 L29.3234986,6.555649 C30.1116116,5.09823897 31.9319676,4.55566648 33.3893777,5.34377943 C33.90146,5.62069444 34.32191,6.04062003 34.599464,6.55235632 Z M32,49 C33.6568542,49 35,47.6568542 35,46 C35,44.3431458 33.6568542,43 32,43 C30.3431458,43 29,44.3431458 29,46 C29,47.6568542 30.3431458,49 32,49 Z M32.982486,40 L36,24 L28,24 L30.9870897,40 L32.982486,40 Z"
-            fill="#39ff14"
-            fillRule="nonzero"
-          />
-        </g>
-      </svg>
-      <br />
-      <span
-        style={
-          Object {
-            "fontSize": 10,
-          }
-        }
-      >
-        
-      </span>
-      <span>
-        Highlightss
-      </span>
-      <div
-        className="filters"
-      >
-        <label
-          className="checkbox"
-          htmlFor="highlights-checkbox-0"
-        >
-          <input
-            checked={true}
-            id="highlights-checkbox-0"
-            onChange={[Function]}
-            type="checkbox"
-          />
-          <div
-            aria-hidden="true"
-            className="checkbox__indicator"
+          <svg
+            className="manicon-svg visibility-menu__group-icon svg-icon--"
+            height={30.667}
+            style={
+              Object {
+                "backgroundColor": "yellow",
+              }
+            }
+            viewBox="0 0 64 64"
+            width={30.667}
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-hidden={true}
-              className="manicon-svg checkbox__icon svg-icon--checkmark16"
-              height={16}
-              viewBox="0 0 16 16"
-              width={16}
-              xmlns="http://www.w3.org/2000/svg"
+            <g
+              fill="none"
+              fillRule="evenodd"
             >
-              <polygon
-                fill="currentColor"
+              <path
+                d="M34.599464,6.55235632 L59.0158347,51.5697026 C59.8057661,53.0261278 59.2654662,54.8471596 57.809041,55.6370911 C57.369926,55.8752569 56.8782883,56 56.3787436,56 L7.61867231,56 C5.96181806,56 4.61867231,54.6568542 4.61867231,53 C4.61867231,52.5017228 4.74278339,52.0112922 4.97979802,51.5729953 L29.3234986,6.555649 C30.1116116,5.09823897 31.9319676,4.55566648 33.3893777,5.34377943 C33.90146,5.62069444 34.32191,6.04062003 34.599464,6.55235632 Z M32,49 C33.6568542,49 35,47.6568542 35,46 C35,44.3431458 33.6568542,43 32,43 C30.3431458,43 29,44.3431458 29,46 C29,47.6568542 30.3431458,49 32,49 Z M32.982486,40 L36,24 L28,24 L30.9870897,40 L32.982486,40 Z"
+                fill="#39ff14"
                 fillRule="nonzero"
-                points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
               />
-            </svg>
-          </div>
-          Yours
-        </label>
-        <label
-          className="checkbox"
-          htmlFor="highlights-checkbox-1"
-        >
-          <input
-            checked={true}
-            id="highlights-checkbox-1"
-            onChange={[Function]}
-            type="checkbox"
-          />
-          <div
-            aria-hidden="true"
-            className="checkbox__indicator"
+              <path
+                d="M34.599464,6.55235632 L59.0158347,51.5697026 C59.8057661,53.0261278 59.2654662,54.8471596 57.809041,55.6370911 C57.369926,55.8752569 56.8782883,56 56.3787436,56 L7.61867231,56 C5.96181806,56 4.61867231,54.6568542 4.61867231,53 C4.61867231,52.5017228 4.74278339,52.0112922 4.97979802,51.5729953 L29.3234986,6.555649 C30.1116116,5.09823897 31.9319676,4.55566648 33.3893777,5.34377943 C33.90146,5.62069444 34.32191,6.04062003 34.599464,6.55235632 Z M32,49 C33.6568542,49 35,47.6568542 35,46 C35,44.3431458 33.6568542,43 32,43 C30.3431458,43 29,44.3431458 29,46 C29,47.6568542 30.3431458,49 32,49 Z M32.982486,40 L36,24 L28,24 L30.9870897,40 L32.982486,40 Z"
+                fill="#39ff14"
+                fillRule="nonzero"
+              />
+            </g>
+          </svg>
+          <br />
+          <span
+            style={
+              Object {
+                "fontSize": 10,
+              }
+            }
           >
-            <svg
-              aria-hidden={true}
-              className="manicon-svg checkbox__icon svg-icon--checkmark16"
-              height={16}
-              viewBox="0 0 16 16"
-              width={16}
-              xmlns="http://www.w3.org/2000/svg"
+            
+          </span>
+          <span>
+            Highlightss
+          </span>
+        </legend>
+        <div
+          className="visibility-menu__filters"
+        >
+          <label
+            className="checkbox"
+            htmlFor="highlights-checkbox-0"
+          >
+            <input
+              checked={true}
+              id="highlights-checkbox-0"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            <div
+              aria-hidden="true"
+              className="checkbox__indicator"
             >
-              <polygon
-                fill="currentColor"
-                fillRule="nonzero"
-                points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
-              />
-            </svg>
-          </div>
-          Others
-        </label>
-      </div>
+              <svg
+                aria-hidden={true}
+                className="manicon-svg checkbox__icon svg-icon--checkmark16"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <polygon
+                  fill="currentColor"
+                  fillRule="nonzero"
+                  points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
+                />
+              </svg>
+            </div>
+            Yours
+          </label>
+          <label
+            className="checkbox"
+            htmlFor="highlights-checkbox-1"
+          >
+            <input
+              checked={true}
+              id="highlights-checkbox-1"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            <div
+              aria-hidden="true"
+              className="checkbox__indicator"
+            >
+              <svg
+                aria-hidden={true}
+                className="manicon-svg checkbox__icon svg-icon--checkmark16"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <polygon
+                  fill="currentColor"
+                  fillRule="nonzero"
+                  points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
+                />
+              </svg>
+            </div>
+            Others
+          </label>
+        </div>
+      </fieldset>
     </li>
     <li>
-      <svg
-        className="manicon-svg visibility-menu__group-icon svg-icon--"
-        height={30.667}
-        style={
-          Object {
-            "backgroundColor": "yellow",
-          }
-        }
-        viewBox="0 0 64 64"
-        width={30.667}
-        xmlns="http://www.w3.org/2000/svg"
+      <fieldset
+        className="visibility-menu__group"
       >
-        <g
-          fill="none"
-          fillRule="evenodd"
+        <legend
+          className="visibility-menu__legend"
         >
-          <path
-            d="M34.599464,6.55235632 L59.0158347,51.5697026 C59.8057661,53.0261278 59.2654662,54.8471596 57.809041,55.6370911 C57.369926,55.8752569 56.8782883,56 56.3787436,56 L7.61867231,56 C5.96181806,56 4.61867231,54.6568542 4.61867231,53 C4.61867231,52.5017228 4.74278339,52.0112922 4.97979802,51.5729953 L29.3234986,6.555649 C30.1116116,5.09823897 31.9319676,4.55566648 33.3893777,5.34377943 C33.90146,5.62069444 34.32191,6.04062003 34.599464,6.55235632 Z M32,49 C33.6568542,49 35,47.6568542 35,46 C35,44.3431458 33.6568542,43 32,43 C30.3431458,43 29,44.3431458 29,46 C29,47.6568542 30.3431458,49 32,49 Z M32.982486,40 L36,24 L28,24 L30.9870897,40 L32.982486,40 Z"
-            fill="#39ff14"
-            fillRule="nonzero"
-          />
-          <path
-            d="M34.599464,6.55235632 L59.0158347,51.5697026 C59.8057661,53.0261278 59.2654662,54.8471596 57.809041,55.6370911 C57.369926,55.8752569 56.8782883,56 56.3787436,56 L7.61867231,56 C5.96181806,56 4.61867231,54.6568542 4.61867231,53 C4.61867231,52.5017228 4.74278339,52.0112922 4.97979802,51.5729953 L29.3234986,6.555649 C30.1116116,5.09823897 31.9319676,4.55566648 33.3893777,5.34377943 C33.90146,5.62069444 34.32191,6.04062003 34.599464,6.55235632 Z M32,49 C33.6568542,49 35,47.6568542 35,46 C35,44.3431458 33.6568542,43 32,43 C30.3431458,43 29,44.3431458 29,46 C29,47.6568542 30.3431458,49 32,49 Z M32.982486,40 L36,24 L28,24 L30.9870897,40 L32.982486,40 Z"
-            fill="#39ff14"
-            fillRule="nonzero"
-          />
-        </g>
-      </svg>
-      <br />
-      <span
-        style={
-          Object {
-            "fontSize": 10,
-          }
-        }
-      >
-        
-      </span>
-      <span>
-        Annotationss
-      </span>
-      <div
-        className="filters"
-      >
-        <label
-          className="checkbox"
-          htmlFor="annotations-checkbox-0"
-        >
-          <input
-            checked={true}
-            id="annotations-checkbox-0"
-            onChange={[Function]}
-            type="checkbox"
-          />
-          <div
-            aria-hidden="true"
-            className="checkbox__indicator"
+          <svg
+            className="manicon-svg visibility-menu__group-icon svg-icon--"
+            height={30.667}
+            style={
+              Object {
+                "backgroundColor": "yellow",
+              }
+            }
+            viewBox="0 0 64 64"
+            width={30.667}
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-hidden={true}
-              className="manicon-svg checkbox__icon svg-icon--checkmark16"
-              height={16}
-              viewBox="0 0 16 16"
-              width={16}
-              xmlns="http://www.w3.org/2000/svg"
+            <g
+              fill="none"
+              fillRule="evenodd"
             >
-              <polygon
-                fill="currentColor"
+              <path
+                d="M34.599464,6.55235632 L59.0158347,51.5697026 C59.8057661,53.0261278 59.2654662,54.8471596 57.809041,55.6370911 C57.369926,55.8752569 56.8782883,56 56.3787436,56 L7.61867231,56 C5.96181806,56 4.61867231,54.6568542 4.61867231,53 C4.61867231,52.5017228 4.74278339,52.0112922 4.97979802,51.5729953 L29.3234986,6.555649 C30.1116116,5.09823897 31.9319676,4.55566648 33.3893777,5.34377943 C33.90146,5.62069444 34.32191,6.04062003 34.599464,6.55235632 Z M32,49 C33.6568542,49 35,47.6568542 35,46 C35,44.3431458 33.6568542,43 32,43 C30.3431458,43 29,44.3431458 29,46 C29,47.6568542 30.3431458,49 32,49 Z M32.982486,40 L36,24 L28,24 L30.9870897,40 L32.982486,40 Z"
+                fill="#39ff14"
                 fillRule="nonzero"
-                points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
               />
-            </svg>
-          </div>
-          Yours
-        </label>
-        <label
-          className="checkbox"
-          htmlFor="annotations-checkbox-1"
-        >
-          <input
-            checked={true}
-            id="annotations-checkbox-1"
-            onChange={[Function]}
-            type="checkbox"
-          />
-          <div
-            aria-hidden="true"
-            className="checkbox__indicator"
+              <path
+                d="M34.599464,6.55235632 L59.0158347,51.5697026 C59.8057661,53.0261278 59.2654662,54.8471596 57.809041,55.6370911 C57.369926,55.8752569 56.8782883,56 56.3787436,56 L7.61867231,56 C5.96181806,56 4.61867231,54.6568542 4.61867231,53 C4.61867231,52.5017228 4.74278339,52.0112922 4.97979802,51.5729953 L29.3234986,6.555649 C30.1116116,5.09823897 31.9319676,4.55566648 33.3893777,5.34377943 C33.90146,5.62069444 34.32191,6.04062003 34.599464,6.55235632 Z M32,49 C33.6568542,49 35,47.6568542 35,46 C35,44.3431458 33.6568542,43 32,43 C30.3431458,43 29,44.3431458 29,46 C29,47.6568542 30.3431458,49 32,49 Z M32.982486,40 L36,24 L28,24 L30.9870897,40 L32.982486,40 Z"
+                fill="#39ff14"
+                fillRule="nonzero"
+              />
+            </g>
+          </svg>
+          <br />
+          <span
+            style={
+              Object {
+                "fontSize": 10,
+              }
+            }
           >
-            <svg
-              aria-hidden={true}
-              className="manicon-svg checkbox__icon svg-icon--checkmark16"
-              height={16}
-              viewBox="0 0 16 16"
-              width={16}
-              xmlns="http://www.w3.org/2000/svg"
+            
+          </span>
+          <span>
+            Annotationss
+          </span>
+        </legend>
+        <div
+          className="visibility-menu__filters"
+        >
+          <label
+            className="checkbox"
+            htmlFor="annotations-checkbox-0"
+          >
+            <input
+              checked={true}
+              id="annotations-checkbox-0"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            <div
+              aria-hidden="true"
+              className="checkbox__indicator"
             >
-              <polygon
-                fill="currentColor"
-                fillRule="nonzero"
-                points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
-              />
-            </svg>
-          </div>
-          Others
-        </label>
-      </div>
+              <svg
+                aria-hidden={true}
+                className="manicon-svg checkbox__icon svg-icon--checkmark16"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <polygon
+                  fill="currentColor"
+                  fillRule="nonzero"
+                  points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
+                />
+              </svg>
+            </div>
+            Yours
+          </label>
+          <label
+            className="checkbox"
+            htmlFor="annotations-checkbox-1"
+          >
+            <input
+              checked={true}
+              id="annotations-checkbox-1"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            <div
+              aria-hidden="true"
+              className="checkbox__indicator"
+            >
+              <svg
+                aria-hidden={true}
+                className="manicon-svg checkbox__icon svg-icon--checkmark16"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <polygon
+                  fill="currentColor"
+                  fillRule="nonzero"
+                  points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
+                />
+              </svg>
+            </div>
+            Others
+          </label>
+        </div>
+      </fieldset>
     </li>
     <li>
-      <svg
-        className="manicon-svg visibility-menu__group-icon svg-icon--"
-        height={30.667}
-        style={
-          Object {
-            "backgroundColor": "yellow",
-          }
-        }
-        viewBox="0 0 64 64"
-        width={30.667}
-        xmlns="http://www.w3.org/2000/svg"
+      <fieldset
+        className="visibility-menu__group"
       >
-        <g
-          fill="none"
-          fillRule="evenodd"
+        <legend
+          className="visibility-menu__legend"
         >
-          <path
-            d="M34.599464,6.55235632 L59.0158347,51.5697026 C59.8057661,53.0261278 59.2654662,54.8471596 57.809041,55.6370911 C57.369926,55.8752569 56.8782883,56 56.3787436,56 L7.61867231,56 C5.96181806,56 4.61867231,54.6568542 4.61867231,53 C4.61867231,52.5017228 4.74278339,52.0112922 4.97979802,51.5729953 L29.3234986,6.555649 C30.1116116,5.09823897 31.9319676,4.55566648 33.3893777,5.34377943 C33.90146,5.62069444 34.32191,6.04062003 34.599464,6.55235632 Z M32,49 C33.6568542,49 35,47.6568542 35,46 C35,44.3431458 33.6568542,43 32,43 C30.3431458,43 29,44.3431458 29,46 C29,47.6568542 30.3431458,49 32,49 Z M32.982486,40 L36,24 L28,24 L30.9870897,40 L32.982486,40 Z"
-            fill="#39ff14"
-            fillRule="nonzero"
-          />
-          <path
-            d="M34.599464,6.55235632 L59.0158347,51.5697026 C59.8057661,53.0261278 59.2654662,54.8471596 57.809041,55.6370911 C57.369926,55.8752569 56.8782883,56 56.3787436,56 L7.61867231,56 C5.96181806,56 4.61867231,54.6568542 4.61867231,53 C4.61867231,52.5017228 4.74278339,52.0112922 4.97979802,51.5729953 L29.3234986,6.555649 C30.1116116,5.09823897 31.9319676,4.55566648 33.3893777,5.34377943 C33.90146,5.62069444 34.32191,6.04062003 34.599464,6.55235632 Z M32,49 C33.6568542,49 35,47.6568542 35,46 C35,44.3431458 33.6568542,43 32,43 C30.3431458,43 29,44.3431458 29,46 C29,47.6568542 30.3431458,49 32,49 Z M32.982486,40 L36,24 L28,24 L30.9870897,40 L32.982486,40 Z"
-            fill="#39ff14"
-            fillRule="nonzero"
-          />
-        </g>
-      </svg>
-      <br />
-      <span
-        style={
-          Object {
-            "fontSize": 10,
-          }
-        }
-      >
-        
-      </span>
-      <span>
-        Resourcess
-      </span>
-      <div
-        className="filters"
-      >
-        <label
-          className="checkbox"
-          htmlFor="resources-checkbox-0"
-        >
-          <input
-            checked={true}
-            id="resources-checkbox-0"
-            onChange={[Function]}
-            type="checkbox"
-          />
-          <div
-            aria-hidden="true"
-            className="checkbox__indicator"
+          <svg
+            className="manicon-svg visibility-menu__group-icon svg-icon--"
+            height={30.667}
+            style={
+              Object {
+                "backgroundColor": "yellow",
+              }
+            }
+            viewBox="0 0 64 64"
+            width={30.667}
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-hidden={true}
-              className="manicon-svg checkbox__icon svg-icon--checkmark16"
-              height={16}
-              viewBox="0 0 16 16"
-              width={16}
-              xmlns="http://www.w3.org/2000/svg"
+            <g
+              fill="none"
+              fillRule="evenodd"
             >
-              <polygon
-                fill="currentColor"
+              <path
+                d="M34.599464,6.55235632 L59.0158347,51.5697026 C59.8057661,53.0261278 59.2654662,54.8471596 57.809041,55.6370911 C57.369926,55.8752569 56.8782883,56 56.3787436,56 L7.61867231,56 C5.96181806,56 4.61867231,54.6568542 4.61867231,53 C4.61867231,52.5017228 4.74278339,52.0112922 4.97979802,51.5729953 L29.3234986,6.555649 C30.1116116,5.09823897 31.9319676,4.55566648 33.3893777,5.34377943 C33.90146,5.62069444 34.32191,6.04062003 34.599464,6.55235632 Z M32,49 C33.6568542,49 35,47.6568542 35,46 C35,44.3431458 33.6568542,43 32,43 C30.3431458,43 29,44.3431458 29,46 C29,47.6568542 30.3431458,49 32,49 Z M32.982486,40 L36,24 L28,24 L30.9870897,40 L32.982486,40 Z"
+                fill="#39ff14"
                 fillRule="nonzero"
-                points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
               />
-            </svg>
-          </div>
-          Show All
-        </label>
-      </div>
+              <path
+                d="M34.599464,6.55235632 L59.0158347,51.5697026 C59.8057661,53.0261278 59.2654662,54.8471596 57.809041,55.6370911 C57.369926,55.8752569 56.8782883,56 56.3787436,56 L7.61867231,56 C5.96181806,56 4.61867231,54.6568542 4.61867231,53 C4.61867231,52.5017228 4.74278339,52.0112922 4.97979802,51.5729953 L29.3234986,6.555649 C30.1116116,5.09823897 31.9319676,4.55566648 33.3893777,5.34377943 C33.90146,5.62069444 34.32191,6.04062003 34.599464,6.55235632 Z M32,49 C33.6568542,49 35,47.6568542 35,46 C35,44.3431458 33.6568542,43 32,43 C30.3431458,43 29,44.3431458 29,46 C29,47.6568542 30.3431458,49 32,49 Z M32.982486,40 L36,24 L28,24 L30.9870897,40 L32.982486,40 Z"
+                fill="#39ff14"
+                fillRule="nonzero"
+              />
+            </g>
+          </svg>
+          <br />
+          <span
+            style={
+              Object {
+                "fontSize": 10,
+              }
+            }
+          >
+            
+          </span>
+          <span>
+            Resourcess
+          </span>
+        </legend>
+        <div
+          className="visibility-menu__filters"
+        >
+          <label
+            className="checkbox"
+            htmlFor="resources-checkbox-0"
+          >
+            <input
+              checked={true}
+              id="resources-checkbox-0"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            <div
+              aria-hidden="true"
+              className="checkbox__indicator"
+            >
+              <svg
+                aria-hidden={true}
+                className="manicon-svg checkbox__icon svg-icon--checkmark16"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <polygon
+                  fill="currentColor"
+                  fillRule="nonzero"
+                  points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
+                />
+              </svg>
+            </div>
+            Show All
+          </label>
+        </div>
+      </fieldset>
     </li>
   </ul>
 </nav>

--- a/client/src/reader/components/notes/__tests__/__snapshots__/FilteredList-test.js.snap
+++ b/client/src/reader/components/notes/__tests__/__snapshots__/FilteredList-test.js.snap
@@ -28,81 +28,85 @@ exports[`Reader.Notes.FilteredList Component renders correctly 1`] = `
       </span>
     </button>
   </div>
-  <nav
+  <fieldset
     className="filters"
   >
-    <h4
-      className="label"
-    >
-      Show your:
-    </h4>
     <div
-      className="checkbox-group"
+      className="notes-drawer__filters-inner"
     >
-      <label
-        className="checkbox"
-        htmlFor="highlight-checkbox"
+      <legend
+        className="label"
       >
-        <input
-          checked={true}
-          id="highlight-checkbox"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <div
-          aria-hidden="true"
-          className="checkbox__indicator"
-        >
-          <svg
-            aria-hidden={true}
-            className="manicon-svg checkbox__icon svg-icon--checkmark16"
-            height={16}
-            viewBox="0 0 16 16"
-            width={16}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <polygon
-              fill="currentColor"
-              fillRule="nonzero"
-              points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
-            />
-          </svg>
-        </div>
-        Highlights
-      </label>
-      <label
-        className="checkbox"
-        htmlFor="annotation-checkbox"
+        Show your:
+      </legend>
+      <div
+        className="checkbox-group"
       >
-        <input
-          checked={true}
-          id="annotation-checkbox"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <div
-          aria-hidden="true"
-          className="checkbox__indicator"
+        <label
+          className="checkbox"
+          htmlFor="highlight-checkbox"
         >
-          <svg
-            aria-hidden={true}
-            className="manicon-svg checkbox__icon svg-icon--checkmark16"
-            height={16}
-            viewBox="0 0 16 16"
-            width={16}
-            xmlns="http://www.w3.org/2000/svg"
+          <input
+            checked={true}
+            id="highlight-checkbox"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <div
+            aria-hidden="true"
+            className="checkbox__indicator"
           >
-            <polygon
-              fill="currentColor"
-              fillRule="nonzero"
-              points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
-            />
-          </svg>
-        </div>
-        Annotations
-      </label>
+            <svg
+              aria-hidden={true}
+              className="manicon-svg checkbox__icon svg-icon--checkmark16"
+              height={16}
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                fill="currentColor"
+                fillRule="nonzero"
+                points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
+              />
+            </svg>
+          </div>
+          Highlights
+        </label>
+        <label
+          className="checkbox"
+          htmlFor="annotation-checkbox"
+        >
+          <input
+            checked={true}
+            id="annotation-checkbox"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <div
+            aria-hidden="true"
+            className="checkbox__indicator"
+          >
+            <svg
+              aria-hidden={true}
+              className="manicon-svg checkbox__icon svg-icon--checkmark16"
+              height={16}
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                fill="currentColor"
+                fillRule="nonzero"
+                points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
+              />
+            </svg>
+          </div>
+          Annotations
+        </label>
+      </div>
     </div>
-  </nav>
+  </fieldset>
   <nav>
     <ul>
       <li>

--- a/client/src/reader/components/notes/partial/Filters.js
+++ b/client/src/reader/components/notes/partial/Filters.js
@@ -52,13 +52,15 @@ export default class Filters extends Component {
 
   render() {
     return (
-      <nav className="filters">
-        <h4 className="label">Show your:</h4>
-        <div className="checkbox-group">
-          {this.renderCheckBox("Highlights", "highlight")}
-          {this.renderCheckBox("Annotations", "annotation")}
+      <fieldset className="filters">
+        <div className="notes-drawer__filters-inner">
+          <legend className="label">Show your:</legend>
+          <div className="checkbox-group">
+            {this.renderCheckBox("Highlights", "highlight")}
+            {this.renderCheckBox("Annotations", "annotation")}
+          </div>
         </div>
-      </nav>
+      </fieldset>
     );
   }
 }

--- a/client/src/reader/components/notes/partial/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/reader/components/notes/partial/__tests__/__snapshots__/Filters-test.js.snap
@@ -1,79 +1,83 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Reader.Notes.Partial.Group Component renders correctly 1`] = `
-<nav
+<fieldset
   className="filters"
 >
-  <h4
-    className="label"
-  >
-    Show your:
-  </h4>
   <div
-    className="checkbox-group"
+    className="notes-drawer__filters-inner"
   >
-    <label
-      className="checkbox"
-      htmlFor="highlight-checkbox"
+    <legend
+      className="label"
     >
-      <input
-        checked={true}
-        id="highlight-checkbox"
-        onChange={[Function]}
-        type="checkbox"
-      />
-      <div
-        aria-hidden="true"
-        className="checkbox__indicator"
-      >
-        <svg
-          aria-hidden={true}
-          className="manicon-svg checkbox__icon svg-icon--checkmark16"
-          height={16}
-          viewBox="0 0 16 16"
-          width={16}
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <polygon
-            fill="currentColor"
-            fillRule="nonzero"
-            points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
-          />
-        </svg>
-      </div>
-      Highlights
-    </label>
-    <label
-      className="checkbox"
-      htmlFor="annotation-checkbox"
+      Show your:
+    </legend>
+    <div
+      className="checkbox-group"
     >
-      <input
-        checked={true}
-        id="annotation-checkbox"
-        onChange={[Function]}
-        type="checkbox"
-      />
-      <div
-        aria-hidden="true"
-        className="checkbox__indicator"
+      <label
+        className="checkbox"
+        htmlFor="highlight-checkbox"
       >
-        <svg
-          aria-hidden={true}
-          className="manicon-svg checkbox__icon svg-icon--checkmark16"
-          height={16}
-          viewBox="0 0 16 16"
-          width={16}
-          xmlns="http://www.w3.org/2000/svg"
+        <input
+          checked={true}
+          id="highlight-checkbox"
+          onChange={[Function]}
+          type="checkbox"
+        />
+        <div
+          aria-hidden="true"
+          className="checkbox__indicator"
         >
-          <polygon
-            fill="currentColor"
-            fillRule="nonzero"
-            points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
-          />
-        </svg>
-      </div>
-      Annotations
-    </label>
+          <svg
+            aria-hidden={true}
+            className="manicon-svg checkbox__icon svg-icon--checkmark16"
+            height={16}
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polygon
+              fill="currentColor"
+              fillRule="nonzero"
+              points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
+            />
+          </svg>
+        </div>
+        Highlights
+      </label>
+      <label
+        className="checkbox"
+        htmlFor="annotation-checkbox"
+      >
+        <input
+          checked={true}
+          id="annotation-checkbox"
+          onChange={[Function]}
+          type="checkbox"
+        />
+        <div
+          aria-hidden="true"
+          className="checkbox__indicator"
+        >
+          <svg
+            aria-hidden={true}
+            className="manicon-svg checkbox__icon svg-icon--checkmark16"
+            height={16}
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polygon
+              fill="currentColor"
+              fillRule="nonzero"
+              points="14.204 2.5 6.411 12.011 1.721 7.432 1 8.135 6.495 13.5 15 3.122"
+            />
+          </svg>
+        </div>
+        Annotations
+      </label>
+    </div>
   </div>
-</nav>
+</fieldset>
 `;

--- a/client/src/reader/containers/Search/__tests__/__snapshots__/Search-test.js.snap
+++ b/client/src/reader/containers/Search/__tests__/__snapshots__/Search-test.js.snap
@@ -116,10 +116,13 @@ exports[`Reader SearchContainer renders correctly 1`] = `
             </button>
           </div>
           <div
+            aria-labelledby="show-results-for-header"
             className="filters"
+            role="group"
           >
             <h4
               className="group-label"
+              id="show-results-for-header"
             >
               Show Results For:
             </h4>

--- a/client/src/theme/styles/components/backend/list/entity/_entity-list-search.scss
+++ b/client/src/theme/styles/components/backend/list/entity/_entity-list-search.scss
@@ -156,6 +156,10 @@
       border: 1px solid $neutral80;
       border-radius: 8px;
       transition: border-color $duration $timing;
+
+      &:focus {
+        @include focusOutline;
+      }
     }
 
     svg {

--- a/client/src/theme/styles/components/reader/_notes.scss
+++ b/client/src/theme/styles/components/reader/_notes.scss
@@ -261,18 +261,11 @@
     }
 
     .filters {
-      padding: 15px 20px;
+      padding: 0;
+      margin: 0;
       background-color: $neutral20;
+      border: 0;
       border-bottom: 2px solid $neutral40;
-
-      @include respond($break65) {
-        padding: 21px 32px 18px;
-      }
-
-      @include respond($break90) {
-        display: flex;
-        align-items: center;
-      }
 
       label {
         @include utilityPrimary;
@@ -329,6 +322,19 @@
       display: flex;
       flex-grow: 1;
       justify-content: space-between;
+    }
+  }
+
+  &__filters-inner {
+    padding: 15px 20px;
+
+    @include respond($break65) {
+      padding: 21px 32px 18px;
+    }
+
+    @include respond($break90) {
+      display: flex;
+      align-items: center;
     }
   }
 }

--- a/client/src/theme/styles/components/reader/_visibility-menu.scss
+++ b/client/src/theme/styles/components/reader/_visibility-menu.scss
@@ -14,6 +14,12 @@
     padding: 30px 35px;
   }
 
+  &__group {
+    padding: 0;
+    margin: 0;
+    border: none;
+  }
+
   &__group-icon {
     margin-right: 6px;
     margin-left: -4px;
@@ -26,7 +32,7 @@
     color: $neutral75;
   }
 
-  .filters {
+  &__filters {
     display: flex;
     justify-content: space-between;
     padding-top: 22px;


### PR DESCRIPTION
This PR revises markup in forms throughout the application to create a semantic association between related form controls. This change compliments the visual grouping already present, thereby creating a more consistent user experience for sighted and non-sighted users.

 Grouping is done in some cases using the `fieldset` and `legend` elements, and elsewhere using the WAI-ARIA role "group", with appropriate linking of the group to header and instructions using `aria-labelledby` and `aria-describedby`.

Resolves #2250