### PR TITLE
[B] Add workaround for Windows CSV upload bug

### DIFF
--- a/client/src/global/components/form/Upload/index.js
+++ b/client/src/global/components/form/Upload/index.js
@@ -31,7 +31,7 @@ export class FormUpload extends Component {
       extensions: "doc, docx, txt, odt"
     },
     csv: {
-      accepts: "text/plain, text/csv",
+      accepts: "text/*,",
       extensions: "txt, csv"
     },
     spreadsheet: {


### PR DESCRIPTION
Since we do server-side validation of CSV files, we can safely use [this workaround](https://github.com/react-dropzone/react-dropzone/issues/276#issuecomment-278357061)
for react-dropzone that allows CSV files to be uploaded in MS Edge.

Resolves #2409