### PR TITLE
[B] Restore height to annotation popup wrapper

### DIFF
--- a/client/src/theme/styles/components/reader/annotations/_popup.scss
+++ b/client/src/theme/styles/components/reader/annotations/_popup.scss
@@ -27,7 +27,7 @@
 
   &__panel {
     @include boxShadow(0, 12px, 22px, -3px, $neutralBlack, 0.39);
-    position: absolute;
+    position: relative;
     left: 50%;
     background-color: $panelBgColor;
     border-radius: $panelRoundedRadius;


### PR DESCRIPTION
When the panel is positioned absolutely, the .annotation-popup ancestor
element does not have height. The popup positioner needs to be able to
accurately determine the height off the .annotation-popup container so
that it can determine whether to position it above or below the
selection. One of the jobs of the popup positioner is to prevent the
popup from colliding with the edges of the window, and it cannot do this
without an accurate height measurement.

Fixes #2469