### PR TITLE
[B] Improve markup of file upload components

### DIFF
--- a/client/src/backend/components/form/Upload/Base.js
+++ b/client/src/backend/components/form/Upload/Base.js
@@ -127,7 +127,7 @@ export default class FormUpload extends Component {
               this.dropzone = dropzone;
             }}
             onDrop={this.handleFileDrop}
-            accepts={this.props.accepts}
+            accept={this.props.accepts.accepts}
           >
             {this.previewable ? (
               <Preview

--- a/client/src/backend/components/form/Upload/Empty.js
+++ b/client/src/backend/components/form/Upload/Empty.js
@@ -38,9 +38,13 @@ export default class FormUploadEmpty extends PureComponent {
               </span>
             ) : (
               <React.Fragment>
-                <span className="fake-link" role="button" aria-hidden>
+                <button
+                  className="form-dropzone__inline-button"
+                  aria-hidden
+                  tabIndex="-1"
+                >
                   {"Upload a file"}
-                </span>
+                </button>
                 {" or "}
                 <br />
                 {"drag and drop here"}

--- a/client/src/backend/components/form/Upload/FilePreview.js
+++ b/client/src/backend/components/form/Upload/FilePreview.js
@@ -21,20 +21,22 @@ export default class FormUploadFilePreview extends PureComponent {
           />
           <p className="primary">{this.props.fileName}</p>
           <p className="secondary">
-            <span
-              role="button"
+            <button
               tabIndex="0"
-              className="fake-link"
+              className="form-dropzone__inline-button"
               onClick={this.props.handleRemove}
-              href="#"
             >
               Remove this file
-            </span>
+            </button>
             <br />
             or{" "}
-            <span className="fake-link" role="button" aria-hidden>
+            <button
+              className="form-dropzone__inline-button"
+              aria-hidden
+              tabIndex="-1"
+            >
               Upload a new file
-            </span>
+            </button>
           </p>
         </div>
       </div>

--- a/client/src/backend/components/form/Upload/ImagePreview.js
+++ b/client/src/backend/components/form/Upload/ImagePreview.js
@@ -21,20 +21,23 @@ export default class FormUploadImagePreview extends PureComponent {
       <div className="contents-image-preview" data-id="preview">
         <div className="message">
           <p className="secondary">
-            <span
-              role="button"
+            <button
               tabIndex="0"
               data-id="remove"
-              className="fake-link"
+              className="form-dropzone__inline-button"
               onClick={this.props.handleRemove}
             >
               Remove this image
-            </span>
+            </button>
             <br />
             or{" "}
-            <span className="fake-link" role="button" aria-hidden>
+            <button
+              className="form-dropzone__inline-button"
+              aria-hidden
+              tabIndex="-1"
+            >
               Upload an image
-            </span>
+            </button>
           </p>
         </div>
         <img alt="Upload preview" className="preview" src={this.imageUrl} />

--- a/client/src/backend/components/form/__tests__/__snapshots__/Upload-test.js.snap
+++ b/client/src/backend/components/form/__tests__/__snapshots__/Upload-test.js.snap
@@ -15,12 +15,7 @@ exports[`Backend.Form.Upload component when the upload input does not have a val
       Cover
     </label>
     <react-dropzone
-      accepts={
-        Object {
-          "accepts": "image/*",
-          "extensions": "gif, jpeg, jpg, png",
-        }
-      }
+      accept="image/*"
       className="form-dropzone style-portrait"
       inputProps={
         Object {
@@ -59,13 +54,13 @@ exports[`Backend.Form.Upload component when the upload input does not have a val
           <p
             className="primary"
           >
-            <span
+            <button
               aria-hidden={true}
-              className="fake-link"
-              role="button"
+              className="form-dropzone__inline-button"
+              tabIndex="-1"
             >
               Upload a file
-            </span>
+            </button>
              or 
             <br />
             drag and drop here
@@ -98,12 +93,7 @@ exports[`Backend.Form.Upload component when the upload input doesn't have a remo
       Cover
     </label>
     <react-dropzone
-      accepts={
-        Object {
-          "accepts": "image/*",
-          "extensions": "gif, jpeg, jpg, png",
-        }
-      }
+      accept="image/*"
       className="form-dropzone style-portrait"
       inputProps={
         Object {
@@ -124,25 +114,24 @@ exports[`Backend.Form.Upload component when the upload input doesn't have a remo
           <p
             className="secondary"
           >
-            <span
-              className="fake-link"
+            <button
+              className="form-dropzone__inline-button"
               data-id="remove"
               onClick={[Function]}
-              role="button"
               tabIndex="0"
             >
               Remove this image
-            </span>
+            </button>
             <br />
             or
              
-            <span
+            <button
               aria-hidden={true}
-              className="fake-link"
-              role="button"
+              className="form-dropzone__inline-button"
+              tabIndex="-1"
             >
               Upload an image
-            </span>
+            </button>
           </p>
         </div>
         <img
@@ -176,12 +165,7 @@ exports[`Backend.Form.Upload component when the upload input doesn't have set an
       Cover
     </label>
     <react-dropzone
-      accepts={
-        Object {
-          "accepts": "image/*",
-          "extensions": "gif, jpeg, jpg, png",
-        }
-      }
+      accept="image/*"
       className="form-dropzone style-portrait"
       inputProps={
         Object {
@@ -202,25 +186,24 @@ exports[`Backend.Form.Upload component when the upload input doesn't have set an
           <p
             className="secondary"
           >
-            <span
-              className="fake-link"
+            <button
+              className="form-dropzone__inline-button"
               data-id="remove"
               onClick={[Function]}
-              role="button"
               tabIndex="0"
             >
               Remove this image
-            </span>
+            </button>
             <br />
             or
              
-            <span
+            <button
               aria-hidden={true}
-              className="fake-link"
-              role="button"
+              className="form-dropzone__inline-button"
+              tabIndex="-1"
             >
               Upload an image
-            </span>
+            </button>
           </p>
         </div>
         <img
@@ -254,12 +237,7 @@ exports[`Backend.Form.Upload component when the upload input has a value renders
       Cover
     </label>
     <react-dropzone
-      accepts={
-        Object {
-          "accepts": "image/*",
-          "extensions": "gif, jpeg, jpg, png",
-        }
-      }
+      accept="image/*"
       className="form-dropzone style-portrait"
       inputProps={
         Object {
@@ -280,25 +258,24 @@ exports[`Backend.Form.Upload component when the upload input has a value renders
           <p
             className="secondary"
           >
-            <span
-              className="fake-link"
+            <button
+              className="form-dropzone__inline-button"
               data-id="remove"
               onClick={[Function]}
-              role="button"
               tabIndex="0"
             >
               Remove this image
-            </span>
+            </button>
             <br />
             or
              
-            <span
+            <button
               aria-hidden={true}
-              className="fake-link"
-              role="button"
+              className="form-dropzone__inline-button"
+              tabIndex="-1"
             >
               Upload an image
-            </span>
+            </button>
           </p>
         </div>
         <img

--- a/client/src/backend/components/ingestion/form/__tests__/__snapshots__/Upload-test.js.snap
+++ b/client/src/backend/components/ingestion/form/__tests__/__snapshots__/Upload-test.js.snap
@@ -23,12 +23,7 @@ exports[`Backend.Ingestion.Form.Upload component renders correctly 1`] = `
         Upload a file
       </label>
       <react-dropzone
-        accepts={
-          Object {
-            "accepts": null,
-            "extensions": null,
-          }
-        }
+        accept={null}
         className="form-dropzone style-landscape"
         inputProps={
           Object {
@@ -72,13 +67,13 @@ exports[`Backend.Ingestion.Form.Upload component renders correctly 1`] = `
             <p
               className="primary"
             >
-              <span
+              <button
                 aria-hidden={true}
-                className="fake-link"
-                role="button"
+                className="form-dropzone__inline-button"
+                tabIndex="-1"
               >
                 Upload a file
-              </span>
+              </button>
                or 
               <br />
               drag and drop here

--- a/client/src/backend/components/ingestion/form/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/backend/components/ingestion/form/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -29,12 +29,7 @@ exports[`Backend.Ingestion.Form.Wrapper component renders correctly 1`] = `
             Upload a file
           </label>
           <react-dropzone
-            accepts={
-              Object {
-                "accepts": null,
-                "extensions": null,
-              }
-            }
+            accept={null}
             className="form-dropzone style-landscape"
             inputProps={
               Object {
@@ -78,13 +73,13 @@ exports[`Backend.Ingestion.Form.Wrapper component renders correctly 1`] = `
                 <p
                   className="primary"
                 >
-                  <span
+                  <button
                     aria-hidden={true}
-                    className="fake-link"
-                    role="button"
+                    className="form-dropzone__inline-button"
+                    tabIndex="-1"
                   >
                     Upload a file
-                  </span>
+                  </button>
                    or 
                   <br />
                   drag and drop here

--- a/client/src/backend/components/resource/form/__tests__/__snapshots__/KindAttributes-test.js.snap
+++ b/client/src/backend/components/resource/form/__tests__/__snapshots__/KindAttributes-test.js.snap
@@ -15,12 +15,7 @@ exports[`Backend.Resource.Form.KindAttributes component when kind is audio rende
       Image File
     </label>
     <react-dropzone
-      accepts={
-        Object {
-          "accepts": "image/*",
-          "extensions": "gif, jpeg, jpg, png",
-        }
-      }
+      accept="image/*"
       className="form-dropzone style-square"
       inputProps={
         Object {
@@ -59,13 +54,13 @@ exports[`Backend.Resource.Form.KindAttributes component when kind is audio rende
           <p
             className="primary"
           >
-            <span
+            <button
               aria-hidden={true}
-              className="fake-link"
-              role="button"
+              className="form-dropzone__inline-button"
+              tabIndex="-1"
             >
               Upload a file
-            </span>
+            </button>
              or 
             <br />
             drag and drop here

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Audio-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Audio-test.js.snap
@@ -18,12 +18,7 @@ exports[`Backend.Resource.Form.Audio component renders correctly 1`] = `
         Audio File
       </label>
       <react-dropzone
-        accepts={
-          Object {
-            "accepts": "audio/*",
-            "extensions": "mp3, flac, wav, ogg, oga",
-          }
-        }
+        accept="audio/*"
         className="form-dropzone style-square"
         inputProps={
           Object {
@@ -62,13 +57,13 @@ exports[`Backend.Resource.Form.Audio component renders correctly 1`] = `
             <p
               className="primary"
             >
-              <span
+              <button
                 aria-hidden={true}
-                className="fake-link"
-                role="button"
+                className="form-dropzone__inline-button"
+                tabIndex="-1"
               >
                 Upload a file
-              </span>
+              </button>
                or 
               <br />
               drag and drop here

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Document-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Document-test.js.snap
@@ -15,12 +15,7 @@ exports[`Backend.Resource.Form.Document component renders correctly 1`] = `
       Document File
     </label>
     <react-dropzone
-      accepts={
-        Object {
-          "accepts": "application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/msword,text/*,application/vnd.oasis.opendocument.text",
-          "extensions": "doc, docx, txt, odt",
-        }
-      }
+      accept="application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/msword,text/*,application/vnd.oasis.opendocument.text"
       className="form-dropzone style-square"
       inputProps={
         Object {
@@ -59,13 +54,13 @@ exports[`Backend.Resource.Form.Document component renders correctly 1`] = `
           <p
             className="primary"
           >
-            <span
+            <button
               aria-hidden={true}
-              className="fake-link"
-              role="button"
+              className="form-dropzone__inline-button"
+              tabIndex="-1"
             >
               Upload a file
-            </span>
+            </button>
              or 
             <br />
             drag and drop here

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/File-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/File-test.js.snap
@@ -15,12 +15,7 @@ exports[`Backend.Resource.Form.File component renders correctly 1`] = `
       File
     </label>
     <react-dropzone
-      accepts={
-        Object {
-          "accepts": null,
-          "extensions": null,
-        }
-      }
+      accept={null}
       className="form-dropzone style-square"
       inputProps={
         Object {
@@ -59,13 +54,13 @@ exports[`Backend.Resource.Form.File component renders correctly 1`] = `
           <p
             className="primary"
           >
-            <span
+            <button
               aria-hidden={true}
-              className="fake-link"
-              role="button"
+              className="form-dropzone__inline-button"
+              tabIndex="-1"
             >
               Upload a file
-            </span>
+            </button>
              or 
             <br />
             drag and drop here

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Image-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Image-test.js.snap
@@ -15,12 +15,7 @@ exports[`Backend.Resource.Form.Image component renders correctly 1`] = `
       Image File
     </label>
     <react-dropzone
-      accepts={
-        Object {
-          "accepts": "image/*",
-          "extensions": "gif, jpeg, jpg, png",
-        }
-      }
+      accept="image/*"
       className="form-dropzone style-square"
       inputProps={
         Object {
@@ -59,13 +54,13 @@ exports[`Backend.Resource.Form.Image component renders correctly 1`] = `
           <p
             className="primary"
           >
-            <span
+            <button
               aria-hidden={true}
-              className="fake-link"
-              role="button"
+              className="form-dropzone__inline-button"
+              tabIndex="-1"
             >
               Upload a file
-            </span>
+            </button>
              or 
             <br />
             drag and drop here

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Pdf-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Pdf-test.js.snap
@@ -15,12 +15,7 @@ exports[`Backend.Resource.Form.Pdf component renders correctly 1`] = `
       PDF File
     </label>
     <react-dropzone
-      accepts={
-        Object {
-          "accepts": "application/pdf",
-          "extensions": "pdf",
-        }
-      }
+      accept="application/pdf"
       className="form-dropzone style-square"
       inputProps={
         Object {
@@ -59,13 +54,13 @@ exports[`Backend.Resource.Form.Pdf component renders correctly 1`] = `
           <p
             className="primary"
           >
-            <span
+            <button
               aria-hidden={true}
-              className="fake-link"
-              role="button"
+              className="form-dropzone__inline-button"
+              tabIndex="-1"
             >
               Upload a file
-            </span>
+            </button>
              or 
             <br />
             drag and drop here

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Presentation-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Presentation-test.js.snap
@@ -15,12 +15,7 @@ exports[`Backend.Resource.Form.Presentation component renders correctly 1`] = `
       Presentation File
     </label>
     <react-dropzone
-      accepts={
-        Object {
-          "accepts": "application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-powerpoint,application/vnd.oasis.opendocument.presentation",
-          "extensions": "ppt, pptx, odp",
-        }
-      }
+      accept="application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-powerpoint,application/vnd.oasis.opendocument.presentation"
       className="form-dropzone style-square"
       inputProps={
         Object {
@@ -59,13 +54,13 @@ exports[`Backend.Resource.Form.Presentation component renders correctly 1`] = `
           <p
             className="primary"
           >
-            <span
+            <button
               aria-hidden={true}
-              className="fake-link"
-              role="button"
+              className="form-dropzone__inline-button"
+              tabIndex="-1"
             >
               Upload a file
-            </span>
+            </button>
              or 
             <br />
             drag and drop here

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Spreadsheet-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Spreadsheet-test.js.snap
@@ -15,12 +15,7 @@ exports[`Backend.Resource.Form.Spreadsheet component renders correctly 1`] = `
       Spreadsheet File
     </label>
     <react-dropzone
-      accepts={
-        Object {
-          "accepts": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,application/vnd.oasis.opendocument.spreadsheet,",
-          "extensions": "xls, xlsx, ods",
-        }
-      }
+      accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,application/vnd.oasis.opendocument.spreadsheet,"
       className="form-dropzone style-square"
       inputProps={
         Object {
@@ -59,13 +54,13 @@ exports[`Backend.Resource.Form.Spreadsheet component renders correctly 1`] = `
           <p
             className="primary"
           >
-            <span
+            <button
               aria-hidden={true}
-              className="fake-link"
-              role="button"
+              className="form-dropzone__inline-button"
+              tabIndex="-1"
             >
               Upload a file
-            </span>
+            </button>
              or 
             <br />
             drag and drop here

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Variants-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Variants-test.js.snap
@@ -24,12 +24,7 @@ exports[`Backend.Resource.Form.Variants component renders correctly 1`] = `
           Variant #1
         </label>
         <react-dropzone
-          accepts={
-            Object {
-              "accepts": null,
-              "extensions": null,
-            }
-          }
+          accept={null}
           className="form-dropzone style-square"
           inputProps={
             Object {
@@ -68,13 +63,13 @@ exports[`Backend.Resource.Form.Variants component renders correctly 1`] = `
               <p
                 className="primary"
               >
-                <span
+                <button
                   aria-hidden={true}
-                  className="fake-link"
-                  role="button"
+                  className="form-dropzone__inline-button"
+                  tabIndex="-1"
                 >
                   Upload a file
-                </span>
+                </button>
                  or 
                 <br />
                 drag and drop here
@@ -99,12 +94,7 @@ exports[`Backend.Resource.Form.Variants component renders correctly 1`] = `
           Variant #2
         </label>
         <react-dropzone
-          accepts={
-            Object {
-              "accepts": null,
-              "extensions": null,
-            }
-          }
+          accept={null}
           className="form-dropzone style-square"
           inputProps={
             Object {
@@ -143,13 +133,13 @@ exports[`Backend.Resource.Form.Variants component renders correctly 1`] = `
               <p
                 className="primary"
               >
-                <span
+                <button
                   aria-hidden={true}
-                  className="fake-link"
-                  role="button"
+                  className="form-dropzone__inline-button"
+                  tabIndex="-1"
                 >
                   Upload a file
-                </span>
+                </button>
                  or 
                 <br />
                 drag and drop here
@@ -182,12 +172,7 @@ exports[`Backend.Resource.Form.Variants component when kind is image renders cor
         High Resolution Image
       </label>
       <react-dropzone
-        accepts={
-          Object {
-            "accepts": "image/*",
-            "extensions": "gif, jpeg, jpg, png",
-          }
-        }
+        accept="image/*"
         className="form-dropzone style-square"
         inputProps={
           Object {
@@ -226,13 +211,13 @@ exports[`Backend.Resource.Form.Variants component when kind is image renders cor
             <p
               className="primary"
             >
-              <span
+              <button
                 aria-hidden={true}
-                className="fake-link"
-                role="button"
+                className="form-dropzone__inline-button"
+                tabIndex="-1"
               >
                 Upload a file
-              </span>
+              </button>
                or 
               <br />
               drag and drop here
@@ -262,12 +247,7 @@ exports[`Backend.Resource.Form.Variants component when kind is image renders cor
         Thumbnail Image
       </label>
       <react-dropzone
-        accepts={
-          Object {
-            "accepts": "image/*",
-            "extensions": "gif, jpeg, jpg, png",
-          }
-        }
+        accept="image/*"
         className="form-dropzone style-square"
         inputProps={
           Object {
@@ -306,13 +286,13 @@ exports[`Backend.Resource.Form.Variants component when kind is image renders cor
             <p
               className="primary"
             >
-              <span
+              <button
                 aria-hidden={true}
-                className="fake-link"
-                role="button"
+                className="form-dropzone__inline-button"
+                tabIndex="-1"
               >
                 Upload a file
-              </span>
+              </button>
                or 
               <br />
               drag and drop here
@@ -349,12 +329,7 @@ exports[`Backend.Resource.Form.Variants component when kind is pdf renders corre
         Thumbnail Image
       </label>
       <react-dropzone
-        accepts={
-          Object {
-            "accepts": "image/*",
-            "extensions": "gif, jpeg, jpg, png",
-          }
-        }
+        accept="image/*"
         className="form-dropzone style-square"
         inputProps={
           Object {
@@ -393,13 +368,13 @@ exports[`Backend.Resource.Form.Variants component when kind is pdf renders corre
             <p
               className="primary"
             >
-              <span
+              <button
                 aria-hidden={true}
-                className="fake-link"
-                role="button"
+                className="form-dropzone__inline-button"
+                tabIndex="-1"
               >
                 Upload a file
-              </span>
+              </button>
                or 
               <br />
               drag and drop here

--- a/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Video-test.js.snap
+++ b/client/src/backend/components/resource/form/kind/__tests__/__snapshots__/Video-test.js.snap
@@ -49,12 +49,7 @@ exports[`Backend.Resource.Form.Video component renders correctly 1`] = `
         Video File
       </label>
       <react-dropzone
-        accepts={
-          Object {
-            "accepts": "video/x-flv,video/*",
-            "extensions": "mp4, webm, flv, mov, avi",
-          }
-        }
+        accept="video/x-flv,video/*"
         className="form-dropzone style-square"
         inputProps={
           Object {
@@ -93,13 +88,13 @@ exports[`Backend.Resource.Form.Video component renders correctly 1`] = `
             <p
               className="primary"
             >
-              <span
+              <button
                 aria-hidden={true}
-                className="fake-link"
-                role="button"
+                className="form-dropzone__inline-button"
+                tabIndex="-1"
               >
                 Upload a file
-              </span>
+              </button>
                or 
               <br />
               drag and drop here

--- a/client/src/backend/containers/makers/__tests__/__snapshots__/Edit-test.js.snap
+++ b/client/src/backend/containers/makers/__tests__/__snapshots__/Edit-test.js.snap
@@ -161,12 +161,7 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
               Avatar Image
             </label>
             <react-dropzone
-              accepts={
-                Object {
-                  "accepts": "image/*",
-                  "extensions": "gif, jpeg, jpg, png",
-                }
-              }
+              accept="image/*"
               className="form-dropzone style-square"
               inputProps={
                 Object {
@@ -205,13 +200,13 @@ exports[`Backend People Makers Edit Container renders correctly 1`] = `
                   <p
                     className="primary"
                   >
-                    <span
+                    <button
                       aria-hidden={true}
-                      className="fake-link"
-                      role="button"
+                      className="form-dropzone__inline-button"
+                      tabIndex="-1"
                     >
                       Upload a file
-                    </span>
+                    </button>
                      or 
                     <br />
                     drag and drop here

--- a/client/src/backend/containers/makers/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/makers/__tests__/__snapshots__/New-test.js.snap
@@ -133,12 +133,7 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
               Avatar Image
             </label>
             <react-dropzone
-              accepts={
-                Object {
-                  "accepts": "image/*",
-                  "extensions": "gif, jpeg, jpg, png",
-                }
-              }
+              accept="image/*"
               className="form-dropzone style-square"
               inputProps={
                 Object {
@@ -177,13 +172,13 @@ exports[`Backend People Makers New Container renders correctly 1`] = `
                   <p
                     className="primary"
                   >
-                    <span
+                    <button
                       aria-hidden={true}
-                      className="fake-link"
-                      role="button"
+                      className="form-dropzone__inline-button"
+                      tabIndex="-1"
                     >
                       Upload a file
-                    </span>
+                    </button>
                      or 
                     <br />
                     drag and drop here

--- a/client/src/backend/containers/project/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/General-test.js.snap
@@ -1019,12 +1019,7 @@ exports[`Backend Project General Container renders correctly 1`] = `
                       style={Object {}}
                     >
                       <react-dropzone
-                        accepts={
-                          Object {
-                            "accepts": "image/*",
-                            "extensions": "gif, jpeg, jpg, png",
-                          }
-                        }
+                        accept="image/*"
                         className="form-dropzone style-square"
                         inputProps={
                           Object {
@@ -1063,13 +1058,13 @@ exports[`Backend Project General Container renders correctly 1`] = `
                             <p
                               className="primary"
                             >
-                              <span
+                              <button
                                 aria-hidden={true}
-                                className="fake-link"
-                                role="button"
+                                className="form-dropzone__inline-button"
+                                tabIndex="-1"
                               >
                                 Upload a file
-                              </span>
+                              </button>
                                or 
                               <br />
                               drag and drop here

--- a/client/src/backend/containers/project/__tests__/__snapshots__/ProjectPage-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/ProjectPage-test.js.snap
@@ -109,12 +109,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
                 Hero Image
               </label>
               <react-dropzone
-                accepts={
-                  Object {
-                    "accepts": "image/*",
-                    "extensions": "gif, jpeg, jpg, png",
-                  }
-                }
+                accept="image/*"
                 className="form-dropzone style-landscape"
                 inputProps={
                   Object {
@@ -153,13 +148,13 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
                     <p
                       className="primary"
                     >
-                      <span
+                      <button
                         aria-hidden={true}
-                        className="fake-link"
-                        role="button"
+                        className="form-dropzone__inline-button"
+                        tabIndex="-1"
                       >
                         Upload a file
-                      </span>
+                      </button>
                        or 
                       <br />
                       drag and drop here
@@ -195,12 +190,7 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
                 Cover
               </label>
               <react-dropzone
-                accepts={
-                  Object {
-                    "accepts": "image/*",
-                    "extensions": "gif, jpeg, jpg, png",
-                  }
-                }
+                accept="image/*"
                 className="form-dropzone style-portrait"
                 inputProps={
                   Object {
@@ -239,13 +229,13 @@ exports[`Backend Project ProjectPage Container renders correctly 1`] = `
                     <p
                       className="primary"
                     >
-                      <span
+                      <button
                         aria-hidden={true}
-                        className="fake-link"
-                        role="button"
+                        className="form-dropzone__inline-button"
+                        tabIndex="-1"
                       >
                         Upload a file
-                      </span>
+                      </button>
                        or 
                       <br />
                       drag and drop here

--- a/client/src/backend/containers/project/text/ingestion/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/project/text/ingestion/__tests__/__snapshots__/New-test.js.snap
@@ -30,12 +30,7 @@ exports[`Project Text Ingestion New Container renders correctly 1`] = `
               Upload a file
             </label>
             <react-dropzone
-              accepts={
-                Object {
-                  "accepts": null,
-                  "extensions": null,
-                }
-              }
+              accept={null}
               className="form-dropzone style-landscape"
               inputProps={
                 Object {
@@ -79,13 +74,13 @@ exports[`Project Text Ingestion New Container renders correctly 1`] = `
                   <p
                     className="primary"
                   >
-                    <span
+                    <button
                       aria-hidden={true}
-                      className="fake-link"
-                      role="button"
+                      className="form-dropzone__inline-button"
+                      tabIndex="-1"
                     >
                       Upload a file
-                    </span>
+                    </button>
                      or 
                     <br />
                     drag and drop here

--- a/client/src/backend/containers/resource-collection/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/resource-collection/__tests__/__snapshots__/General-test.js.snap
@@ -87,12 +87,7 @@ exports[`Backend ResourceCollection General Container renders correctly 1`] = `
             Cover Image
           </label>
           <react-dropzone
-            accepts={
-              Object {
-                "accepts": "image/*",
-                "extensions": "gif, jpeg, jpg, png",
-              }
-            }
+            accept="image/*"
             className="form-dropzone style-landscape"
             inputProps={
               Object {
@@ -131,13 +126,13 @@ exports[`Backend ResourceCollection General Container renders correctly 1`] = `
                 <p
                   className="primary"
                 >
-                  <span
+                  <button
                     aria-hidden={true}
-                    className="fake-link"
-                    role="button"
+                    className="form-dropzone__inline-button"
+                    tabIndex="-1"
                   >
                     Upload a file
-                  </span>
+                  </button>
                    or 
                   <br />
                   drag and drop here

--- a/client/src/backend/containers/resource-collection/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/resource-collection/__tests__/__snapshots__/New-test.js.snap
@@ -181,12 +181,7 @@ exports[`Backend ResourceCollection New Container renders correctly 1`] = `
                   Cover Image
                 </label>
                 <react-dropzone
-                  accepts={
-                    Object {
-                      "accepts": "image/*",
-                      "extensions": "gif, jpeg, jpg, png",
-                    }
-                  }
+                  accept="image/*"
                   className="form-dropzone style-landscape"
                   inputProps={
                     Object {
@@ -225,13 +220,13 @@ exports[`Backend ResourceCollection New Container renders correctly 1`] = `
                       <p
                         className="primary"
                       >
-                        <span
+                        <button
                           aria-hidden={true}
-                          className="fake-link"
-                          role="button"
+                          className="form-dropzone__inline-button"
+                          tabIndex="-1"
                         >
                           Upload a file
-                        </span>
+                        </button>
                          or 
                         <br />
                         drag and drop here

--- a/client/src/backend/containers/resource/__tests__/__snapshots__/General-test.js.snap
+++ b/client/src/backend/containers/resource/__tests__/__snapshots__/General-test.js.snap
@@ -429,12 +429,7 @@ exports[`Backend Resource General Container renders correctly 1`] = `
             Image File
           </label>
           <react-dropzone
-            accepts={
-              Object {
-                "accepts": "image/*",
-                "extensions": "gif, jpeg, jpg, png",
-              }
-            }
+            accept="image/*"
             className="form-dropzone style-square"
             inputProps={
               Object {
@@ -473,13 +468,13 @@ exports[`Backend Resource General Container renders correctly 1`] = `
                 <p
                   className="primary"
                 >
-                  <span
+                  <button
                     aria-hidden={true}
-                    className="fake-link"
-                    role="button"
+                    className="form-dropzone__inline-button"
+                    tabIndex="-1"
                   >
                     Upload a file
-                  </span>
+                  </button>
                    or 
                   <br />
                   drag and drop here

--- a/client/src/backend/containers/resource/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/resource/__tests__/__snapshots__/New-test.js.snap
@@ -631,12 +631,7 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                   Image File
                 </label>
                 <react-dropzone
-                  accepts={
-                    Object {
-                      "accepts": "image/*",
-                      "extensions": "gif, jpeg, jpg, png",
-                    }
-                  }
+                  accept="image/*"
                   className="form-dropzone style-square"
                   inputProps={
                     Object {
@@ -675,13 +670,13 @@ exports[`Backend Resource New Container renders correctly 1`] = `
                       <p
                         className="primary"
                       >
-                        <span
+                        <button
                           aria-hidden={true}
-                          className="fake-link"
-                          role="button"
+                          className="form-dropzone__inline-button"
+                          tabIndex="-1"
                         >
                           Upload a file
-                        </span>
+                        </button>
                          or 
                         <br />
                         drag and drop here

--- a/client/src/backend/containers/resource/__tests__/__snapshots__/Variants-test.js.snap
+++ b/client/src/backend/containers/resource/__tests__/__snapshots__/Variants-test.js.snap
@@ -25,12 +25,7 @@ exports[`Backend Resource Variants Container renders correctly 1`] = `
               High Resolution Image
             </label>
             <react-dropzone
-              accepts={
-                Object {
-                  "accepts": "image/*",
-                  "extensions": "gif, jpeg, jpg, png",
-                }
-              }
+              accept="image/*"
               className="form-dropzone style-square"
               inputProps={
                 Object {
@@ -69,13 +64,13 @@ exports[`Backend Resource Variants Container renders correctly 1`] = `
                   <p
                     className="primary"
                   >
-                    <span
+                    <button
                       aria-hidden={true}
-                      className="fake-link"
-                      role="button"
+                      className="form-dropzone__inline-button"
+                      tabIndex="-1"
                     >
                       Upload a file
-                    </span>
+                    </button>
                      or 
                     <br />
                     drag and drop here
@@ -105,12 +100,7 @@ exports[`Backend Resource Variants Container renders correctly 1`] = `
               Thumbnail Image
             </label>
             <react-dropzone
-              accepts={
-                Object {
-                  "accepts": "image/*",
-                  "extensions": "gif, jpeg, jpg, png",
-                }
-              }
+              accept="image/*"
               className="form-dropzone style-square"
               inputProps={
                 Object {
@@ -149,13 +139,13 @@ exports[`Backend Resource Variants Container renders correctly 1`] = `
                   <p
                     className="primary"
                   >
-                    <span
+                    <button
                       aria-hidden={true}
-                      className="fake-link"
-                      role="button"
+                      className="form-dropzone__inline-button"
+                      tabIndex="-1"
                     >
                       Upload a file
-                    </span>
+                    </button>
                      or 
                     <br />
                     drag and drop here

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Integrations-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Integrations-test.js.snap
@@ -210,12 +210,7 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                       Google Service Config File
                     </label>
                     <react-dropzone
-                      accepts={
-                        Object {
-                          "accepts": "application/json",
-                          "extensions": "json",
-                        }
-                      }
+                      accept="application/json"
                       className="form-dropzone style-square"
                       inputProps={
                         Object {
@@ -254,13 +249,13 @@ exports[`Backend Settings Integrations Container renders correctly 1`] = `
                           <p
                             className="primary"
                           >
-                            <span
+                            <button
                               aria-hidden={true}
-                              className="fake-link"
-                              role="button"
+                              className="form-dropzone__inline-button"
+                              tabIndex="-1"
                             >
                               Upload a file
-                            </span>
+                            </button>
                              or 
                             <br />
                             drag and drop here

--- a/client/src/backend/containers/settings/__tests__/__snapshots__/Theme-test.js.snap
+++ b/client/src/backend/containers/settings/__tests__/__snapshots__/Theme-test.js.snap
@@ -87,12 +87,7 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
                       Header Logo
                     </label>
                     <react-dropzone
-                      accepts={
-                        Object {
-                          "accepts": "image/*",
-                          "extensions": "gif, jpeg, jpg, png",
-                        }
-                      }
+                      accept="image/*"
                       className="form-dropzone style-square"
                       inputProps={
                         Object {
@@ -131,13 +126,13 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
                           <p
                             className="primary"
                           >
-                            <span
+                            <button
                               aria-hidden={true}
-                              className="fake-link"
-                              role="button"
+                              className="form-dropzone__inline-button"
+                              tabIndex="-1"
                             >
                               Upload a file
-                            </span>
+                            </button>
                              or 
                             <br />
                             drag and drop here
@@ -173,12 +168,7 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
                       Mobile Header Logo
                     </label>
                     <react-dropzone
-                      accepts={
-                        Object {
-                          "accepts": "image/*",
-                          "extensions": "gif, jpeg, jpg, png",
-                        }
-                      }
+                      accept="image/*"
                       className="form-dropzone style-square"
                       inputProps={
                         Object {
@@ -217,13 +207,13 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
                           <p
                             className="primary"
                           >
-                            <span
+                            <button
                               aria-hidden={true}
-                              className="fake-link"
-                              role="button"
+                              className="form-dropzone__inline-button"
+                              tabIndex="-1"
                             >
                               Upload a file
-                            </span>
+                            </button>
                              or 
                             <br />
                             drag and drop here
@@ -259,12 +249,7 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
                       Press Footer Logo
                     </label>
                     <react-dropzone
-                      accepts={
-                        Object {
-                          "accepts": "image/*",
-                          "extensions": "gif, jpeg, jpg, png",
-                        }
-                      }
+                      accept="image/*"
                       className="form-dropzone style-square"
                       inputProps={
                         Object {
@@ -303,13 +288,13 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
                           <p
                             className="primary"
                           >
-                            <span
+                            <button
                               aria-hidden={true}
-                              className="fake-link"
-                              role="button"
+                              className="form-dropzone__inline-button"
+                              tabIndex="-1"
                             >
                               Upload a file
-                            </span>
+                            </button>
                              or 
                             <br />
                             drag and drop here
@@ -345,12 +330,7 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
                       Favicon
                     </label>
                     <react-dropzone
-                      accepts={
-                        Object {
-                          "accepts": "image/*",
-                          "extensions": "gif, jpeg, jpg, png",
-                        }
-                      }
+                      accept="image/*"
                       className="form-dropzone style-square"
                       inputProps={
                         Object {
@@ -389,13 +369,13 @@ exports[`Backend Settings Theme Container renders correctly 1`] = `
                           <p
                             className="primary"
                           >
-                            <span
+                            <button
                               aria-hidden={true}
-                              className="fake-link"
-                              role="button"
+                              className="form-dropzone__inline-button"
+                              tabIndex="-1"
                             >
                               Upload a file
-                            </span>
+                            </button>
                              or 
                             <br />
                             drag and drop here

--- a/client/src/backend/containers/text/ingestion/__tests__/__snapshots__/New-test.js.snap
+++ b/client/src/backend/containers/text/ingestion/__tests__/__snapshots__/New-test.js.snap
@@ -30,12 +30,7 @@ exports[`Backend Text Ingestion New Container renders correctly 1`] = `
               Upload a file
             </label>
             <react-dropzone
-              accepts={
-                Object {
-                  "accepts": null,
-                  "extensions": null,
-                }
-              }
+              accept={null}
               className="form-dropzone style-landscape"
               inputProps={
                 Object {
@@ -79,13 +74,13 @@ exports[`Backend Text Ingestion New Container renders correctly 1`] = `
                   <p
                     className="primary"
                   >
-                    <span
+                    <button
                       aria-hidden={true}
-                      className="fake-link"
-                      role="button"
+                      className="form-dropzone__inline-button"
+                      tabIndex="-1"
                     >
                       Upload a file
-                    </span>
+                    </button>
                      or 
                     <br />
                     drag and drop here

--- a/client/src/theme/styles/components/global/forms/_shared.scss
+++ b/client/src/theme/styles/components/global/forms/_shared.scss
@@ -49,6 +49,14 @@
 .form-dropzone {
   cursor: pointer;
 
+  &__inline-button {
+    @include buttonUnstyled;
+    display: inline;
+    text-decoration: underline;
+    text-transform: inherit;
+    letter-spacing: inherit;
+  }
+
   .dropzone-button {
     @include buttonUnstyled;
     @include buttonRounded;


### PR DESCRIPTION
* Fixes prop name on, and data passed to, Dropzone component to correctly limit accepted file types for upload
* Uses native HTML `<button>` for all interactive elements to allow keyboard interaction

Resolves #2295