### PR TITLE
[B] Fix content block margins

### DIFF
--- a/client/src/frontend/components/project/Detail.js
+++ b/client/src/frontend/components/project/Detail.js
@@ -25,11 +25,13 @@ class Detail extends Component {
     if (!project) return <LoadingBlock />;
 
     return (
-      <div>
-        <Hero project={project} />
-        <ContentBlock project={project} />
+      <>
+        <section>
+          <Hero project={project} />
+          <ContentBlock project={project} />
+        </section>
         {!this.context.isStandalone && <Layout.ButtonNavigation />}
-      </div>
+      </>
     );
   }
 }

--- a/client/src/frontend/components/project/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/project/__tests__/__snapshots__/Detail-test.js.snap
@@ -1,257 +1,259 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frontend.Project.Detail component renders correctly 1`] = `
-<div>
-  <section
-    className="project-hero project-hero--light"
-  >
-    <div
-      className="project-hero__inner"
+Array [
+  <section>
+    <section
+      className="project-hero project-hero--light"
     >
       <div
-        className="project-hero__left-top-block"
+        className="project-hero__inner"
       >
-        <div>
-          <header
-            className="project-hero__heading"
+        <div
+          className="project-hero__left-top-block"
+        >
+          <div>
+            <header
+              className="project-hero__heading"
+            >
+              <div
+                className="project-hero__heading-inner"
+              >
+                <h1
+                  className="project-hero__title"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "Rowan Test",
+                    }
+                  }
+                />
+                <div
+                  className="project-hero__subtitle"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": undefined,
+                    }
+                  }
+                />
+              </div>
+            </header>
+          </div>
+          <div
+            className="project-hero__meta-block"
           >
             <div
-              className="project-hero__heading-inner"
-            >
-              <h1
-                className="project-hero__title"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "Rowan Test",
-                  }
+              className="project-hero__description"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "The look in your eyes, I recognize it. You used to have it for me. I guess it's better to be lucky than good. Mr. Crusher, ready a collision course with the Borg ship. My oath is between Captain Kargan and myself. Your only concern is with how you obey my orders. Or do you prefer the rank of prisoner to that of lieutenant? That might've been one of the shortest assignments in the history of Starfleet. I'll alert the crew.",
                 }
-              />
-              <div
-                className="project-hero__subtitle"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": undefined,
-                  }
-                }
-              />
-            </div>
-          </header>
+              }
+            />
+          </div>
         </div>
         <div
-          className="project-hero__meta-block"
+          className="project-hero__left-bottom-block"
         >
           <div
-            className="project-hero__description"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "The look in your eyes, I recognize it. You used to have it for me. I guess it's better to be lucky than good. Mr. Crusher, ready a collision course with the Borg ship. My oath is between Captain Kargan and myself. Your only concern is with how you obey my orders. Or do you prefer the rank of prisoner to that of lieutenant? That might've been one of the shortest assignments in the history of Starfleet. I'll alert the crew.",
-              }
-            }
-          />
-        </div>
-      </div>
-      <div
-        className="project-hero__left-bottom-block"
-      >
-        <div
-          className="project-hero__social-block"
-        >
-          <a
-            className="project-hero__hashtag"
-            href="https://twitter.com/hashtag/cute_dog"
-            rel="noopener noreferrer"
-            target="_blank"
+            className="project-hero__social-block"
           >
-            #cute_dog
-          </a>
-        </div>
-      </div>
-      <div
-        className="project-hero__right-top-block"
-      >
-        <div
-          className="project-hero__cover-block"
-        >
-          <figure
-            className="project-hero__figure project-hero__figure--constrained"
-          >
-            <svg
-              aria-label={null}
-              className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
-              height={134}
-              viewBox="0 0 134 134"
-              width={134}
-              xmlns="http://www.w3.org/2000/svg"
+            <a
+              className="project-hero__hashtag"
+              href="https://twitter.com/hashtag/cute_dog"
+              rel="noopener noreferrer"
+              target="_blank"
             >
-              <g
-                fill="none"
-                fillRule="evenodd"
+              #cute_dog
+            </a>
+          </div>
+        </div>
+        <div
+          className="project-hero__right-top-block"
+        >
+          <div
+            className="project-hero__cover-block"
+          >
+            <figure
+              className="project-hero__figure project-hero__figure--constrained"
+            >
+              <svg
+                aria-label={null}
+                className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
+                height={134}
+                viewBox="0 0 134 134"
+                width={134}
+                xmlns="http://www.w3.org/2000/svg"
               >
                 <g
-                  className="project-thumb-placeholder__frame"
-                  strokeWidth="1.5"
-                  transform="translate(2 2)"
-                >
-                  <polyline
-                    points="124 6 124 124 6 124"
-                  />
-                  <polyline
-                    points="130 12 130 130 12 130"
-                  />
-                  <polygon
-                    points="0 118 118 118 118 0 0 0"
-                  />
-                </g>
-                <polygon
-                  className="project-thumb-placeholder__tile"
-                  points="0 102 102 102 102 0 0 0"
-                  transform="translate(10 10)"
-                />
-                <g
-                  className="project-thumb-placeholder__illustration"
-                  transform="translate(34 32)"
+                  fill="none"
+                  fillRule="evenodd"
                 >
                   <g
-                    transform="translate(47.557 2.968)"
+                    className="project-thumb-placeholder__frame"
+                    strokeWidth="1.5"
+                    transform="translate(2 2)"
                   >
                     <polyline
-                      className="project-thumb-placeholder__illustration"
-                      points=".271 7.606 .271 50.893 3.747 57.089 7.221 50.893 7.221 7.606"
-                      strokeWidth="1.5"
+                      points="124 6 124 124 6 124"
                     />
-                    <path
-                      d="M7.22166456 50.8926203L.271601266 50.8926203M.27135443 3.82883544L.27135443 2.02693671C.27135443.936746835 1.1558481.0522531646 2.24603797.0522531646L5.24673418.0522531646C6.33774684.0522531646 7.22141772.936746835 7.22141772 2.02693671L7.22141772 3.82883544"
-                      strokeWidth="1.5"
+                    <polyline
+                      points="130 12 130 130 12 130"
                     />
                     <polygon
-                      points=".272 7.606 7.222 7.606 7.222 3.829 .272 3.829"
-                      strokeWidth="1.5"
-                    />
-                    <path
-                      d="M3.74655063,11.5277975 L3.74655063,46.9708987"
-                      strokeWidth="1.5"
-                    />
-                    <polygon
-                      points="2.183 54.3 3.747 57.089 5.311 54.3"
+                      points="0 118 118 118 118 0 0 0"
                     />
                   </g>
-                  <g
-                    strokeWidth="1.5"
-                    transform="translate(0 26)"
-                  >
-                    <polygon
-                      points="34.054 .598 .703 .598 .703 26.635 17.859 26.635 17.859 34.057 24.336 26.635 34.054 26.635"
-                    />
-                    <path
-                      d="M28.3519304 7.9074557L6.30870253 7.9074557M28.3519304 18.7725759L6.30870253 18.7725759M28.3519304 13.3399747L6.30870253 13.3399747"
-                    />
-                  </g>
-                  <g
-                    strokeWidth="1.5"
-                  >
-                    <path
-                      d="M27.3882848 11.8128038C27.3882848 14.7707152 24.9898671 17.1691329 22.0319557 17.1691329 19.0740443 17.1691329 16.6756266 14.7707152 16.6756266 11.8128038 16.6756266 8.85489241 19.0740443 6.45647468 22.0319557 6.45647468 24.9898671 6.45647468 27.3882848 8.85489241 27.3882848 11.8128038zM27.3882848 12.0765886L34.9537911 4.51108228C36.3196139 3.14608228 38.6546772 4.11285443 38.6546772 6.04475316M8.54099982 6.88421582L14.7943291.639221519C16.1601519-.726601266 18.4952152.240993671 18.4952152 2.17206962M11.4153165 12.3338734L12.5877848 11.8393797C13.52 11.4469114 14.5706962 11.4469114 15.5029114 11.8393797L16.6753797 12.3338734"
-                    />
-                    <path
-                      d="M11.4153165,11.8128038 C11.4153165,14.7707152 9.01689873,17.1691329 6.05898734,17.1691329 C3.10107595,17.1691329 0.702658228,14.7707152 0.702658228,11.8128038 C0.702658228,8.85489241 3.10107595,6.45647468 6.05898734,6.45647468 C9.01689873,6.45647468 11.4153165,8.85489241 11.4153165,11.8128038 Z"
-                    />
-                  </g>
-                </g>
-              </g>
-            </svg>
-            <svg
-              aria-label={null}
-              className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
-              height="100%"
-              viewBox="0 0 48 48"
-              width="100%"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-              >
-                <polygon
-                  className="project-thumb-placeholder__tile"
-                  fill="#CBF7E6"
-                  points="0 42 42 42 42 0 0 0"
-                />
-                <g
-                  className="project-thumb-placeholder__illustration"
-                  transform="translate(9 8)"
-                >
-                  <g
-                    transform="translate(20.683 2.244)"
-                  >
-                    <polygon
-                      points=".161 2.954 .161 21.013 1.612 23.598 3.06 21.013 3.06 2.954"
-                    />
-                    <path
-                      d="M3.06081501,21.012797 L0.161633021,21.012797"
-                    />
-                    <path
-                      d="M0.162011257,2.95560225 L3.06119325,2.95560225 L3.06119325,1.53299812 C3.06119325,0.980713374 2.613478,0.532998124 2.06119325,0.532998124 L1.16201126,0.532998124 C0.609726507,0.532998124 0.162011257,0.980713374 0.162011257,1.53299812 L0.162011257,2.95560225 Z"
-                      strokeLinejoin="round"
-                    />
-                  </g>
-                  <g
-                    transform="translate(.195 11.463)"
-                  >
-                    <polygon
-                      points="14.898 .419 .985 .419 .985 11.282 8.141 11.282 8.141 14.378 10.844 11.282 14.898 11.282"
-                    />
-                    <path
-                      d="M12.5237854 3.46905816L3.32696735 3.46905816M12.5237854 8.00165403L3.32696735 8.00165403M12.5237854 5.73507242L3.32696735 5.73507242"
-                    />
-                  </g>
-                  <g
-                    transform="translate(.195 .195)"
-                  >
-                    <path
-                      d="M11.8853223 5.12585966C11.8853223 6.3608015 10.8848871 7.36123677 9.64994522 7.36123677 8.41689456 7.36123677 7.41645929 6.3608015 7.41645929 5.12585966 7.41645929 3.89091782 8.41689456 2.89048255 9.64994522 2.89048255 10.8848871 2.89048255 11.8853223 3.89091782 11.8853223 5.12585966zM11.8853223 5.23573734L15.0417051 2.0793546C15.6109508 1.51010882 16.5849096 1.91293058 16.5849096 2.71857411M3.99814784 3.09718874L6.63067317.464663415C7.20181013-.106473546 8.17576886.2982394 8.17576886 1.10388293"
-                    />
-                    <path
-                      d="M5.22155347 5.12585966C5.22155347 6.3608015 4.2211182 7.36123677 2.98617636 7.36123677 1.7531257 7.36123677.752690432 6.3608015.752690432 5.12585966.752690432 3.89091782 1.7531257 2.89048255 2.98617636 2.89048255 4.2211182 2.89048255 5.22155347 3.89091782 5.22155347 5.12585966zM5.22155347 5.34334559L5.71136961 5.13720675C6.09906191 4.97267392 6.53781614 4.97267392 6.92739962 5.13720675L7.41532458 5.34334559"
-                    />
-                  </g>
-                </g>
-                <g
-                  className="project-thumb-placeholder__frame"
-                  stroke="#828282"
-                >
-                  <polyline
-                    points="48 6 48 48 6 48"
-                  />
-                  <polyline
-                    points="45 3 45 45 3 45"
-                  />
                   <polygon
+                    className="project-thumb-placeholder__tile"
+                    points="0 102 102 102 102 0 0 0"
+                    transform="translate(10 10)"
+                  />
+                  <g
+                    className="project-thumb-placeholder__illustration"
+                    transform="translate(34 32)"
+                  >
+                    <g
+                      transform="translate(47.557 2.968)"
+                    >
+                      <polyline
+                        className="project-thumb-placeholder__illustration"
+                        points=".271 7.606 .271 50.893 3.747 57.089 7.221 50.893 7.221 7.606"
+                        strokeWidth="1.5"
+                      />
+                      <path
+                        d="M7.22166456 50.8926203L.271601266 50.8926203M.27135443 3.82883544L.27135443 2.02693671C.27135443.936746835 1.1558481.0522531646 2.24603797.0522531646L5.24673418.0522531646C6.33774684.0522531646 7.22141772.936746835 7.22141772 2.02693671L7.22141772 3.82883544"
+                        strokeWidth="1.5"
+                      />
+                      <polygon
+                        points=".272 7.606 7.222 7.606 7.222 3.829 .272 3.829"
+                        strokeWidth="1.5"
+                      />
+                      <path
+                        d="M3.74655063,11.5277975 L3.74655063,46.9708987"
+                        strokeWidth="1.5"
+                      />
+                      <polygon
+                        points="2.183 54.3 3.747 57.089 5.311 54.3"
+                      />
+                    </g>
+                    <g
+                      strokeWidth="1.5"
+                      transform="translate(0 26)"
+                    >
+                      <polygon
+                        points="34.054 .598 .703 .598 .703 26.635 17.859 26.635 17.859 34.057 24.336 26.635 34.054 26.635"
+                      />
+                      <path
+                        d="M28.3519304 7.9074557L6.30870253 7.9074557M28.3519304 18.7725759L6.30870253 18.7725759M28.3519304 13.3399747L6.30870253 13.3399747"
+                      />
+                    </g>
+                    <g
+                      strokeWidth="1.5"
+                    >
+                      <path
+                        d="M27.3882848 11.8128038C27.3882848 14.7707152 24.9898671 17.1691329 22.0319557 17.1691329 19.0740443 17.1691329 16.6756266 14.7707152 16.6756266 11.8128038 16.6756266 8.85489241 19.0740443 6.45647468 22.0319557 6.45647468 24.9898671 6.45647468 27.3882848 8.85489241 27.3882848 11.8128038zM27.3882848 12.0765886L34.9537911 4.51108228C36.3196139 3.14608228 38.6546772 4.11285443 38.6546772 6.04475316M8.54099982 6.88421582L14.7943291.639221519C16.1601519-.726601266 18.4952152.240993671 18.4952152 2.17206962M11.4153165 12.3338734L12.5877848 11.8393797C13.52 11.4469114 14.5706962 11.4469114 15.5029114 11.8393797L16.6753797 12.3338734"
+                      />
+                      <path
+                        d="M11.4153165,11.8128038 C11.4153165,14.7707152 9.01689873,17.1691329 6.05898734,17.1691329 C3.10107595,17.1691329 0.702658228,14.7707152 0.702658228,11.8128038 C0.702658228,8.85489241 3.10107595,6.45647468 6.05898734,6.45647468 C9.01689873,6.45647468 11.4153165,8.85489241 11.4153165,11.8128038 Z"
+                      />
+                    </g>
+                  </g>
+                </g>
+              </svg>
+              <svg
+                aria-label={null}
+                className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
+                height="100%"
+                viewBox="0 0 48 48"
+                width="100%"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                >
+                  <polygon
+                    className="project-thumb-placeholder__tile"
+                    fill="#CBF7E6"
                     points="0 42 42 42 42 0 0 0"
                   />
+                  <g
+                    className="project-thumb-placeholder__illustration"
+                    transform="translate(9 8)"
+                  >
+                    <g
+                      transform="translate(20.683 2.244)"
+                    >
+                      <polygon
+                        points=".161 2.954 .161 21.013 1.612 23.598 3.06 21.013 3.06 2.954"
+                      />
+                      <path
+                        d="M3.06081501,21.012797 L0.161633021,21.012797"
+                      />
+                      <path
+                        d="M0.162011257,2.95560225 L3.06119325,2.95560225 L3.06119325,1.53299812 C3.06119325,0.980713374 2.613478,0.532998124 2.06119325,0.532998124 L1.16201126,0.532998124 C0.609726507,0.532998124 0.162011257,0.980713374 0.162011257,1.53299812 L0.162011257,2.95560225 Z"
+                        strokeLinejoin="round"
+                      />
+                    </g>
+                    <g
+                      transform="translate(.195 11.463)"
+                    >
+                      <polygon
+                        points="14.898 .419 .985 .419 .985 11.282 8.141 11.282 8.141 14.378 10.844 11.282 14.898 11.282"
+                      />
+                      <path
+                        d="M12.5237854 3.46905816L3.32696735 3.46905816M12.5237854 8.00165403L3.32696735 8.00165403M12.5237854 5.73507242L3.32696735 5.73507242"
+                      />
+                    </g>
+                    <g
+                      transform="translate(.195 .195)"
+                    >
+                      <path
+                        d="M11.8853223 5.12585966C11.8853223 6.3608015 10.8848871 7.36123677 9.64994522 7.36123677 8.41689456 7.36123677 7.41645929 6.3608015 7.41645929 5.12585966 7.41645929 3.89091782 8.41689456 2.89048255 9.64994522 2.89048255 10.8848871 2.89048255 11.8853223 3.89091782 11.8853223 5.12585966zM11.8853223 5.23573734L15.0417051 2.0793546C15.6109508 1.51010882 16.5849096 1.91293058 16.5849096 2.71857411M3.99814784 3.09718874L6.63067317.464663415C7.20181013-.106473546 8.17576886.2982394 8.17576886 1.10388293"
+                      />
+                      <path
+                        d="M5.22155347 5.12585966C5.22155347 6.3608015 4.2211182 7.36123677 2.98617636 7.36123677 1.7531257 7.36123677.752690432 6.3608015.752690432 5.12585966.752690432 3.89091782 1.7531257 2.89048255 2.98617636 2.89048255 4.2211182 2.89048255 5.22155347 3.89091782 5.22155347 5.12585966zM5.22155347 5.34334559L5.71136961 5.13720675C6.09906191 4.97267392 6.53781614 4.97267392 6.92739962 5.13720675L7.41532458 5.34334559"
+                      />
+                    </g>
+                  </g>
+                  <g
+                    className="project-thumb-placeholder__frame"
+                    stroke="#828282"
+                  >
+                    <polyline
+                      points="48 6 48 48 6 48"
+                    />
+                    <polyline
+                      points="45 3 45 45 3 45"
+                    />
+                    <polygon
+                      points="0 42 42 42 42 0 0 0"
+                    />
+                  </g>
                 </g>
-              </g>
-            </svg>
-          </figure>
+              </svg>
+            </figure>
+          </div>
         </div>
-      </div>
-      <div
-        className="project-hero__right-bottom-block"
-      >
         <div
-          className="project-hero__credits-block"
+          className="project-hero__right-bottom-block"
         >
           <div
-            className="project-hero__credits-text"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<p>Rowan, <em>The Dog</em></p>",
+            className="project-hero__credits-block"
+          >
+            <div
+              className="project-hero__credits-text"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "<p>Rowan, <em>The Dog</em></p>",
+                }
               }
-            }
-          />
+            />
+          </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
+  </section>,
   <section
     className="bg-neutral05"
   >
@@ -293,262 +295,264 @@ exports[`Frontend.Project.Detail component renders correctly 1`] = `
         </a>
       </div>
     </div>
-  </section>
-</div>
+  </section>,
+]
 `;
 
 exports[`Frontend.Project.Detail component renders correctly when hideActivity is true 1`] = `
-<div>
-  <section
-    className="project-hero project-hero--light"
-  >
-    <div
-      className="project-hero__inner"
+Array [
+  <section>
+    <section
+      className="project-hero project-hero--light"
     >
       <div
-        className="project-hero__left-top-block"
+        className="project-hero__inner"
       >
-        <div>
-          <header
-            className="project-hero__heading"
+        <div
+          className="project-hero__left-top-block"
+        >
+          <div>
+            <header
+              className="project-hero__heading"
+            >
+              <div
+                className="project-hero__heading-inner"
+              >
+                <h1
+                  className="project-hero__title"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "Rowan Test",
+                    }
+                  }
+                />
+                <div
+                  className="project-hero__subtitle"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": undefined,
+                    }
+                  }
+                />
+              </div>
+            </header>
+          </div>
+          <div
+            className="project-hero__meta-block"
           >
             <div
-              className="project-hero__heading-inner"
-            >
-              <h1
-                className="project-hero__title"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "Rowan Test",
-                  }
+              className="project-hero__description"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "The look in your eyes, I recognize it. You used to have it for me. I guess it's better to be lucky than good. Mr. Crusher, ready a collision course with the Borg ship. My oath is between Captain Kargan and myself. Your only concern is with how you obey my orders. Or do you prefer the rank of prisoner to that of lieutenant? That might've been one of the shortest assignments in the history of Starfleet. I'll alert the crew.",
                 }
-              />
-              <div
-                className="project-hero__subtitle"
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": undefined,
-                  }
-                }
-              />
-            </div>
-          </header>
+              }
+            />
+          </div>
         </div>
         <div
-          className="project-hero__meta-block"
+          className="project-hero__left-bottom-block"
         >
           <div
-            className="project-hero__description"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "The look in your eyes, I recognize it. You used to have it for me. I guess it's better to be lucky than good. Mr. Crusher, ready a collision course with the Borg ship. My oath is between Captain Kargan and myself. Your only concern is with how you obey my orders. Or do you prefer the rank of prisoner to that of lieutenant? That might've been one of the shortest assignments in the history of Starfleet. I'll alert the crew.",
-              }
-            }
-          />
-        </div>
-      </div>
-      <div
-        className="project-hero__left-bottom-block"
-      >
-        <div
-          className="project-hero__social-block"
-        >
-          <a
-            className="project-hero__hashtag"
-            href="https://twitter.com/hashtag/cute_dog"
-            rel="noopener noreferrer"
-            target="_blank"
+            className="project-hero__social-block"
           >
-            #cute_dog
-          </a>
-        </div>
-      </div>
-      <div
-        className="project-hero__right-top-block"
-      >
-        <div
-          className="project-hero__cover-block"
-        >
-          <figure
-            className="project-hero__figure project-hero__figure--constrained"
-          >
-            <svg
-              aria-label={null}
-              className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
-              height={134}
-              viewBox="0 0 134 134"
-              width={134}
-              xmlns="http://www.w3.org/2000/svg"
+            <a
+              className="project-hero__hashtag"
+              href="https://twitter.com/hashtag/cute_dog"
+              rel="noopener noreferrer"
+              target="_blank"
             >
-              <g
-                fill="none"
-                fillRule="evenodd"
+              #cute_dog
+            </a>
+          </div>
+        </div>
+        <div
+          className="project-hero__right-top-block"
+        >
+          <div
+            className="project-hero__cover-block"
+          >
+            <figure
+              className="project-hero__figure project-hero__figure--constrained"
+            >
+              <svg
+                aria-label={null}
+                className="project-thumb-placeholder project-thumb-placeholder--desktop project-thumb-placeholder--primary"
+                height={134}
+                viewBox="0 0 134 134"
+                width={134}
+                xmlns="http://www.w3.org/2000/svg"
               >
                 <g
-                  className="project-thumb-placeholder__frame"
-                  strokeWidth="1.5"
-                  transform="translate(2 2)"
-                >
-                  <polyline
-                    points="124 6 124 124 6 124"
-                  />
-                  <polyline
-                    points="130 12 130 130 12 130"
-                  />
-                  <polygon
-                    points="0 118 118 118 118 0 0 0"
-                  />
-                </g>
-                <polygon
-                  className="project-thumb-placeholder__tile"
-                  points="0 102 102 102 102 0 0 0"
-                  transform="translate(10 10)"
-                />
-                <g
-                  className="project-thumb-placeholder__illustration"
-                  transform="translate(34 32)"
+                  fill="none"
+                  fillRule="evenodd"
                 >
                   <g
-                    transform="translate(47.557 2.968)"
+                    className="project-thumb-placeholder__frame"
+                    strokeWidth="1.5"
+                    transform="translate(2 2)"
                   >
                     <polyline
-                      className="project-thumb-placeholder__illustration"
-                      points=".271 7.606 .271 50.893 3.747 57.089 7.221 50.893 7.221 7.606"
-                      strokeWidth="1.5"
+                      points="124 6 124 124 6 124"
                     />
-                    <path
-                      d="M7.22166456 50.8926203L.271601266 50.8926203M.27135443 3.82883544L.27135443 2.02693671C.27135443.936746835 1.1558481.0522531646 2.24603797.0522531646L5.24673418.0522531646C6.33774684.0522531646 7.22141772.936746835 7.22141772 2.02693671L7.22141772 3.82883544"
-                      strokeWidth="1.5"
+                    <polyline
+                      points="130 12 130 130 12 130"
                     />
                     <polygon
-                      points=".272 7.606 7.222 7.606 7.222 3.829 .272 3.829"
-                      strokeWidth="1.5"
-                    />
-                    <path
-                      d="M3.74655063,11.5277975 L3.74655063,46.9708987"
-                      strokeWidth="1.5"
-                    />
-                    <polygon
-                      points="2.183 54.3 3.747 57.089 5.311 54.3"
+                      points="0 118 118 118 118 0 0 0"
                     />
                   </g>
-                  <g
-                    strokeWidth="1.5"
-                    transform="translate(0 26)"
-                  >
-                    <polygon
-                      points="34.054 .598 .703 .598 .703 26.635 17.859 26.635 17.859 34.057 24.336 26.635 34.054 26.635"
-                    />
-                    <path
-                      d="M28.3519304 7.9074557L6.30870253 7.9074557M28.3519304 18.7725759L6.30870253 18.7725759M28.3519304 13.3399747L6.30870253 13.3399747"
-                    />
-                  </g>
-                  <g
-                    strokeWidth="1.5"
-                  >
-                    <path
-                      d="M27.3882848 11.8128038C27.3882848 14.7707152 24.9898671 17.1691329 22.0319557 17.1691329 19.0740443 17.1691329 16.6756266 14.7707152 16.6756266 11.8128038 16.6756266 8.85489241 19.0740443 6.45647468 22.0319557 6.45647468 24.9898671 6.45647468 27.3882848 8.85489241 27.3882848 11.8128038zM27.3882848 12.0765886L34.9537911 4.51108228C36.3196139 3.14608228 38.6546772 4.11285443 38.6546772 6.04475316M8.54099982 6.88421582L14.7943291.639221519C16.1601519-.726601266 18.4952152.240993671 18.4952152 2.17206962M11.4153165 12.3338734L12.5877848 11.8393797C13.52 11.4469114 14.5706962 11.4469114 15.5029114 11.8393797L16.6753797 12.3338734"
-                    />
-                    <path
-                      d="M11.4153165,11.8128038 C11.4153165,14.7707152 9.01689873,17.1691329 6.05898734,17.1691329 C3.10107595,17.1691329 0.702658228,14.7707152 0.702658228,11.8128038 C0.702658228,8.85489241 3.10107595,6.45647468 6.05898734,6.45647468 C9.01689873,6.45647468 11.4153165,8.85489241 11.4153165,11.8128038 Z"
-                    />
-                  </g>
-                </g>
-              </g>
-            </svg>
-            <svg
-              aria-label={null}
-              className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
-              height="100%"
-              viewBox="0 0 48 48"
-              width="100%"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fillRule="evenodd"
-              >
-                <polygon
-                  className="project-thumb-placeholder__tile"
-                  fill="#CBF7E6"
-                  points="0 42 42 42 42 0 0 0"
-                />
-                <g
-                  className="project-thumb-placeholder__illustration"
-                  transform="translate(9 8)"
-                >
-                  <g
-                    transform="translate(20.683 2.244)"
-                  >
-                    <polygon
-                      points=".161 2.954 .161 21.013 1.612 23.598 3.06 21.013 3.06 2.954"
-                    />
-                    <path
-                      d="M3.06081501,21.012797 L0.161633021,21.012797"
-                    />
-                    <path
-                      d="M0.162011257,2.95560225 L3.06119325,2.95560225 L3.06119325,1.53299812 C3.06119325,0.980713374 2.613478,0.532998124 2.06119325,0.532998124 L1.16201126,0.532998124 C0.609726507,0.532998124 0.162011257,0.980713374 0.162011257,1.53299812 L0.162011257,2.95560225 Z"
-                      strokeLinejoin="round"
-                    />
-                  </g>
-                  <g
-                    transform="translate(.195 11.463)"
-                  >
-                    <polygon
-                      points="14.898 .419 .985 .419 .985 11.282 8.141 11.282 8.141 14.378 10.844 11.282 14.898 11.282"
-                    />
-                    <path
-                      d="M12.5237854 3.46905816L3.32696735 3.46905816M12.5237854 8.00165403L3.32696735 8.00165403M12.5237854 5.73507242L3.32696735 5.73507242"
-                    />
-                  </g>
-                  <g
-                    transform="translate(.195 .195)"
-                  >
-                    <path
-                      d="M11.8853223 5.12585966C11.8853223 6.3608015 10.8848871 7.36123677 9.64994522 7.36123677 8.41689456 7.36123677 7.41645929 6.3608015 7.41645929 5.12585966 7.41645929 3.89091782 8.41689456 2.89048255 9.64994522 2.89048255 10.8848871 2.89048255 11.8853223 3.89091782 11.8853223 5.12585966zM11.8853223 5.23573734L15.0417051 2.0793546C15.6109508 1.51010882 16.5849096 1.91293058 16.5849096 2.71857411M3.99814784 3.09718874L6.63067317.464663415C7.20181013-.106473546 8.17576886.2982394 8.17576886 1.10388293"
-                    />
-                    <path
-                      d="M5.22155347 5.12585966C5.22155347 6.3608015 4.2211182 7.36123677 2.98617636 7.36123677 1.7531257 7.36123677.752690432 6.3608015.752690432 5.12585966.752690432 3.89091782 1.7531257 2.89048255 2.98617636 2.89048255 4.2211182 2.89048255 5.22155347 3.89091782 5.22155347 5.12585966zM5.22155347 5.34334559L5.71136961 5.13720675C6.09906191 4.97267392 6.53781614 4.97267392 6.92739962 5.13720675L7.41532458 5.34334559"
-                    />
-                  </g>
-                </g>
-                <g
-                  className="project-thumb-placeholder__frame"
-                  stroke="#828282"
-                >
-                  <polyline
-                    points="48 6 48 48 6 48"
-                  />
-                  <polyline
-                    points="45 3 45 45 3 45"
-                  />
                   <polygon
+                    className="project-thumb-placeholder__tile"
+                    points="0 102 102 102 102 0 0 0"
+                    transform="translate(10 10)"
+                  />
+                  <g
+                    className="project-thumb-placeholder__illustration"
+                    transform="translate(34 32)"
+                  >
+                    <g
+                      transform="translate(47.557 2.968)"
+                    >
+                      <polyline
+                        className="project-thumb-placeholder__illustration"
+                        points=".271 7.606 .271 50.893 3.747 57.089 7.221 50.893 7.221 7.606"
+                        strokeWidth="1.5"
+                      />
+                      <path
+                        d="M7.22166456 50.8926203L.271601266 50.8926203M.27135443 3.82883544L.27135443 2.02693671C.27135443.936746835 1.1558481.0522531646 2.24603797.0522531646L5.24673418.0522531646C6.33774684.0522531646 7.22141772.936746835 7.22141772 2.02693671L7.22141772 3.82883544"
+                        strokeWidth="1.5"
+                      />
+                      <polygon
+                        points=".272 7.606 7.222 7.606 7.222 3.829 .272 3.829"
+                        strokeWidth="1.5"
+                      />
+                      <path
+                        d="M3.74655063,11.5277975 L3.74655063,46.9708987"
+                        strokeWidth="1.5"
+                      />
+                      <polygon
+                        points="2.183 54.3 3.747 57.089 5.311 54.3"
+                      />
+                    </g>
+                    <g
+                      strokeWidth="1.5"
+                      transform="translate(0 26)"
+                    >
+                      <polygon
+                        points="34.054 .598 .703 .598 .703 26.635 17.859 26.635 17.859 34.057 24.336 26.635 34.054 26.635"
+                      />
+                      <path
+                        d="M28.3519304 7.9074557L6.30870253 7.9074557M28.3519304 18.7725759L6.30870253 18.7725759M28.3519304 13.3399747L6.30870253 13.3399747"
+                      />
+                    </g>
+                    <g
+                      strokeWidth="1.5"
+                    >
+                      <path
+                        d="M27.3882848 11.8128038C27.3882848 14.7707152 24.9898671 17.1691329 22.0319557 17.1691329 19.0740443 17.1691329 16.6756266 14.7707152 16.6756266 11.8128038 16.6756266 8.85489241 19.0740443 6.45647468 22.0319557 6.45647468 24.9898671 6.45647468 27.3882848 8.85489241 27.3882848 11.8128038zM27.3882848 12.0765886L34.9537911 4.51108228C36.3196139 3.14608228 38.6546772 4.11285443 38.6546772 6.04475316M8.54099982 6.88421582L14.7943291.639221519C16.1601519-.726601266 18.4952152.240993671 18.4952152 2.17206962M11.4153165 12.3338734L12.5877848 11.8393797C13.52 11.4469114 14.5706962 11.4469114 15.5029114 11.8393797L16.6753797 12.3338734"
+                      />
+                      <path
+                        d="M11.4153165,11.8128038 C11.4153165,14.7707152 9.01689873,17.1691329 6.05898734,17.1691329 C3.10107595,17.1691329 0.702658228,14.7707152 0.702658228,11.8128038 C0.702658228,8.85489241 3.10107595,6.45647468 6.05898734,6.45647468 C9.01689873,6.45647468 11.4153165,8.85489241 11.4153165,11.8128038 Z"
+                      />
+                    </g>
+                  </g>
+                </g>
+              </svg>
+              <svg
+                aria-label={null}
+                className="project-thumb-placeholder project-thumb-placeholder--mobile project-thumb-placeholder--primary"
+                height="100%"
+                viewBox="0 0 48 48"
+                width="100%"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                >
+                  <polygon
+                    className="project-thumb-placeholder__tile"
+                    fill="#CBF7E6"
                     points="0 42 42 42 42 0 0 0"
                   />
+                  <g
+                    className="project-thumb-placeholder__illustration"
+                    transform="translate(9 8)"
+                  >
+                    <g
+                      transform="translate(20.683 2.244)"
+                    >
+                      <polygon
+                        points=".161 2.954 .161 21.013 1.612 23.598 3.06 21.013 3.06 2.954"
+                      />
+                      <path
+                        d="M3.06081501,21.012797 L0.161633021,21.012797"
+                      />
+                      <path
+                        d="M0.162011257,2.95560225 L3.06119325,2.95560225 L3.06119325,1.53299812 C3.06119325,0.980713374 2.613478,0.532998124 2.06119325,0.532998124 L1.16201126,0.532998124 C0.609726507,0.532998124 0.162011257,0.980713374 0.162011257,1.53299812 L0.162011257,2.95560225 Z"
+                        strokeLinejoin="round"
+                      />
+                    </g>
+                    <g
+                      transform="translate(.195 11.463)"
+                    >
+                      <polygon
+                        points="14.898 .419 .985 .419 .985 11.282 8.141 11.282 8.141 14.378 10.844 11.282 14.898 11.282"
+                      />
+                      <path
+                        d="M12.5237854 3.46905816L3.32696735 3.46905816M12.5237854 8.00165403L3.32696735 8.00165403M12.5237854 5.73507242L3.32696735 5.73507242"
+                      />
+                    </g>
+                    <g
+                      transform="translate(.195 .195)"
+                    >
+                      <path
+                        d="M11.8853223 5.12585966C11.8853223 6.3608015 10.8848871 7.36123677 9.64994522 7.36123677 8.41689456 7.36123677 7.41645929 6.3608015 7.41645929 5.12585966 7.41645929 3.89091782 8.41689456 2.89048255 9.64994522 2.89048255 10.8848871 2.89048255 11.8853223 3.89091782 11.8853223 5.12585966zM11.8853223 5.23573734L15.0417051 2.0793546C15.6109508 1.51010882 16.5849096 1.91293058 16.5849096 2.71857411M3.99814784 3.09718874L6.63067317.464663415C7.20181013-.106473546 8.17576886.2982394 8.17576886 1.10388293"
+                      />
+                      <path
+                        d="M5.22155347 5.12585966C5.22155347 6.3608015 4.2211182 7.36123677 2.98617636 7.36123677 1.7531257 7.36123677.752690432 6.3608015.752690432 5.12585966.752690432 3.89091782 1.7531257 2.89048255 2.98617636 2.89048255 4.2211182 2.89048255 5.22155347 3.89091782 5.22155347 5.12585966zM5.22155347 5.34334559L5.71136961 5.13720675C6.09906191 4.97267392 6.53781614 4.97267392 6.92739962 5.13720675L7.41532458 5.34334559"
+                      />
+                    </g>
+                  </g>
+                  <g
+                    className="project-thumb-placeholder__frame"
+                    stroke="#828282"
+                  >
+                    <polyline
+                      points="48 6 48 48 6 48"
+                    />
+                    <polyline
+                      points="45 3 45 45 3 45"
+                    />
+                    <polygon
+                      points="0 42 42 42 42 0 0 0"
+                    />
+                  </g>
                 </g>
-              </g>
-            </svg>
-          </figure>
+              </svg>
+            </figure>
+          </div>
         </div>
-      </div>
-      <div
-        className="project-hero__right-bottom-block"
-      >
         <div
-          className="project-hero__credits-block"
+          className="project-hero__right-bottom-block"
         >
           <div
-            className="project-hero__credits-text"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "<p>Rowan, <em>The Dog</em></p>",
+            className="project-hero__credits-block"
+          >
+            <div
+              className="project-hero__credits-text"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "<p>Rowan, <em>The Dog</em></p>",
+                }
               }
-            }
-          />
+            />
+          </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
+  </section>,
   <section
     className="bg-neutral05"
   >
@@ -590,6 +594,6 @@ exports[`Frontend.Project.Detail component renders correctly when hideActivity i
         </a>
       </div>
     </div>
-  </section>
-</div>
+  </section>,
+]
 `;

--- a/client/src/frontend/containers/ProjectDetail/__tests__/__snapshots__/ProjectDetail-test.js.snap
+++ b/client/src/frontend/containers/ProjectDetail/__tests__/__snapshots__/ProjectDetail-test.js.snap
@@ -4,7 +4,7 @@ exports[`Frontend ProjectDetail Container renders correctly in library mode 1`] 
 <div
   className="project-detail"
 >
-  <div>
+  <section>
     <section
       className="project-hero project-hero--light"
     >
@@ -255,49 +255,49 @@ exports[`Frontend ProjectDetail Container renders correctly in library mode 1`] 
         </div>
       </div>
     </section>
-    <section
-      className="bg-neutral05"
+  </section>
+  <section
+    className="bg-neutral05"
+  >
+    <div
+      className="container"
     >
-      <div
-        className="container"
+      <h2
+        className="screen-reader-text"
       >
-        <h2
-          className="screen-reader-text"
+        Project Navigation
+      </h2>
+      <div
+        className="button-nav button-nav--default"
+      >
+        <a
+          className="button-icon-primary"
+          href="/projects/all"
+          onClick={[Function]}
         >
-          Project Navigation
-        </h2>
-        <div
-          className="button-nav button-nav--default"
-        >
-          <a
-            className="button-icon-primary"
-            href="/projects/all"
-            onClick={[Function]}
+          <svg
+            aria-hidden={true}
+            className="manicon-svg button-icon-primary__icon svg-icon--projects64"
+            fill="currentColor"
+            height={48}
+            viewBox="0 0 64 64"
+            width={48}
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-hidden={true}
-              className="manicon-svg button-icon-primary__icon svg-icon--projects64"
-              fill="currentColor"
-              height={48}
-              viewBox="0 0 64 64"
-              width={48}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M48.522,10 L36.417,11.872 L42.4,50.553 L35.188,50.553 L35.188,11.257 L22.939,11.257 L22.939,50.553 L20.819,50.553 L20.819,11.257 L8.57,11.257 L8.57,50.553 L4,50.553 L4,52.553 L59.467,52.553 L59.467,50.553 L50.237,50.553 L54.688,49.865 L48.522,10 Z M38.699,13.542 L46.851,12.281 L52.405,48.194 L44.254,49.455 L38.699,13.542 Z M24.939,15.622 L33.188,15.622 L33.188,13.257 L24.939,13.257 L24.939,15.622 Z M10.57,16.689 L18.819,16.689 L18.819,13.257 L10.57,13.257 L10.57,16.689 Z M24.939,19.725 L33.188,19.725 L33.188,17.622 L24.939,17.622 L24.939,19.725 Z M10.57,44.164 L18.819,44.164 L18.819,18.689 L10.57,18.689 L10.57,44.164 Z M24.939,41.127 L33.188,41.127 L33.188,21.726 L24.939,21.726 L24.939,41.127 Z M24.939,45.23 L33.188,45.23 L33.188,43.127 L24.939,43.127 L24.939,45.23 Z M10.57,49.596 L18.819,49.596 L18.819,46.163 L10.57,46.163 L10.57,49.596 Z M24.939,49.595 L33.188,49.595 L33.188,47.23 L24.939,47.23 L24.939,49.595 Z M45.8783,32.9758 C47.0433,32.7958 47.8403,31.7058 47.6603,30.5418 C47.4803,29.3778 46.3903,28.5798 45.2263,28.7598 C44.0623,28.9408 43.2643,30.0308 43.4443,31.1948 C43.6243,32.3588 44.7143,33.1568 45.8783,32.9758"
-                fillRule="evenodd"
-              />
-            </svg>
-            <span
-              className="button-icon-primary__text"
-            >
-              See All Projects
-            </span>
-          </a>
-        </div>
+            <path
+              d="M48.522,10 L36.417,11.872 L42.4,50.553 L35.188,50.553 L35.188,11.257 L22.939,11.257 L22.939,50.553 L20.819,50.553 L20.819,11.257 L8.57,11.257 L8.57,50.553 L4,50.553 L4,52.553 L59.467,52.553 L59.467,50.553 L50.237,50.553 L54.688,49.865 L48.522,10 Z M38.699,13.542 L46.851,12.281 L52.405,48.194 L44.254,49.455 L38.699,13.542 Z M24.939,15.622 L33.188,15.622 L33.188,13.257 L24.939,13.257 L24.939,15.622 Z M10.57,16.689 L18.819,16.689 L18.819,13.257 L10.57,13.257 L10.57,16.689 Z M24.939,19.725 L33.188,19.725 L33.188,17.622 L24.939,17.622 L24.939,19.725 Z M10.57,44.164 L18.819,44.164 L18.819,18.689 L10.57,18.689 L10.57,44.164 Z M24.939,41.127 L33.188,41.127 L33.188,21.726 L24.939,21.726 L24.939,41.127 Z M24.939,45.23 L33.188,45.23 L33.188,43.127 L24.939,43.127 L24.939,45.23 Z M10.57,49.596 L18.819,49.596 L18.819,46.163 L10.57,46.163 L10.57,49.596 Z M24.939,49.595 L33.188,49.595 L33.188,47.23 L24.939,47.23 L24.939,49.595 Z M45.8783,32.9758 C47.0433,32.7958 47.8403,31.7058 47.6603,30.5418 C47.4803,29.3778 46.3903,28.5798 45.2263,28.7598 C44.0623,28.9408 43.2643,30.0308 43.4443,31.1948 C43.6243,32.3588 44.7143,33.1568 45.8783,32.9758"
+              fillRule="evenodd"
+            />
+          </svg>
+          <span
+            className="button-icon-primary__text"
+          >
+            See All Projects
+          </span>
+        </a>
       </div>
-    </section>
-  </div>
+    </div>
+  </section>
   <script
     dangerouslySetInnerHTML={
       Object {
@@ -313,7 +313,7 @@ exports[`Frontend ProjectDetail Container renders correctly in standalone mode 1
 <div
   className="project-detail"
 >
-  <div>
+  <section>
     <section
       className="project-hero project-hero--light project-hero--standalone"
     >
@@ -564,7 +564,7 @@ exports[`Frontend ProjectDetail Container renders correctly in standalone mode 1
         </div>
       </div>
     </section>
-  </div>
+  </section>
   <script
     dangerouslySetInnerHTML={
       Object {

--- a/client/src/theme/styles/components/frontend/project/_content-block.scss
+++ b/client/src/theme/styles/components/frontend/project/_content-block.scss
@@ -9,7 +9,7 @@
     margin-bottom: 65px;
   }
 
-  & + &:not(:last-of-type) {
+  & + &:not(:last-child) {
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
Originally caught in #2329. Fix implemented in 0a87c2a did not adequately address all cases. This commit revises project detail page markup so that bottom project navigation (when present) is no longer a sibling of content blocks.