### PR TITLE
[C] Minor changes to rswag internal interfaces

### DIFF
--- a/api/app/services/types/serializer.rb
+++ b/api/app/services/types/serializer.rb
@@ -7,7 +7,7 @@ module Types
 
     Pointer = Types::Hash.schema(id: ID, type: Types::String)
     Collection = Types::Hash.schema(data: Types::Array.of(Pointer))
-    Resource = Types::Hash.schema(data: Pointer)
+    Resource = Types::Hash.schema(data: Pointer.optional)
 
     NotificationPreference = Types::String.enum("always", "never", "daily")
 

--- a/api/spec/api_docs/examples/create.rb
+++ b/api/spec/api_docs/examples/create.rb
@@ -12,7 +12,7 @@ shared_examples_for "an API create request" do |options|
       parameter(parameter_options)
     end
 
-    description api_spec_helper.description if api_spec_helper.description
+    description api_spec_helper.response_description if api_spec_helper.response_description?
     produces api_spec_helper.content_type
     consumes api_spec_helper.content_type
     security [apiKey: []] if api_spec_helper.with_auth

--- a/api/spec/api_docs/examples/destroy.rb
+++ b/api/spec/api_docs/examples/destroy.rb
@@ -8,7 +8,7 @@ shared_examples_for "an API destroy request" do |options|
     api_spec_helper.parameters.each do |parameter_options|
       parameter(parameter_options)
     end
-    description api_spec_helper.description if api_spec_helper.description
+    description api_spec_helper.response_description if api_spec_helper.response_description?
     security [apiKey: []]
     tags api_spec_helper.tags
 

--- a/api/spec/api_docs/examples/update.rb
+++ b/api/spec/api_docs/examples/update.rb
@@ -14,7 +14,7 @@ shared_examples_for "an API update request" do |options|
     api_spec_helper.parameters.each do |parameter_options|
       parameter(parameter_options)
     end
-    description api_spec_helper.description if api_spec_helper.description
+    description api_spec_helper.response_description if api_spec_helper.response_description?
     produces api_spec_helper.content_type
     consumes api_spec_helper.content_type
     security [apiKey: []]

--- a/api/spec/api_docs/helpers/request.rb
+++ b/api/spec/api_docs/helpers/request.rb
@@ -39,7 +39,15 @@ module ApiDocs
       end
 
       def response_description
-        description || body_response_description
+        [included_relationships, description, body_response_description].join("\n\n")
+      end
+
+      def included_relationships
+        included = @options[:included_relationships] || []
+        return nil if included.empty?
+
+        docs = "Included relationships:\n* "
+        docs << included.join("\n* ")
       end
 
       def description


### PR DESCRIPTION
* There is at least one case where the resource returned is `null`. Changing the pointer on the resource to be optional gets the test passing in that case.
* `response_description` seemed to be the more comprehensive choice for all route documentation. I changed cases of direct access to `description` in `api_docs/examples` to `response_description`
* I changed the logic in the `response_description` so it combines description sources rather than returning the first one that is not blank. It makes more sense to me that a developer would want to be able to document something for each route that uses a resource in the resource definition, then add to it in the spec on a route-by-route basis. I'm open to doing it a different way though.