### PR TITLE
[F] Render structured data for projects

### DIFF
--- a/client/src/frontend/containers/ProjectDetail/__tests__/__snapshots__/ProjectDetail-test.js.snap
+++ b/client/src/frontend/containers/ProjectDetail/__tests__/__snapshots__/ProjectDetail-test.js.snap
@@ -298,6 +298,14 @@ exports[`Frontend ProjectDetail Container renders correctly in library mode 1`] 
       </div>
     </section>
   </div>
+  <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"WebPage\\",\\"mainEntity\\":{\\"@type\\":\\"Book\\",\\"@id\\":\\"https://doi.org/10.12345.6789\\",\\"name\\":\\"Rowan Test\\",\\"url\\":\\"/projects/slug-1\\",\\"author\\":null,\\"contributor\\":null,\\"bookFormat\\":\\"EBook\\"}}",
+      }
+    }
+    type="application/ld+json"
+  />
 </div>
 `;
 
@@ -557,5 +565,13 @@ exports[`Frontend ProjectDetail Container renders correctly in standalone mode 1
       </div>
     </section>
   </div>
+  <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"WebPage\\",\\"mainEntity\\":{\\"@type\\":\\"Book\\",\\"@id\\":\\"https://doi.org/10.12345.6789\\",\\"name\\":\\"Rowan Test\\",\\"url\\":\\"/projects/slug-1\\",\\"author\\":null,\\"contributor\\":null,\\"bookFormat\\":\\"EBook\\"}}",
+      }
+    }
+    type="application/ld+json"
+  />
 </div>
 `;

--- a/client/src/frontend/containers/ProjectDetail/index.js
+++ b/client/src/frontend/containers/ProjectDetail/index.js
@@ -5,6 +5,7 @@ import { Redirect } from "react-router-dom";
 import lh from "helpers/linkHandler";
 import HeadContent from "global/components/HeadContent";
 import { uiFrontendModeActions } from "actions";
+import Schema from "global/components/schema";
 
 export default class ProjectDetailContainer extends Component {
   static propTypes = {
@@ -38,6 +39,10 @@ export default class ProjectDetailContainer extends Component {
         <Project.Detail
           project={this.props.project}
           dispatch={this.props.dispatch}
+        />
+        <Schema.Project
+          attributes={project.attributes}
+          relationships={project.relationships}
         />
       </div>
     );

--- a/client/src/global/components/schema/Project.js
+++ b/client/src/global/components/schema/Project.js
@@ -1,0 +1,136 @@
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
+import lh from "helpers/linkHandler";
+
+export default class Project extends PureComponent {
+  static displayName = "Schema.Project";
+
+  static propTypes = {
+    url: PropTypes.string,
+    attributes: PropTypes.shape({
+      title: PropTypes.string,
+      metadata: PropTypes.shape({
+        isbn: PropTypes.string,
+        rightsHolder: PropTypes.string,
+        publisher: PropTypes.string,
+        seriesTitle: PropTypes.string,
+        doi: PropTypes.string,
+        edition: PropTypes.string
+      }),
+      purchaseUrl: PropTypes.string,
+      purchasePrice: PropTypes.number,
+      purchasePriceCurrency: PropTypes.string,
+      avatarStyles: PropTypes.shape({
+        small: PropTypes.string
+      }),
+      publicationDate: PropTypes.string,
+      createdAt: PropTypes.string,
+      updatedAt: PropTypes.string
+    }),
+    relationships: PropTypes.shape({
+      creators: PropTypes.arrayOf(
+        PropTypes.shape({
+          attributes: PropTypes.shape({
+            fullName: PropTypes.string.isRequired
+          }).isRequired
+        })
+      ),
+      contributors: PropTypes.arrayOf(
+        PropTypes.shape({
+          attributes: PropTypes.shape({
+            fullName: PropTypes.string.isRequired
+          }).isRequired
+        })
+      )
+    })
+  };
+
+  get showOffer() {
+    const {
+      purchasePrice,
+      purchasePriceCurrency,
+      purchaseUrl
+    } = this.props.attributes;
+    return purchasePrice && purchasePriceCurrency && purchaseUrl;
+  }
+
+  personArray(persons) {
+    if (!persons || persons.length < 1) return null;
+
+    return persons.map(p => ({
+      "@type": "Person",
+      name: p.attributes.fullName
+    }));
+  }
+
+  renderSeries() {
+    const { seriesTitle } = this.props.attributes.metadata;
+
+    return {
+      "@type": "CreativeWorkSeries",
+      name: seriesTitle
+    };
+  }
+
+  renderOffer() {
+    const {
+      purchasePrice,
+      purchasePriceCurrency,
+      purchaseUrl
+    } = this.props.attributes;
+    return {
+      "@type": "Offer",
+      price: purchasePrice,
+      priceCurrency: purchasePriceCurrency,
+      url: purchaseUrl
+    };
+  }
+
+  renderMainEntity() {
+    const {
+      slug,
+      title,
+      metadata,
+      publicationDate,
+      createdAt,
+      updatedAt,
+      avatarStyles
+    } = this.props.attributes;
+    const { creators, contributors } = this.props.relationships;
+
+    return {
+      "@type": "Book",
+      "@id": metadata.doi,
+      name: title,
+      url: lh.link("frontendProjectDetail", slug),
+      isbn: metadata.isbn,
+      author: this.personArray(creators),
+      contributor: this.personArray(contributors),
+      copyrightHolder: metadata.rightsHolder,
+      dateCreated: createdAt,
+      dateModified: updatedAt,
+      datePublished: publicationDate,
+      publisher: metadata.publisher,
+      bookEdition: metadata.edition,
+      bookFormat: "EBook",
+      isPartOf: metadata.seriesTitle && this.renderSeries(),
+      image: avatarStyles && avatarStyles.small,
+      offers: this.showOffer && this.renderOffer()
+    };
+  }
+
+  render() {
+    const data = {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      mainEntity: this.renderMainEntity()
+    };
+
+    return (
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+      />
+    );
+  }
+}

--- a/client/src/global/components/schema/index.js
+++ b/client/src/global/components/schema/index.js
@@ -1,0 +1,5 @@
+import Project from "./Project";
+
+export default {
+  Project
+}


### PR DESCRIPTION
Creates a component, `Schema.Project`, that renders metadata in JSON-LD format on the project homepage in order to improve the quality of information in search results.

We treat these pages as type `WebPage` that describe a `mainEntity` of type `Book`, following https://schema.org/ guidelines.

Resolves #1350