### PR TITLE
[B] Remove hyphenation from key text content

### DIFF
--- a/client/src/theme/styles/base/_appearance.scss
+++ b/client/src/theme/styles/base/_appearance.scss
@@ -457,6 +457,7 @@
     font-weight: $semibold;
     line-height: 1.188;
     white-space: normal;
+    hyphens: none;
     transition: color $duration $timing;
 
     .title-text {
@@ -490,6 +491,7 @@
   .relations-list {
     @include templateCopy;
     line-height: 1.25;
+    hyphens: none;
     transition: color $duration $timing;
   }
 

--- a/client/src/theme/styles/base/_typography.scss
+++ b/client/src/theme/styles/base/_typography.scss
@@ -42,6 +42,7 @@
   margin-bottom: 1.2em;
   font-weight: $medium;
   line-height: 1.32;
+  hyphens: none;
 }
 
 .heading-primary {

--- a/client/src/theme/styles/components/backend/_header.scss
+++ b/client/src/theme/styles/components/backend/_header.scss
@@ -126,6 +126,7 @@
     font-size: 16px;
     font-weight: $medium;
     color: $neutral20;
+    hyphens: none;
 
     @include respond($break65) {
       font-size: 23px;

--- a/client/src/theme/styles/components/backend/category/_text-category-list.scss
+++ b/client/src/theme/styles/components/backend/category/_text-category-list.scss
@@ -23,6 +23,7 @@
     margin: 4px 0;
     font-size: 14px;
     line-height: 1.3em;
+    hyphens: none;
 
     &--notice {
       color: $sp40Tertiary;
@@ -82,5 +83,3 @@
   }
 
 }
-
-

--- a/client/src/theme/styles/components/backend/category/_text-list.scss
+++ b/client/src/theme/styles/components/backend/category/_text-list.scss
@@ -68,6 +68,7 @@
     margin: 0 0 0.4em;
     font-size: 17px;
     color: $neutral30;
+    hyphens: none;
     transition: color $duration $timing;
   }
 

--- a/client/src/theme/styles/components/backend/forms/_has-many-list.scss
+++ b/client/src/theme/styles/components/backend/forms/_has-many-list.scss
@@ -145,6 +145,7 @@
       line-height: 29px;
       color: $neutral40;
       vertical-align: middle;
+      hyphens: none;
 
       @include respond($break60) {
         font-size: 20px;

--- a/client/src/theme/styles/components/backend/list/entity/_entity-row.scss
+++ b/client/src/theme/styles/components/backend/list/entity/_entity-row.scss
@@ -93,6 +93,7 @@
     font-size: 17px;
     font-weight: $regular;
     color: $neutral50;
+    hyphens: none;
 
     a {
       text-decoration: none;

--- a/client/src/theme/styles/components/frontend/collection/_list.scss
+++ b/client/src/theme/styles/components/frontend/collection/_list.scss
@@ -54,6 +54,7 @@
     width: 100%;
     background-color: transparentize($neutralBlack, 0.5);
     border-radius: 0 0 8px 8px;
+    hyphens: none;
     transition: background-color $duration ease-out;
 
     @include respond($break80) {

--- a/client/src/theme/styles/components/frontend/collection/_resource-slideshow.scss
+++ b/client/src/theme/styles/components/frontend/collection/_resource-slideshow.scss
@@ -144,6 +144,7 @@
     font-size: 20px;
     font-weight: $regular;
     color: $neutralOffBlack;
+    hyphens: none;
 
     @include respond($break60) {
       margin-bottom: 0.364em;

--- a/client/src/theme/styles/components/frontend/layout/header/standalone-header.scss
+++ b/client/src/theme/styles/components/frontend/layout/header/standalone-header.scss
@@ -85,6 +85,7 @@
 
   &__title-link {
     line-height: 1.45;
+    hyphens: none;
   }
 
   &__title {

--- a/client/src/theme/styles/components/frontend/page/_content.scss
+++ b/client/src/theme/styles/components/frontend/page/_content.scss
@@ -31,6 +31,7 @@
     font-size: 32px;
     font-weight: $semibold;
     line-height: 1.188;
+    hyphens: none;
   }
 
   h2 {
@@ -38,6 +39,7 @@
     font-size: 30px;
     font-weight: $medium;
     line-height: 1.233;
+    hyphens: none;
   }
 
   h3 {

--- a/client/src/theme/styles/components/frontend/project/_hero.scss
+++ b/client/src/theme/styles/components/frontend/project/_hero.scss
@@ -234,6 +234,7 @@
     position: relative;
     z-index: 50;
     margin-bottom: 24px;
+    hyphens: none;
 
     @include respond($break60) {
       display: block;

--- a/client/src/theme/styles/components/frontend/resource/_card.scss
+++ b/client/src/theme/styles/components/frontend/resource/_card.scss
@@ -172,6 +172,7 @@
     font-size: 16px;
     font-weight: $regular;
     color: $neutral75;
+    hyphens: none;
 
     @include respond($break85) {
       font-size: 17px;

--- a/client/src/theme/styles/components/frontend/resource/_detail.scss
+++ b/client/src/theme/styles/components/frontend/resource/_detail.scss
@@ -85,6 +85,7 @@
       font-size: 26px;
       font-weight: $medium;
       color: $neutral75;
+      hyphens: none;
 
       @include respond($break60) {
         width: auto;

--- a/client/src/theme/styles/components/frontend/text/_text-block.scss
+++ b/client/src/theme/styles/components/frontend/text/_text-block.scss
@@ -83,6 +83,7 @@
     padding-right: 20px;
     padding-left: 15px;
     vertical-align: top;
+    hyphens: none;
   }
 
   &__name {

--- a/client/src/theme/styles/components/global/_asset-thumbnail.scss
+++ b/client/src/theme/styles/components/global/_asset-thumbnail.scss
@@ -173,6 +173,7 @@
       font-weight: $light;
       line-height: 1.1;
       color: $neutral50;
+      hyphens: none;
     }
   }
 

--- a/client/src/theme/styles/components/global/annotation/_meta.scss
+++ b/client/src/theme/styles/components/global/annotation/_meta.scss
@@ -44,6 +44,7 @@
     @include templateHead;
     margin: 0;
     font-weight: $semibold;
+    hyphens: none;
   }
 
   .deleted-notification {

--- a/client/src/theme/styles/components/reader/_return-menu.scss
+++ b/client/src/theme/styles/components/reader/_return-menu.scss
@@ -93,6 +93,7 @@
     font-size: 17px;
     color: $neutral50;
     text-decoration: underline;
+    hyphens: none;
     transition: color $duration $timing;
 
     .reader-return-menu__link:hover &,

--- a/client/src/theme/styles/components/reader/_section-next-section.scss
+++ b/client/src/theme/styles/components/reader/_section-next-section.scss
@@ -40,6 +40,7 @@
     margin-bottom: 1em;
     font-size: 24px;
     font-weight: $semibold;
+    hyphens: none;
     color: $neutral70;
     transition: color $duration $timing;
 

--- a/client/src/theme/styles/components/reader/_toc-drawer.scss
+++ b/client/src/theme/styles/components/reader/_toc-drawer.scss
@@ -44,6 +44,7 @@
         line-height: 1.2;
         color: $neutral90;
         text-decoration: none;
+        hyphens: none;
         border-bottom: 1px solid $neutral40;
         transition: color $duration $timing,
           background-color $duration $timing;


### PR DESCRIPTION
Updates CSS to prevent hyphenation on names of texts, projects, makers, users, and other important pieces of content, such as major headings.

Resolves #1679