### PR TITLE
[B] Fix regression in Form.Switch layout

### DIFF
--- a/client/src/global/components/form/Switch.js
+++ b/client/src/global/components/form/Switch.js
@@ -165,9 +165,9 @@ class FormSwitch extends Component {
                 checked={this.checked}
                 onChange={eventIgnored => this.handleChange()}
               />
-              {this.props.labelPos === "below" && this.renderLabelText()}
               {this.showCheckbox && this.renderCheckboxIndicator()}
               {this.showSwitch && this.renderSwitchIndicator()}
+              {this.props.labelPos === "below" && this.renderLabelText()}
               <Instructions
                 instructions={this.props.instructions}
                 className={this.instructionClasses}


### PR DESCRIPTION
This fixes an issue introduced in ab61beb that caused the label text in Form.Switch to render above the input even when `props.labelPos` was set to `below`.

Resolves #2378