### PR TITLE
[F] Add swagger documentation for ResourceCollection

### DIFF
--- a/api/spec/requests/resource_collections_spec.rb
+++ b/api/spec/requests/resource_collections_spec.rb
@@ -1,17 +1,87 @@
-require "rails_helper"
+require "swagger_helper"
 
 RSpec.describe "Resource Collections API", type: :request do
+  model_name = "resource_collection"
+  model_name_plural = "resource_collections"
+  request_create_schema = { '$ref' => '#/definitions/ResourceCollectionRequestCreate' }
+  request_update_schema = { '$ref' => '#/definitions/ResourceCollectionRequestUpdate' }
+  response_schema = { '$ref' => '#/definitions/ResourceCollectionResponse' }
+  response_schema_all = { '$ref' => '#/definitions/ResourceCollectionsResponse' }
 
   include_context("authenticated request")
   include_context("param helpers")
 
   let(:collection) { FactoryBot.create(:resource_collection) }
 
-  describe "sends a list of resource collections" do
-    describe "the response" do
-      it "has a 200 status code" do
-        get api_v1_resource_collections_path
-        expect(response).to have_http_status(200)
+  path '/resource_collections' do
+    get I18n.t('swagger.get.all.description', type: 'resource collection') do
+      produces 'application/json'
+      tags 'resource collections'
+
+      response '200', I18n.t('swagger.get.all.200', type: 'resource collections') do
+        schema response_schema_all
+        run_test!
+      end
+    end
+
+    # do not document the POST on this route. It will be removed in the future
+  end
+
+  path '/resource_collections/{id}' do
+    accessor_attribute = 'ID'
+    let(:id) { collection[:id] }
+
+    get 'Get a specific resource collection' do
+      consumes 'application/json'
+      produces 'application/json'
+      parameter name: :id, in: :path, :type => :string
+      tags 'resource collections'
+
+      response '200', I18n.t('swagger.get.one.200', type: 'resource collection', attribute: accessor_attribute) do
+        schema response_schema
+        run_test!
+      end
+    end
+
+    patch I18n.t('swagger.patch.description', type: 'resource collection', attribute: accessor_attribute) do
+      parameter name: :id, :in => :path, :type => :string
+      parameter name: :resource_collection_params, in: :body, schema: request_update_schema
+      let(:resource_collection_params) { json_structure_for(:resource_collection) }
+
+      consumes 'application/json'
+      produces 'application/json'
+      security [ apiKey: [] ]
+      tags 'resource collections'
+
+      response '200', I18n.t('swagger.patch.200', type: 'resource collection', attribute: accessor_attribute) do
+        let(:Authorization) { admin_auth }
+        schema response_schema
+        run_test!
+      end
+
+      response '403', I18n.t('swagger.access_denied', type: 'resource collection', attribute: accessor_attribute) do
+        let(:Authorization) { reader_auth }
+        run_test!
+      end
+    end
+
+    delete 'Deletes a specific resource collection' do
+      produces 'application/json'
+
+      parameter name: :id, in: :path, :type => :string
+      let(:id) { collection[:id] }
+
+      security [ apiKey: [] ]
+      tags 'resource collections'
+
+      response '204', 'removes a specific resource collection' do
+        let(:Authorization) { admin_auth }
+        run_test!
+      end
+
+      response '403', I18n.t('swagger.access_denied') do
+        let(:Authorization) { author_auth }
+        run_test!
       end
     end
   end
@@ -29,38 +99,7 @@ RSpec.describe "Resource Collections API", type: :request do
           it("contains the updated title") { expect_updated_param("title", "some title") }
           it("contains the updated description") { expect_updated_param("description", "some description") }
         end
-
-        it "has a 200 OK status code" do
-          patch path, headers: headers, params: json_payload()
-          expect(response).to have_http_status(200)
-        end
-      end
-    end
-
-    describe "destroys a collection" do
-
-      let(:path) { api_v1_resource_collection_path(collection) }
-
-      context "when the user is an admin" do
-
-        let(:headers) { admin_headers }
-
-        it "has a 204 NO CONTENT status code" do
-          delete path, headers: headers
-          expect(response).to have_http_status(204)
-        end
-      end
-
-      context "when the user is a reader" do
-
-        let(:headers) { reader_headers }
-
-        it "has a 403 FORBIDDEN status code" do
-          delete path, headers: headers
-          expect(response).to have_http_status(403)
-        end
       end
     end
   end
-
 end

--- a/api/spec/swagger_definitions/resource_collections.rb
+++ b/api/spec/swagger_definitions/resource_collections.rb
@@ -1,0 +1,65 @@
+require_relative 'base_types'
+
+module ResourceCollections
+  class << self
+
+    #############
+    ## REQUEST ##
+    #############
+    def request_create_attributes
+      {
+        title: Type.string,
+        description: Type.string,
+        thumbnail: Type.attachment,
+        pendingSlug: Type.string
+      }
+    end
+
+    def request_create
+      Type.submit_wrapper(Type.object(request_create_attributes))
+    end
+
+    def request_update_attributes
+      request_create.merge({ remove_thumbnail: Type.boolean })
+    end
+
+    def request_update
+      Type.submit_wrapper(Type.object(request_update_attributes))
+    end
+
+    ##############
+    ## RESPONSE ##
+    ##############
+
+    def response
+      Type.data_response_attributes({
+       id: Type.id,
+       type: Type.string,
+       attributes: Type.object({
+         title: Type.string,
+         titleFormatted: Type.string,
+         createdAt: Type.date_time,
+         description: Type.string( nullable: true ),
+         descriptionFormatted: Type.string,
+         projectId: Type.id,
+         resourceKinds: Type.array( type: Type.string ), # TODO not sure about this data type
+         resourceTags: Type.array( type: Type.string ), # TODO not sure about this data type
+         thumbnailStyles: Type.image,
+         collectionResourcesCount: Type.integer,
+         slug: Type.string,
+         pendingSlug: Type.string,
+         abilities: Type.object( Type.crud )
+       }),
+       relationships: Type.object({
+         resources: Type.relationship_data,
+         project: Type.object({
+           data: Type.object({
+             id: Type.id,
+             type: Type.string
+           })
+         })
+       })
+      })
+    end
+  end
+end

--- a/api/spec/swagger_helper.rb
+++ b/api/spec/swagger_helper.rb
@@ -12,6 +12,7 @@ require_relative 'swagger_definitions/me'
 require_relative 'swagger_definitions/pages'
 require_relative 'swagger_definitions/projects'
 require_relative 'swagger_definitions/project_collections'
+require_relative 'swagger_definitions/resource_collections'
 require_relative 'swagger_definitions/texts'
 require_relative 'swagger_definitions/users'
 
@@ -128,6 +129,11 @@ RSpec.configure do |config|
         ProjectCollectionResponseFull: ProjectCollections.response_full,
         ProjectCollectionRequestCreate: ProjectCollections.request_create,
         ProjectCollectionRequestUpdate: ProjectCollections.request_update,
+
+        ResourceCollectionsResponse: Type.all( ResourceCollections.response ),
+        ResourceCollectionResponse: ResourceCollections.response,
+        ResourceCollectionRequestCreate: ResourceCollections.request_create,
+        ResourceCollectionRequestUpdate: ResourceCollections.request_update,
 
         TextResponse: Texts.response,
         TextResponseFull: Texts.response_full,


### PR DESCRIPTION
This is almost ready to go, but I'm hitting a failing test on a post.

The `post` test in `api/spec/requests/resource_collections_spec.rb` is throwing a 500 error when trying to create a ResourceCollection.

```
"status": 500,
"error": "Internal Server Error",
"exception": "#<NoMethodError: undefined method `updatable_by?' for nil:NilClass>",
  "traces": {
    "Application Trace": [
      {
        "id": 0,
        "trace": "app/authorizers/project_child_authorizer.rb:10:in `default'"
      },
```