### PR TITLE
[B] Style italics in project hero subtitles

### DIFF
--- a/client/src/theme/styles/components/frontend/project/_hero.scss
+++ b/client/src/theme/styles/components/frontend/project/_hero.scss
@@ -273,6 +273,9 @@
       font-size: 24px;
     }
 
+    em, i {
+      font-style: normal;
+    }
   }
 
   &__creators,


### PR DESCRIPTION
Because we allow Markdown in project subtitles, we need styling for the off-chance that there are nested `em` and `i` tags, such as in https://manifold.umn.edu/projects/wisconsin-breweries-and-brewpubs.

Resolves #2375