### PR TITLE
[B] Auto-fill columns for grid entity lists

### DIFF
--- a/client/src/theme/styles/components/backend/list/entity/_entity-list.scss
+++ b/client/src/theme/styles/components/backend/list/entity/_entity-list.scss
@@ -158,25 +158,18 @@
 
         @supports (grid-auto-columns: min-content) {
           display: grid;
-          grid-template-columns:repeat(3, 1fr);
-
-          li {
-            min-width: $grid-item-min-width;
-          }
+          grid-template-columns:repeat(auto-fill, minmax($grid-item-min-width, 1fr));
         }
 
         li {
           flex-basis: 33.333%;
           flex-grow: 1;
+          min-width: $grid-item-min-width;
           border-bottom: none;
         }
       }
 
       @include respond($break85) {
-        @supports (grid-auto-columns: min-content) {
-          grid-template-columns:repeat(4, 1fr);
-        }
-
         li {
           flex-basis: 25%;
         }


### PR DESCRIPTION
This commit reverts fd5092cd and solves #2119 by using auto-fill rather than auto-fit grid tracks. This change allows grid items to flow contextually rather than on fixed tracks, while filling extra space with additional grid tracks rather than widening the grid items.

Resolves #2317