### PR TITLE
[B] Improve a11y of HasMany lists

### DIFF
--- a/client/src/backend/components/form/HasMany/List.js
+++ b/client/src/backend/components/form/HasMany/List.js
@@ -5,7 +5,9 @@ import ListItem from "./ListItem";
 import isString from "lodash/isString";
 import classnames from "classnames";
 
-export default class FormHasManyList extends PureComponent {
+import withScreenReaderStatus from "hoc/with-screen-reader-status";
+
+class FormHasManyList extends PureComponent {
   static displayName = "Form.HasMany.List";
 
   static propTypes = {
@@ -35,6 +37,9 @@ export default class FormHasManyList extends PureComponent {
     newEntities[target] = entity;
     newEntities[index] = tmp;
     this.props.onChange(newEntities, "move");
+    this.props.setScreenReaderStatus(
+      `${this.props.entityName(entity)} moved ${direction}.`
+    );
   };
 
   onRemove = (event, entity) => {
@@ -43,6 +48,9 @@ export default class FormHasManyList extends PureComponent {
       return compare !== entity;
     });
     this.props.onChange(newEntities, "remove");
+    this.props.setScreenReaderStatus(
+      `${this.props.entityName(entity)} removed.`
+    );
   };
 
   maybeRenderPlaceholder(renderConditions) {
@@ -61,7 +69,11 @@ export default class FormHasManyList extends PureComponent {
     });
 
     return (
-      <ul className={listClasses}>
+      <ul
+        role="group"
+        aria-label={`Active ${this.props.label}`}
+        className={listClasses}
+      >
         {hasEntities
           ? entities.map((entity, index) => {
               const key = isString(entity) ? entity : entity.id;
@@ -87,3 +99,5 @@ export default class FormHasManyList extends PureComponent {
     );
   }
 }
+
+export default withScreenReaderStatus(FormHasManyList);

--- a/client/src/backend/components/form/HasMany/ListItem.js
+++ b/client/src/backend/components/form/HasMany/ListItem.js
@@ -75,8 +75,7 @@ export default class FormHasManyList extends PureComponent {
     return (
       <button type="button" className="utility__button" onClick={this.onEdit}>
         <span className="screen-reader-text">
-          Edit {this.name()}
-          in the {this.props.label} list.
+          {`Edit ${this.name()} in the ${this.props.label} list.`}
         </span>
         {this.renderIcon("annotate32")}
       </button>
@@ -87,7 +86,7 @@ export default class FormHasManyList extends PureComponent {
     return (
       <button type="button" onClick={this.onRemove} className="utility__button">
         <span className="screen-reader-text">
-          Remove {this.name()} from the {this.props.label} list.
+          {`Remove ${this.name()} from the ${this.props.label} list.`}
         </span>
         {this.renderIcon("close32", "utility__icon--close")}
       </button>

--- a/client/src/backend/components/form/HasMany/index.js
+++ b/client/src/backend/components/form/HasMany/index.js
@@ -133,7 +133,7 @@ export class FormHasMany extends PureComponent {
               instructions={this.props.instructions}
               idForInstructions={`${this.idForInstructionsPrefix}-${id}`}
             />
-            <nav className="has-many-list">
+            <div className="has-many-list">
               {this.renderList(
                 this.props.orderable || this.props.editClickHandler,
                 this.props
@@ -154,7 +154,7 @@ export class FormHasMany extends PureComponent {
                 !this.props.orderable && !this.props.editClickHandler,
                 this.props
               )}
-            </nav>
+            </div>
           </GlobalForm.Errorable>
         )}
       </UID>

--- a/client/src/backend/components/form/TagList.js
+++ b/client/src/backend/components/form/TagList.js
@@ -114,21 +114,21 @@ class FormTagList extends Component {
             <label htmlFor={`${this.idPrefix}-${id}`} className={labelClass}>
               {this.props.label}
             </label>
-            <ConnectedFormInputs.PredictiveInput
-              placeholder="Enter a Tag"
-              fetch={tagsAPI.index}
-              fetchOptions={this.fetchOptions}
-              onSelect={this.handleAdd}
-              onNew={this.handleAdd}
-              label={this.tagLabel}
-              idForError={`${this.idForErrorPrefix}-${id}`}
-              idForInstructions={`${this.idForInstructionsPrefix}-${id}`}
-            />
-            <Instructions
-              instructions={this.props.instructions}
-              id={`${this.idForInstructionsPrefix}-${id}`}
-            />
             <div className="has-many-list">
+              <ConnectedFormInputs.PredictiveInput
+                placeholder="Enter a Tag"
+                fetch={tagsAPI.index}
+                fetchOptions={this.fetchOptions}
+                onSelect={this.handleAdd}
+                onNew={this.handleAdd}
+                label={this.tagLabel}
+                idForError={`${this.idForErrorPrefix}-${id}`}
+                idForInstructions={`${this.idForInstructionsPrefix}-${id}`}
+              />
+              <Instructions
+                instructions={this.props.instructions}
+                id={`${this.idForInstructionsPrefix}-${id}`}
+              />
               {this.renderList(this.props.value)}
             </div>
           </GlobalForm.Errorable>

--- a/client/src/backend/components/form/__tests__/__snapshots__/HasMany-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/HasMany-test.js.snap
@@ -10,11 +10,19 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
   >
     makers
   </div>
-  <nav
+  <div
     className="has-many-list"
   >
+    <div
+      aria-atomic={true}
+      aria-live="polite"
+      className="screen-reader-text"
+      role="status"
+    />
     <ul
+      aria-label="Active makers"
       className=""
+      role="group"
     >
       <li>
         <div
@@ -62,11 +70,7 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
             <span
               className="screen-reader-text"
             >
-              Remove 
-              John
-               from the 
-              makers
-               list.
+              Remove John from the makers list.
             </span>
             <svg
               aria-hidden={true}
@@ -130,11 +134,7 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
             <span
               className="screen-reader-text"
             >
-              Remove 
-              Jane
-               from the 
-              makers
-               list.
+              Remove Jane from the makers list.
             </span>
             <svg
               aria-hidden={true}
@@ -154,12 +154,25 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
       </li>
     </ul>
     <div
+      aria-atomic={true}
+      aria-live="polite"
+      className="screen-reader-text"
+      role="status"
+    />
+    <div
       className="input-predictive"
     >
       <div
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        aria-owns="1-listbox"
         className="input-predictive__input"
+        role="combobox"
       >
         <input
+          aria-activedescendant={null}
+          aria-autocomplete="list"
+          aria-controls="1-listbox"
           aria-describedby="predictive-text-belongs-to-error-1 predictive-text-belongs-to-instructions-1"
           className="input-predictive__text-input text-input"
           onBlur={[Function]}
@@ -191,14 +204,12 @@ exports[`Backend.Form.HasMany component renders correctly 1`] = `
           </svg>
         </button>
       </div>
-      <nav
-        className="input-predictive__results-wrapper"
-      >
-        <ul
-          className="input-predictive__results"
-        />
-      </nav>
+      <ul
+        className="input-predictive__results"
+        id="1-listbox"
+        role="listbox"
+      />
     </div>
-  </nav>
+  </div>
 </div>
 `;

--- a/client/src/backend/components/form/__tests__/__snapshots__/TagList-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/TagList-test.js.snap
@@ -12,58 +12,77 @@ exports[`Backend.Form.TagList component renders correctly 1`] = `
     Tags
   </label>
   <div
-    className="input-predictive"
-  >
-    <div
-      className="input-predictive__input"
-    >
-      <input
-        aria-describedby="tag-list-error-1 tag-list-instructions-1"
-        aria-label="Enter a Tag"
-        className="input-predictive__text-input text-input"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        placeholder="Enter a Tag"
-        type="text"
-        value=""
-      />
-      <button
-        aria-hidden="true"
-        className="input-predictive__button"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="manicon-svg input-predictive__icon svg-icon--plus16"
-          fill="currentColor"
-          height={20}
-          viewBox="0 0 16 16"
-          width={20}
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M2.01435,8.5138 L2.014482,7.5138 L14.01435,7.5149 L14.014218,8.5149 L2.01435,8.5138 Z M8.5149,14.014218 L7.5149,14.01435 L7.5138,2.014482 L8.5138,2.01435 L8.5149,14.014218 Z"
-          />
-        </svg>
-      </button>
-    </div>
-    <nav
-      className="input-predictive__results-wrapper"
-    >
-      <ul
-        className="input-predictive__results"
-      />
-    </nav>
-  </div>
-  <div
     className="has-many-list"
   >
+    <div
+      aria-atomic={true}
+      aria-live="polite"
+      className="screen-reader-text"
+      role="status"
+    />
+    <div
+      className="input-predictive"
+    >
+      <div
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        aria-owns="1-listbox"
+        className="input-predictive__input"
+        role="combobox"
+      >
+        <input
+          aria-activedescendant={null}
+          aria-autocomplete="list"
+          aria-controls="1-listbox"
+          aria-describedby="tag-list-error-1 tag-list-instructions-1"
+          className="input-predictive__text-input text-input"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          placeholder="Enter a Tag"
+          type="text"
+          value=""
+        />
+        <button
+          aria-hidden="true"
+          className="input-predictive__button"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden={true}
+            className="manicon-svg input-predictive__icon svg-icon--plus16"
+            fill="currentColor"
+            height={20}
+            viewBox="0 0 16 16"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M2.01435,8.5138 L2.014482,7.5138 L14.01435,7.5149 L14.014218,8.5149 L2.01435,8.5138 Z M8.5149,14.014218 L7.5149,14.01435 L7.5138,2.014482 L8.5138,2.01435 L8.5149,14.014218 Z"
+            />
+          </svg>
+        </button>
+      </div>
+      <ul
+        aria-label="Enter a Tag"
+        className="input-predictive__results"
+        id="1-listbox"
+        role="listbox"
+      />
+    </div>
+    <div
+      aria-atomic={true}
+      aria-live="polite"
+      className="screen-reader-text"
+      role="status"
+    />
     <ul
+      aria-label="Active Tags"
       className="bucket empty"
+      role="group"
     >
       <div
         className="placeholder"

--- a/client/src/backend/components/project-collection/form/__tests__/__snapshots__/SmartAttributes-test.js.snap
+++ b/client/src/backend/components/project-collection/form/__tests__/__snapshots__/SmartAttributes-test.js.snap
@@ -78,18 +78,30 @@ Array [
     >
       Include all Projects with these subjects.
     </span>
-    <nav
+    <div
       className="has-many-list"
     >
+      <div
+        aria-atomic={true}
+        aria-live="polite"
+        className="screen-reader-text"
+        role="status"
+      />
       <div
         className="input-predictive"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-owns="1-listbox"
           className="input-predictive__input"
+          role="combobox"
         >
           <input
+            aria-activedescendant={null}
+            aria-autocomplete="list"
+            aria-controls="1-listbox"
             aria-describedby="predictive-text-belongs-to-error-1 predictive-text-belongs-to-instructions-1"
-            aria-label="Add a Subject"
             className="input-predictive__text-input text-input"
             onBlur={[Function]}
             onChange={[Function]}
@@ -101,16 +113,23 @@ Array [
             value=""
           />
         </div>
-        <nav
-          className="input-predictive__results-wrapper"
-        >
-          <ul
-            className="input-predictive__results"
-          />
-        </nav>
+        <ul
+          aria-label="Add a Subject"
+          className="input-predictive__results"
+          id="1-listbox"
+          role="listbox"
+        />
       </div>
+      <div
+        aria-atomic={true}
+        aria-live="polite"
+        className="screen-reader-text"
+        role="status"
+      />
       <ul
+        aria-label="Active Subjects:"
         className="bucket empty"
+        role="group"
       >
         <div
           className="placeholder"
@@ -118,7 +137,7 @@ Array [
           None Added
         </div>
       </ul>
-    </nav>
+    </div>
   </div>,
   <div
     className="form-input"
@@ -131,58 +150,77 @@ Array [
       Tags:
     </label>
     <div
-      className="input-predictive"
-    >
-      <div
-        className="input-predictive__input"
-      >
-        <input
-          aria-describedby="tag-list-error-1 tag-list-instructions-1"
-          aria-label="Enter a Tag"
-          className="input-predictive__text-input text-input"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          placeholder="Enter a Tag"
-          type="text"
-          value=""
-        />
-        <button
-          aria-hidden="true"
-          className="input-predictive__button"
-          onClick={[Function]}
-          type="button"
-        >
-          <svg
-            aria-hidden={true}
-            className="manicon-svg input-predictive__icon svg-icon--plus16"
-            fill="currentColor"
-            height={20}
-            viewBox="0 0 16 16"
-            width={20}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M2.01435,8.5138 L2.014482,7.5138 L14.01435,7.5149 L14.014218,8.5149 L2.01435,8.5138 Z M8.5149,14.014218 L7.5149,14.01435 L7.5138,2.014482 L8.5138,2.01435 L8.5149,14.014218 Z"
-            />
-          </svg>
-        </button>
-      </div>
-      <nav
-        className="input-predictive__results-wrapper"
-      >
-        <ul
-          className="input-predictive__results"
-        />
-      </nav>
-    </div>
-    <div
       className="has-many-list"
     >
+      <div
+        aria-atomic={true}
+        aria-live="polite"
+        className="screen-reader-text"
+        role="status"
+      />
+      <div
+        className="input-predictive"
+      >
+        <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-owns="1-listbox"
+          className="input-predictive__input"
+          role="combobox"
+        >
+          <input
+            aria-activedescendant={null}
+            aria-autocomplete="list"
+            aria-controls="1-listbox"
+            aria-describedby="tag-list-error-1 tag-list-instructions-1"
+            className="input-predictive__text-input text-input"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            placeholder="Enter a Tag"
+            type="text"
+            value=""
+          />
+          <button
+            aria-hidden="true"
+            className="input-predictive__button"
+            onClick={[Function]}
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              className="manicon-svg input-predictive__icon svg-icon--plus16"
+              fill="currentColor"
+              height={20}
+              viewBox="0 0 16 16"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M2.01435,8.5138 L2.014482,7.5138 L14.01435,7.5149 L14.014218,8.5149 L2.01435,8.5138 Z M8.5149,14.014218 L7.5149,14.01435 L7.5138,2.014482 L8.5138,2.01435 L8.5149,14.014218 Z"
+              />
+            </svg>
+          </button>
+        </div>
+        <ul
+          aria-label="Enter a Tag"
+          className="input-predictive__results"
+          id="1-listbox"
+          role="listbox"
+        />
+      </div>
+      <div
+        aria-atomic={true}
+        aria-live="polite"
+        className="screen-reader-text"
+        role="status"
+      />
       <ul
+        aria-label="Active Tags:"
         className="bucket empty"
+        role="group"
       >
         <div
           className="placeholder"

--- a/client/src/backend/components/project/form/__tests__/__snapshots__/Subjects-test.js.snap
+++ b/client/src/backend/components/project/form/__tests__/__snapshots__/Subjects-test.js.snap
@@ -10,18 +10,30 @@ exports[`Backend Project Form Subjects Component renders correctly 1`] = `
   >
     Subjects
   </div>
-  <nav
+  <div
     className="has-many-list"
   >
+    <div
+      aria-atomic={true}
+      aria-live="polite"
+      className="screen-reader-text"
+      role="status"
+    />
     <div
       className="input-predictive"
     >
       <div
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        aria-owns="1-listbox"
         className="input-predictive__input"
+        role="combobox"
       >
         <input
+          aria-activedescendant={null}
+          aria-autocomplete="list"
+          aria-controls="1-listbox"
           aria-describedby="predictive-text-belongs-to-error-1 predictive-text-belongs-to-instructions-1"
-          aria-label="Add a Subject"
           className="input-predictive__text-input text-input"
           onBlur={[Function]}
           onChange={[Function]}
@@ -33,16 +45,23 @@ exports[`Backend Project Form Subjects Component renders correctly 1`] = `
           value=""
         />
       </div>
-      <nav
-        className="input-predictive__results-wrapper"
-      >
-        <ul
-          className="input-predictive__results"
-        />
-      </nav>
+      <ul
+        aria-label="Add a Subject"
+        className="input-predictive__results"
+        id="1-listbox"
+        role="listbox"
+      />
     </div>
+    <div
+      aria-atomic={true}
+      aria-live="polite"
+      className="screen-reader-text"
+      role="status"
+    />
     <ul
+      aria-label="Active Subjects"
       className="bucket"
+      role="group"
     >
       <li>
         <div
@@ -65,11 +84,7 @@ exports[`Backend Project Form Subjects Component renders correctly 1`] = `
             <span
               className="screen-reader-text"
             >
-              Remove 
-              Hip Hop
-               from the 
-              Subjects
-               list.
+              Remove Hip Hop from the Subjects list.
             </span>
             <svg
               aria-hidden={true}
@@ -88,6 +103,6 @@ exports[`Backend Project Form Subjects Component renders correctly 1`] = `
         </div>
       </li>
     </ul>
-  </nav>
+  </div>
 </div>
 `;

--- a/client/src/backend/containers/form-inputs/composite-inputs/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/backend/containers/form-inputs/composite-inputs/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -14,11 +14,19 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
       >
         Authors
       </h2>
-      <nav
+      <div
         className="has-many-list"
       >
+        <div
+          aria-atomic={true}
+          aria-live="polite"
+          className="screen-reader-text"
+          role="status"
+        />
         <ul
+          aria-label="Active Authors"
           className=""
+          role="group"
         >
           <li>
             <div
@@ -61,11 +69,7 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
                 <span
                   className="screen-reader-text"
                 >
-                  Edit 
-                  Rowan Ida
-                  in the 
-                  Authors
-                   list.
+                  Edit Rowan Ida in the Authors list.
                 </span>
                 <svg
                   aria-hidden={true}
@@ -89,11 +93,7 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
                 <span
                   className="screen-reader-text"
                 >
-                  Remove 
-                  Rowan Ida
-                   from the 
-                  Authors
-                   list.
+                  Remove Rowan Ida from the Authors list.
                 </span>
                 <svg
                   aria-hidden={true}
@@ -113,14 +113,26 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
           </li>
         </ul>
         <div
+          aria-atomic={true}
+          aria-live="polite"
+          className="screen-reader-text"
+          role="status"
+        />
+        <div
           className="input-predictive"
         >
           <div
+            aria-expanded={false}
+            aria-haspopup="listbox"
+            aria-owns="1-listbox"
             className="input-predictive__input"
+            role="combobox"
           >
             <input
+              aria-activedescendant={null}
+              aria-autocomplete="list"
+              aria-controls="1-listbox"
               aria-describedby="predictive-text-belongs-to-error-1 predictive-text-belongs-to-instructions-1"
-              aria-label="Add an Author"
               className="input-predictive__text-input text-input"
               onBlur={[Function]}
               onChange={[Function]}
@@ -152,15 +164,14 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
               </svg>
             </button>
           </div>
-          <nav
-            className="input-predictive__results-wrapper"
-          >
-            <ul
-              className="input-predictive__results"
-            />
-          </nav>
+          <ul
+            aria-label="Add an Author"
+            className="input-predictive__results"
+            id="1-listbox"
+            role="listbox"
+          />
         </div>
-      </nav>
+      </div>
     </div>
     <div
       className="form-input"
@@ -171,11 +182,19 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
       >
         Contributors
       </h2>
-      <nav
+      <div
         className="has-many-list"
       >
+        <div
+          aria-atomic={true}
+          aria-live="polite"
+          className="screen-reader-text"
+          role="status"
+        />
         <ul
+          aria-label="Active Contributors"
           className=""
+          role="group"
         >
           <li>
             <div
@@ -218,11 +237,7 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
                 <span
                   className="screen-reader-text"
                 >
-                  Edit 
-                  Rowan Ida
-                  in the 
-                  Contributors
-                   list.
+                  Edit Rowan Ida in the Contributors list.
                 </span>
                 <svg
                   aria-hidden={true}
@@ -246,11 +261,7 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
                 <span
                   className="screen-reader-text"
                 >
-                  Remove 
-                  Rowan Ida
-                   from the 
-                  Contributors
-                   list.
+                  Remove Rowan Ida from the Contributors list.
                 </span>
                 <svg
                   aria-hidden={true}
@@ -270,14 +281,26 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
           </li>
         </ul>
         <div
+          aria-atomic={true}
+          aria-live="polite"
+          className="screen-reader-text"
+          role="status"
+        />
+        <div
           className="input-predictive"
         >
           <div
+            aria-expanded={false}
+            aria-haspopup="listbox"
+            aria-owns="1-listbox"
             className="input-predictive__input"
+            role="combobox"
           >
             <input
+              aria-activedescendant={null}
+              aria-autocomplete="list"
+              aria-controls="1-listbox"
               aria-describedby="predictive-text-belongs-to-error-1 predictive-text-belongs-to-instructions-1"
-              aria-label="Add a Contributor"
               className="input-predictive__text-input text-input"
               onBlur={[Function]}
               onChange={[Function]}
@@ -309,15 +332,14 @@ exports[`Backend Form FormCollaborators Container renders correctly 1`] = `
               </svg>
             </button>
           </div>
-          <nav
-            className="input-predictive__results-wrapper"
-          >
-            <ul
-              className="input-predictive__results"
-            />
-          </nav>
+          <ul
+            aria-label="Add a Contributor"
+            className="input-predictive__results"
+            id="1-listbox"
+            role="listbox"
+          />
         </div>
-      </nav>
+      </div>
     </div>
   </form>
 </section>

--- a/client/src/backend/containers/project/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -15,11 +15,19 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
         >
           Authors
         </h2>
-        <nav
+        <div
           className="has-many-list"
         >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
           <ul
+            aria-label="Active Authors"
             className=""
+            role="group"
           >
             <li>
               <div
@@ -62,11 +70,7 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
                   <span
                     className="screen-reader-text"
                   >
-                    Edit 
-                    Rowan Ida
-                    in the 
-                    Authors
-                     list.
+                    Edit Rowan Ida in the Authors list.
                   </span>
                   <svg
                     aria-hidden={true}
@@ -90,11 +94,7 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
                   <span
                     className="screen-reader-text"
                   >
-                    Remove 
-                    Rowan Ida
-                     from the 
-                    Authors
-                     list.
+                    Remove Rowan Ida from the Authors list.
                   </span>
                   <svg
                     aria-hidden={true}
@@ -114,14 +114,26 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
             </li>
           </ul>
           <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
+          <div
             className="input-predictive"
           >
             <div
+              aria-expanded={false}
+              aria-haspopup="listbox"
+              aria-owns="1-listbox"
               className="input-predictive__input"
+              role="combobox"
             >
               <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-controls="1-listbox"
                 aria-describedby="predictive-text-belongs-to-error-1 predictive-text-belongs-to-instructions-1"
-                aria-label="Add an Author"
                 className="input-predictive__text-input text-input"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -153,15 +165,14 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
                 </svg>
               </button>
             </div>
-            <nav
-              className="input-predictive__results-wrapper"
-            >
-              <ul
-                className="input-predictive__results"
-              />
-            </nav>
+            <ul
+              aria-label="Add an Author"
+              className="input-predictive__results"
+              id="1-listbox"
+              role="listbox"
+            />
           </div>
-        </nav>
+        </div>
       </div>
       <div
         className="form-input"
@@ -172,11 +183,19 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
         >
           Contributors
         </h2>
-        <nav
+        <div
           className="has-many-list"
         >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
           <ul
+            aria-label="Active Contributors"
             className=""
+            role="group"
           >
             <li>
               <div
@@ -219,11 +238,7 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
                   <span
                     className="screen-reader-text"
                   >
-                    Edit 
-                    Rowan Ida
-                    in the 
-                    Contributors
-                     list.
+                    Edit Rowan Ida in the Contributors list.
                   </span>
                   <svg
                     aria-hidden={true}
@@ -247,11 +262,7 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
                   <span
                     className="screen-reader-text"
                   >
-                    Remove 
-                    Rowan Ida
-                     from the 
-                    Contributors
-                     list.
+                    Remove Rowan Ida from the Contributors list.
                   </span>
                   <svg
                     aria-hidden={true}
@@ -271,14 +282,26 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
             </li>
           </ul>
           <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
+          <div
             className="input-predictive"
           >
             <div
+              aria-expanded={false}
+              aria-haspopup="listbox"
+              aria-owns="1-listbox"
               className="input-predictive__input"
+              role="combobox"
             >
               <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-controls="1-listbox"
                 aria-describedby="predictive-text-belongs-to-error-1 predictive-text-belongs-to-instructions-1"
-                aria-label="Add a Contributor"
                 className="input-predictive__text-input text-input"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -310,15 +333,14 @@ exports[`Backend Project Collaborators Container renders correctly 1`] = `
                 </svg>
               </button>
             </div>
-            <nav
-              className="input-predictive__results-wrapper"
-            >
-              <ul
-                className="input-predictive__results"
-              />
-            </nav>
+            <ul
+              aria-label="Add a Contributor"
+              className="input-predictive__results"
+              id="1-listbox"
+              role="listbox"
+            />
           </div>
-        </nav>
+        </div>
       </div>
     </form>
   </section>

--- a/client/src/backend/containers/project/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/General-test.js.snap
@@ -456,18 +456,30 @@ exports[`Backend Project General Container renders correctly 1`] = `
             >
               Subjects
             </div>
-            <nav
+            <div
               className="has-many-list"
             >
+              <div
+                aria-atomic={true}
+                aria-live="polite"
+                className="screen-reader-text"
+                role="status"
+              />
               <div
                 className="input-predictive"
               >
                 <div
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
+                  aria-owns="1-listbox"
                   className="input-predictive__input"
+                  role="combobox"
                 >
                   <input
+                    aria-activedescendant={null}
+                    aria-autocomplete="list"
+                    aria-controls="1-listbox"
                     aria-describedby="predictive-text-belongs-to-error-1 predictive-text-belongs-to-instructions-1"
-                    aria-label="Add a Subject"
                     className="input-predictive__text-input text-input"
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -499,16 +511,23 @@ exports[`Backend Project General Container renders correctly 1`] = `
                     </svg>
                   </button>
                 </div>
-                <nav
-                  className="input-predictive__results-wrapper"
-                >
-                  <ul
-                    className="input-predictive__results"
-                  />
-                </nav>
+                <ul
+                  aria-label="Add a Subject"
+                  className="input-predictive__results"
+                  id="1-listbox"
+                  role="listbox"
+                />
               </div>
+              <div
+                aria-atomic={true}
+                aria-live="polite"
+                className="screen-reader-text"
+                role="status"
+              />
               <ul
+                aria-label="Active Subjects"
                 className="bucket"
+                role="group"
               >
                 <li>
                   <div
@@ -531,11 +550,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
                       <span
                         className="screen-reader-text"
                       >
-                        Remove 
-                        Hip Hop
-                         from the 
-                        Subjects
-                         list.
+                        Remove Hip Hop from the Subjects list.
                       </span>
                       <svg
                         aria-hidden={true}
@@ -554,7 +569,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
                   </div>
                 </li>
               </ul>
-            </nav>
+            </div>
           </div>
           <div
             className="form-input wide"
@@ -567,58 +582,77 @@ exports[`Backend Project General Container renders correctly 1`] = `
               Tags
             </label>
             <div
-              className="input-predictive"
-            >
-              <div
-                className="input-predictive__input"
-              >
-                <input
-                  aria-describedby="tag-list-error-1 tag-list-instructions-1"
-                  aria-label="Enter a Tag"
-                  className="input-predictive__text-input text-input"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  placeholder="Enter a Tag"
-                  type="text"
-                  value=""
-                />
-                <button
-                  aria-hidden="true"
-                  className="input-predictive__button"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="manicon-svg input-predictive__icon svg-icon--plus16"
-                    fill="currentColor"
-                    height={20}
-                    viewBox="0 0 16 16"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M2.01435,8.5138 L2.014482,7.5138 L14.01435,7.5149 L14.014218,8.5149 L2.01435,8.5138 Z M8.5149,14.014218 L7.5149,14.01435 L7.5138,2.014482 L8.5138,2.01435 L8.5149,14.014218 Z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <nav
-                className="input-predictive__results-wrapper"
-              >
-                <ul
-                  className="input-predictive__results"
-                />
-              </nav>
-            </div>
-            <div
               className="has-many-list"
             >
+              <div
+                aria-atomic={true}
+                aria-live="polite"
+                className="screen-reader-text"
+                role="status"
+              />
+              <div
+                className="input-predictive"
+              >
+                <div
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
+                  aria-owns="1-listbox"
+                  className="input-predictive__input"
+                  role="combobox"
+                >
+                  <input
+                    aria-activedescendant={null}
+                    aria-autocomplete="list"
+                    aria-controls="1-listbox"
+                    aria-describedby="tag-list-error-1 tag-list-instructions-1"
+                    className="input-predictive__text-input text-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    placeholder="Enter a Tag"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    aria-hidden="true"
+                    className="input-predictive__button"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="manicon-svg input-predictive__icon svg-icon--plus16"
+                      fill="currentColor"
+                      height={20}
+                      viewBox="0 0 16 16"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2.01435,8.5138 L2.014482,7.5138 L14.01435,7.5149 L14.014218,8.5149 L2.01435,8.5138 Z M8.5149,14.014218 L7.5149,14.01435 L7.5138,2.014482 L8.5138,2.01435 L8.5149,14.014218 Z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <ul
+                  aria-label="Enter a Tag"
+                  className="input-predictive__results"
+                  id="1-listbox"
+                  role="listbox"
+                />
+              </div>
+              <div
+                aria-atomic={true}
+                aria-live="polite"
+                className="screen-reader-text"
+                role="status"
+              />
               <ul
+                aria-label="Active Tags"
                 className="bucket empty"
+                role="group"
               >
                 <div
                   className="placeholder"

--- a/client/src/backend/containers/resource/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/resource/__tests__/__snapshots__/General-test.js.snap
@@ -176,58 +176,77 @@ exports[`Backend Resource General Container renders correctly 1`] = `
           Tags
         </label>
         <div
-          className="input-predictive"
-        >
-          <div
-            className="input-predictive__input"
-          >
-            <input
-              aria-describedby="tag-list-error-1 tag-list-instructions-1"
-              aria-label="Enter a Tag"
-              className="input-predictive__text-input text-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              placeholder="Enter a Tag"
-              type="text"
-              value=""
-            />
-            <button
-              aria-hidden="true"
-              className="input-predictive__button"
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                aria-hidden={true}
-                className="manicon-svg input-predictive__icon svg-icon--plus16"
-                fill="currentColor"
-                height={20}
-                viewBox="0 0 16 16"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M2.01435,8.5138 L2.014482,7.5138 L14.01435,7.5149 L14.014218,8.5149 L2.01435,8.5138 Z M8.5149,14.014218 L7.5149,14.01435 L7.5138,2.014482 L8.5138,2.01435 L8.5149,14.014218 Z"
-                />
-              </svg>
-            </button>
-          </div>
-          <nav
-            className="input-predictive__results-wrapper"
-          >
-            <ul
-              className="input-predictive__results"
-            />
-          </nav>
-        </div>
-        <div
           className="has-many-list"
         >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
+          <div
+            className="input-predictive"
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup="listbox"
+              aria-owns="1-listbox"
+              className="input-predictive__input"
+              role="combobox"
+            >
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-controls="1-listbox"
+                aria-describedby="tag-list-error-1 tag-list-instructions-1"
+                className="input-predictive__text-input text-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                placeholder="Enter a Tag"
+                type="text"
+                value=""
+              />
+              <button
+                aria-hidden="true"
+                className="input-predictive__button"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="manicon-svg input-predictive__icon svg-icon--plus16"
+                  fill="currentColor"
+                  height={20}
+                  viewBox="0 0 16 16"
+                  width={20}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M2.01435,8.5138 L2.014482,7.5138 L14.01435,7.5149 L14.014218,8.5149 L2.01435,8.5138 Z M8.5149,14.014218 L7.5149,14.01435 L7.5138,2.014482 L8.5138,2.01435 L8.5149,14.014218 Z"
+                  />
+                </svg>
+              </button>
+            </div>
+            <ul
+              aria-label="Enter a Tag"
+              className="input-predictive__results"
+              id="1-listbox"
+              role="listbox"
+            />
+          </div>
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
           <ul
+            aria-label="Active Tags"
             className="bucket"
+            role="group"
           >
             <li>
               <div
@@ -250,11 +269,7 @@ exports[`Backend Resource General Container renders correctly 1`] = `
                   <span
                     className="screen-reader-text"
                   >
-                    Remove 
-                    dog
-                     from the 
-                    Tags
-                     list.
+                    Remove dog from the Tags list.
                   </span>
                   <svg
                     aria-hidden={true}
@@ -293,11 +308,7 @@ exports[`Backend Resource General Container renders correctly 1`] = `
                   <span
                     className="screen-reader-text"
                   >
-                    Remove 
-                    puppy
-                     from the 
-                    Tags
-                     list.
+                    Remove puppy from the Tags list.
                   </span>
                   <svg
                     aria-hidden={true}
@@ -336,11 +347,7 @@ exports[`Backend Resource General Container renders correctly 1`] = `
                   <span
                     className="screen-reader-text"
                   >
-                    Remove 
-                    GOAT
-                     from the 
-                    Tags
-                     list.
+                    Remove GOAT from the Tags list.
                   </span>
                   <svg
                     aria-hidden={true}

--- a/client/src/backend/containers/text/__tests__/__snapshots__/Collaborators-test.js.snap
+++ b/client/src/backend/containers/text/__tests__/__snapshots__/Collaborators-test.js.snap
@@ -15,11 +15,19 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
         >
           Authors
         </h2>
-        <nav
+        <div
           className="has-many-list"
         >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
           <ul
+            aria-label="Active Authors"
             className=""
+            role="group"
           >
             <li>
               <div
@@ -62,11 +70,7 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
                   <span
                     className="screen-reader-text"
                   >
-                    Edit 
-                    Rowan Ida
-                    in the 
-                    Authors
-                     list.
+                    Edit Rowan Ida in the Authors list.
                   </span>
                   <svg
                     aria-hidden={true}
@@ -90,11 +94,7 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
                   <span
                     className="screen-reader-text"
                   >
-                    Remove 
-                    Rowan Ida
-                     from the 
-                    Authors
-                     list.
+                    Remove Rowan Ida from the Authors list.
                   </span>
                   <svg
                     aria-hidden={true}
@@ -114,14 +114,26 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
             </li>
           </ul>
           <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
+          <div
             className="input-predictive"
           >
             <div
+              aria-expanded={false}
+              aria-haspopup="listbox"
+              aria-owns="1-listbox"
               className="input-predictive__input"
+              role="combobox"
             >
               <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-controls="1-listbox"
                 aria-describedby="predictive-text-belongs-to-error-1 predictive-text-belongs-to-instructions-1"
-                aria-label="Add an Author"
                 className="input-predictive__text-input text-input"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -153,15 +165,14 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
                 </svg>
               </button>
             </div>
-            <nav
-              className="input-predictive__results-wrapper"
-            >
-              <ul
-                className="input-predictive__results"
-              />
-            </nav>
+            <ul
+              aria-label="Add an Author"
+              className="input-predictive__results"
+              id="1-listbox"
+              role="listbox"
+            />
           </div>
-        </nav>
+        </div>
       </div>
       <div
         className="form-input"
@@ -172,11 +183,19 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
         >
           Contributors
         </h2>
-        <nav
+        <div
           className="has-many-list"
         >
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
           <ul
+            aria-label="Active Contributors"
             className=""
+            role="group"
           >
             <li>
               <div
@@ -219,11 +238,7 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
                   <span
                     className="screen-reader-text"
                   >
-                    Edit 
-                    Rowan Ida
-                    in the 
-                    Contributors
-                     list.
+                    Edit Rowan Ida in the Contributors list.
                   </span>
                   <svg
                     aria-hidden={true}
@@ -247,11 +262,7 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
                   <span
                     className="screen-reader-text"
                   >
-                    Remove 
-                    Rowan Ida
-                     from the 
-                    Contributors
-                     list.
+                    Remove Rowan Ida from the Contributors list.
                   </span>
                   <svg
                     aria-hidden={true}
@@ -271,14 +282,26 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
             </li>
           </ul>
           <div
+            aria-atomic={true}
+            aria-live="polite"
+            className="screen-reader-text"
+            role="status"
+          />
+          <div
             className="input-predictive"
           >
             <div
+              aria-expanded={false}
+              aria-haspopup="listbox"
+              aria-owns="1-listbox"
               className="input-predictive__input"
+              role="combobox"
             >
               <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-controls="1-listbox"
                 aria-describedby="predictive-text-belongs-to-error-1 predictive-text-belongs-to-instructions-1"
-                aria-label="Add a Contributor"
                 className="input-predictive__text-input text-input"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -310,15 +333,14 @@ exports[`Backend Text Collaborators Container renders correctly 1`] = `
                 </svg>
               </button>
             </div>
-            <nav
-              className="input-predictive__results-wrapper"
-            >
-              <ul
-                className="input-predictive__results"
-              />
-            </nav>
+            <ul
+              aria-label="Add a Contributor"
+              className="input-predictive__results"
+              id="1-listbox"
+              role="listbox"
+            />
           </div>
-        </nav>
+        </div>
       </div>
     </form>
   </section>

--- a/client/src/theme/styles/base/_z-stack.scss
+++ b/client/src/theme/styles/base/_z-stack.scss
@@ -71,7 +71,7 @@
   z-index: 140;
 }
 
-.input-predictive__results-wrapper, .fetch-select {
+.input-predictive__results, .fetch-select {
   z-index: 100;
 }
 

--- a/client/src/theme/styles/components/backend/forms/_has-many-list.scss
+++ b/client/src/theme/styles/components/backend/forms/_has-many-list.scss
@@ -26,8 +26,8 @@
     }
   }
 
-  .input-predictive + ul,
-  .fetch-select + ul {
+  .input-predictive ~ ul,
+  .fetch-select ~ ul {
     margin-top: 25px;
   }
 

--- a/client/src/theme/styles/components/backend/forms/_input-predictive.scss
+++ b/client/src/theme/styles/components/backend/forms/_input-predictive.scss
@@ -14,12 +14,14 @@
     color: $accentPrimary;
   }
 
-  &__results-wrapper {
+  &__results {
+    @include listUnstyled;
     position: absolute;
     top: 100%;
     left: 0;
     width: 100%;
     max-height: 210px;
+    padding: 12px 0;
     overflow: auto;
     visibility: hidden;
     background-color: $neutral90;
@@ -34,11 +36,6 @@
       visibility: visible;
       opacity: 1;
     }
-  }
-
-  &__results {
-    @include listUnstyled;
-    padding: 12px 0;
   }
 
   &__result {


### PR DESCRIPTION
This PR makes two improvements to components contained in Form.HasMany in order to make these components more intelligible to screen readers. First, it adds missing WAI-ARIA attributes to elements of the PredictiveInput component that allow screen readers to utilize the autocomplete functionality of the input. Second, it implements the withScreenReaderStatus HOC in various components to announce when items are added to, removed from, or reordered in the HasMany list.

Resolves #2293