### PR TITLE
[B] Don't preserve :focus-visible class in polyfill

### DIFF
--- a/client/webpack/config/base.config.js
+++ b/client/webpack/config/base.config.js
@@ -6,6 +6,8 @@ import paths from "../helpers/paths";
 
 const nameTemplate = environment.production ? "[name]-[hash]" : "[name]";
 
+const postcssFocusVisible = require('postcss-focus-visible');
+
 /* eslint-disable  global-require */
 export default function buildWebpackConfiguration(target = "web") {
   function styleLoader() {
@@ -61,7 +63,11 @@ export default function buildWebpackConfiguration(target = "web") {
                 syntax: "postcss-scss",
                 plugins: () => [
                   require("autoprefixer"),
-                  require("postcss-focus-visible")
+                  postcssFocusVisible({
+                    // don't preserve `:focus-visible` selector until wider browser support exists
+                    // https://github.com/jonathantneal/postcss-focus-visible/issues/6
+                    preserve: false
+                  })
                 ]
               }
             },


### PR DESCRIPTION
Browsers that don't support this pseudo-class (all at the moment) will ignore any block that uses it. This is especially problematic is production, where minification merges related chunks of CSS. Until wider browser support exists, we're disabling the `preserve` option on the postCSS plugin, so that `:focus-visible` is removed entirely and just `.focus-visible` is used.

See https://github.com/jonathantneal/postcss-focus-visible/issues/6