### PR TITLE
[B] Fix focusability of event tiles

### DIFF
--- a/client/src/backend/containers/project/__tests__/__snapshots__/Events-test.js.snap
+++ b/client/src/backend/containers/project/__tests__/__snapshots__/Events-test.js.snap
@@ -147,7 +147,8 @@ Array [
               <div
                 className="event-tile"
                 onClick={[Function]}
-                role="link"
+                role={null}
+                tabIndex={null}
               >
                 <div
                   className="event-tile__inner"
@@ -227,7 +228,8 @@ Array [
               <div
                 className="event-tile"
                 onClick={[Function]}
-                role="link"
+                role={null}
+                tabIndex={null}
               >
                 <div
                   className="event-tile__inner"

--- a/client/src/frontend/components/event/Tile.js
+++ b/client/src/frontend/components/event/Tile.js
@@ -35,19 +35,19 @@ export class EventTile extends Component {
     itemClass: ""
   };
 
+  get hasLink() {
+    const { linkHref, hideLink } = this.props;
+    return !hideLink && linkHref;
+  }
+
   handleTileClick = event => {
     if (event.target.href) return;
-    if (!this.hasLink()) return;
+    if (!this.hasLink) return;
     const { linkHref, linkTarget } = this.props;
     if (linkTarget !== "_self" && window)
       return window.open(linkHref, "_blank");
     if (this.props.history) this.props.history.push(linkHref);
   };
-
-  hasLink() {
-    const { linkHref, hideLink } = this.props;
-    return !hideLink && linkHref;
-  }
 
   render() {
     if (!this.props.visible) return null;
@@ -66,12 +66,17 @@ export class EventTile extends Component {
 
     const baseClass = "event-tile";
     const tileClass = classNames(baseClass, this.props.tileClass, {
-      [`${baseClass}--linked`]: this.hasLink()
+      [`${baseClass}--linked`]: this.hasLink
     });
 
     return (
       <div className={this.props.itemClass}>
-        <div role="link" className={tileClass} onClick={this.handleTileClick}>
+        <div
+          role={this.hasLink ? "link" : null}
+          tabIndex={this.hasLink ? "0" : null}
+          className={tileClass}
+          onClick={this.handleTileClick}
+        >
           <div className={`${baseClass}__inner`}>
             {icon && (
               <Utility.IconComposer

--- a/client/src/frontend/components/event/__tests__/__snapshots__/List-test.js.snap
+++ b/client/src/frontend/components/event/__tests__/__snapshots__/List-test.js.snap
@@ -14,6 +14,7 @@ exports[`Frontend.Event.List Component renders correctly 1`] = `
         className="event-tile event-tile--linked"
         onClick={[Function]}
         role="link"
+        tabIndex="0"
       >
         <div
           className="event-tile__inner"
@@ -64,6 +65,7 @@ exports[`Frontend.Event.List Component renders correctly 1`] = `
         className="event-tile event-tile--linked"
         onClick={[Function]}
         role="link"
+        tabIndex="0"
       >
         <div
           className="event-tile__inner"

--- a/client/src/frontend/components/project/__tests__/__snapshots__/Events-test.js.snap
+++ b/client/src/frontend/components/project/__tests__/__snapshots__/Events-test.js.snap
@@ -49,6 +49,7 @@ exports[`Frontend.Project.Events component renders correctly 1`] = `
               className="event-tile event-tile--linked"
               onClick={[Function]}
               role="link"
+              tabIndex="0"
             >
               <div
                 className="event-tile__inner"
@@ -99,6 +100,7 @@ exports[`Frontend.Project.Events component renders correctly 1`] = `
               className="event-tile event-tile--linked"
               onClick={[Function]}
               role="link"
+              tabIndex="0"
             >
               <div
                 className="event-tile__inner"

--- a/client/src/frontend/containers/EventList/__tests__/__snapshots__/EventList-test.js.snap
+++ b/client/src/frontend/containers/EventList/__tests__/__snapshots__/EventList-test.js.snap
@@ -49,6 +49,7 @@ exports[`Frontend EventList Container renders correctly 1`] = `
               className="event-tile event-tile--linked"
               onClick={[Function]}
               role="link"
+              tabIndex="0"
             >
               <div
                 className="event-tile__inner"
@@ -99,6 +100,7 @@ exports[`Frontend EventList Container renders correctly 1`] = `
               className="event-tile event-tile--linked"
               onClick={[Function]}
               role="link"
+              tabIndex="0"
             >
               <div
                 className="event-tile__inner"


### PR DESCRIPTION
* Applies role `link` only when `hasLink` is `true` to prevent unlinked tiles from allowing focus
* Adds `tabIndex` of `0` when `hasLink` is `true` to make tabbable

Fixes #2385