### PR TITLE
[B] Use section element to wrap FE content blocks

### DIFF
--- a/client/src/frontend/components/content-block/Block/parts/Wrapper.js
+++ b/client/src/frontend/components/content-block/Block/parts/Wrapper.js
@@ -12,7 +12,7 @@ export default class ProjectContentBlockWrapper extends PureComponent {
 
   render() {
     return (
-      <div
+      <section
         className={classNames(
           "project-content-block",
           this.props.additionalClasses
@@ -21,7 +21,7 @@ export default class ProjectContentBlockWrapper extends PureComponent {
         <div className="container entity-section-wrapper">
           {this.props.children}
         </div>
-      </div>
+      </section>
     );
   }
 }


### PR DESCRIPTION
This PR applies `<section>` as the outermost element of FE content blocks rather than `<div>`. This removes the implicit `banner` role for the `<header>` element in each content block and thus eliminates unwanted ARIA `banner` landmarks on the page.

Resolves #2262