### PR TITLE
[B] Improve Annotation.SourceSummary rendering

### DIFF
--- a/client/src/global/components/Annotation/Annotation/TextContent/index.js
+++ b/client/src/global/components/Annotation/Annotation/TextContent/index.js
@@ -15,7 +15,9 @@ export default class AnnotationSelectionWrapper extends PureComponent {
     subject: PropTypes.string,
     onViewInText: PropTypes.func,
     onAnnotate: PropTypes.func,
-    onLogin: PropTypes.func
+    onLogin: PropTypes.func,
+    projectTitle: PropTypes.string,
+    sectionTitle: PropTypes.string
   };
 
   constructor(props) {
@@ -98,12 +100,11 @@ export default class AnnotationSelectionWrapper extends PureComponent {
             iconClass={this.iconClassNames}
           />
           {this.maybeTruncateSelection()}
-          {this.viewable && (
-            <SourceSummary
-              projectTitle={projectTitle}
-              sectionTitle={sectionTitle}
-            />
-          )}
+          <SourceSummary
+            projectTitle={projectTitle}
+            sectionTitle={sectionTitle}
+            viewable={this.viewable}
+          />
         </div>
         {this.annotatable && (
           <Fragment>

--- a/client/src/global/components/Annotation/Annotation/index.js
+++ b/client/src/global/components/Annotation/Annotation/index.js
@@ -13,11 +13,17 @@ export default class Annotation extends PureComponent {
     });
   }
 
+  get textSection() {
+    return this.props.annotation.relationships.textSection;
+  }
+
   get projectTitle() {
+    if (!this.textSection || !this.textSection.attributes) return null;
     return this.props.annotation.relationships.textSection.attributes.textTitle;
   }
 
   get sectionTitle() {
+    if (!this.textSection || !this.textSection.attributes) return null;
     return this.props.annotation.relationships.textSection.attributes.name;
   }
 

--- a/client/src/global/components/Annotation/Highlight/index.js
+++ b/client/src/global/components/Annotation/Highlight/index.js
@@ -53,12 +53,18 @@ class HighlightDetail extends PureComponent {
     });
   }
 
+  get textSection() {
+    return this.props.annotation.relationships.textSection;
+  }
+
   get projectTitle() {
-    return this.props.annotation.relationships.textSection.attributes.textTitle;
+    if (!this.textSection || !this.textSection.attributes) return null;
+    return this.textSection.attributes.textTitle;
   }
 
   get sectionTitle() {
-    return this.props.annotation.relationships.textSection.attributes.name;
+    if (!this.textSection || !this.textSection.attributes) return null;
+    return this.textSection.attributes.name;
   }
 
   get user() {
@@ -83,14 +89,13 @@ class HighlightDetail extends PureComponent {
         <span className="annotation-selection__highlight-text">
           {annotation.attributes.subject}
         </span>
-        {this.viewable && (
-          <SourceSummary
-            user={this.user}
-            projectTitle={this.projectTitle}
-            sectionTitle={this.sectionTitle}
-            highlightDate={this.highlightDate}
-          />
-        )}
+        <SourceSummary
+          user={this.user}
+          projectTitle={this.projectTitle}
+          sectionTitle={this.sectionTitle}
+          highlightDate={this.highlightDate}
+          viewable={this.viewable}
+        />
         <Authorize entity={annotation} ability={"delete"}>
           <div className="annotation-selection__action-buttons">
             <Utility.ConfirmableButton

--- a/client/src/global/components/Annotation/SourceSummary/index.js
+++ b/client/src/global/components/Annotation/SourceSummary/index.js
@@ -5,44 +5,72 @@ import FormattedDate from "global/components/FormattedDate";
 
 export default class SourceSummary extends React.PureComponent {
   static propTypes = {
+    user: PropTypes.string,
     projectTitle: PropTypes.string,
-    sectionTitle: PropTypes.string
+    sectionTitle: PropTypes.string,
+    highlightDate: PropTypes.string,
+    viewable: PropTypes.bool
   };
 
-  renderUser(user) {
+  renderUser() {
+    if (!this.props.user) return null;
     return (
       <React.Fragment>
-        <i>{user}</i>
+        <i>{this.props.user}</i>
         {" highlighted "}
       </React.Fragment>
     );
   }
 
-  renderDate(highlightDate) {
+  renderSectionAndTitle() {
+    const { user, projectTitle, sectionTitle } = this.props;
+    if (!projectTitle && !sectionTitle) return null;
+
+    return (
+      <React.Fragment>
+        {!user && "from "}
+        {sectionTitle && `“${sectionTitle}”`}
+        {(sectionTitle && projectTitle) && " in "}
+        {projectTitle && <i>{projectTitle}</i>}
+      </React.Fragment>
+    );
+  }
+
+  renderDate() {
+    if (!this.props.highlightDate) return null;
     return (
       <React.Fragment>
         {" on "}
-        <FormattedDate date={highlightDate} />
+        <FormattedDate date={this.props.highlightDate} />
       </React.Fragment>
     );
   }
 
   render() {
-    const { projectTitle, sectionTitle, user, highlightDate } = this.props;
+    const {
+      user,
+      projectTitle,
+      sectionTitle,
+      highlightDate,
+      viewable
+    } = this.props;
+
+    if (!user && !projectTitle && !sectionTitle && !highlightDate) return null;
 
     return (
       <div className="annotation-selection__source-summary">
         <span className="annotation-selection__source-summary-text">
-          {user ? this.renderUser(user) : "from "}
-          {`"${sectionTitle}" in `}
-          <i>{projectTitle}</i>
-          {highlightDate && this.renderDate(highlightDate)}
+          {this.renderUser()}
+          {this.renderSectionAndTitle()}
+          {this.renderDate()}
         </span>
-        <Utility.IconComposer
-          icon="arrowLongRight16"
-          size={24}
-          iconClass="annotation-selection__hover-arrow"
-        />
+        {viewable && (
+          <Utility.IconComposer
+            icon="arrowLongRight16"
+            size={24}
+            iconClass="annotation-selection__hover-arrow"
+          />
+        )}
       </div>
     );
   }

--- a/client/src/reader/components/notes/__tests__/__snapshots__/DetailedList-test.js.snap
+++ b/client/src/reader/components/notes/__tests__/__snapshots__/DetailedList-test.js.snap
@@ -41,7 +41,8 @@ exports[`Reader.Notes.DetailedList Component renders correctly 1`] = `
                 Harry Henderson
               </i>
                highlighted 
-              "Title Page" in 
+              “Title Page”
+               in 
               <i>
                 Hail Seitan
               </i>
@@ -107,7 +108,8 @@ exports[`Reader.Notes.DetailedList Component renders correctly 1`] = `
                 Harry Henderson
               </i>
                highlighted 
-              "Title Page" in 
+              “Title Page”
+               in 
               <i>
                 Hail Seitan
               </i>

--- a/client/src/reader/containers/ReaderNotes/__tests__/__snapshots__/ReaderNotes-test.js.snap
+++ b/client/src/reader/containers/ReaderNotes/__tests__/__snapshots__/ReaderNotes-test.js.snap
@@ -39,7 +39,8 @@ exports[`Reader ReaderNotes Container renders correctly 1`] = `
                 Harry Henderson
               </i>
                highlighted 
-              "Title Page" in 
+              “Title Page”
+               in 
               <i>
                 Hail Seitan
               </i>
@@ -105,7 +106,8 @@ exports[`Reader ReaderNotes Container renders correctly 1`] = `
                 Harry Henderson
               </i>
                highlighted 
-              "Title Page" in 
+              “Title Page”
+               in 
               <i>
                 Hail Seitan
               </i>


### PR DESCRIPTION
Fixes a bug where annotations and highlights lacking a text section relationship were throwing an exception in the notes drawer. Also decouples rendering of SourceSummary content from whether the annotation is viewable in the text, and refines how SourceSummary content renders based on data available.