### PR TITLE
[B] Rescue file not found exception in v3 upgrade

### DIFF
--- a/api/app/services/system_upgrades/upgrades/manifold030000.rb
+++ b/api/app/services/system_upgrades/upgrades/manifold030000.rb
@@ -23,9 +23,15 @@ module SystemUpgrades
 
         Text.find_each do |text|
           next unless text.cover_attacher.stored?
+          next if text.cover[:small].present?
 
-          logger.info("Generating cover styles for Text #{text.id}")
-          text.update cover: text.cover[:original]
+          begin
+            logger.info("Generating cover styles for Text #{text.id}")
+            text.update cover: text.cover[:original]
+          rescue Errno::ENOENT
+            logger.warn("The cover file image for Text #{text.id} is missing.")
+            logger.warn("  You should clear the cover data in the Manifold backend.")
+          end
         end
       end
 


### PR DESCRIPTION
The V3 upgrade involves the migration from Paperclip to Shrine. If we're
unable to find the file associated with a model, we will warn the user
instead of failing.