### PR TITLE
[B] Persist dirty form values when model updates

### DIFF
--- a/client/src/actions/entityEditor.js
+++ b/client/src/actions/entityEditor.js
@@ -1,5 +1,9 @@
 import { createAction } from "redux-actions";
 
+export const refresh = createAction("ENTITY_EDITOR_REFRESH", (key, model) => {
+  return { key, model };
+});
+
 export const open = createAction("ENTITY_EDITOR_OPEN", (key, model) => {
   return { key, model };
 });

--- a/client/src/global/containers/form/Form.js
+++ b/client/src/global/containers/form/Form.js
@@ -16,7 +16,7 @@ import { FormContext } from "helpers/contexts";
 import isArray from "lodash/isArray";
 
 const { request, flush } = entityStoreActions;
-const { close, open, set } = entityEditorActions;
+const { close, open, set, refresh } = entityEditorActions;
 
 export class FormContainer extends PureComponent {
   static mapStateToProps = (state, ownProps) => {
@@ -101,10 +101,22 @@ export class FormContainer extends PureComponent {
     const model = props.model || {};
 
     if (prevProps.model !== props.model) {
-      return this.openSession(props.name, model);
+      if (
+        prevProps.model &&
+        props.model &&
+        prevProps.model.id === props.model.id
+      ) {
+        return this.refreshSession(props.name, model);
+      } else {
+        return this.openSession(props.name, model);
+      }
     }
     if (props.session) return null;
     this.openSession(props.name, model);
+  }
+
+  refreshSession(name, model = {}) {
+    this.props.dispatch(refresh(name, model));
   }
 
   openSession(name, model = {}) {


### PR DESCRIPTION
Prior to this change, any change to a model on a form edit session
would re-open the editing session and the user would lose any unsaved
changes to the model. With this change, the form will attempt to
refresh the existing session rather than opening a new editing session.
The refresh action will update the underyling model for the session and
will loop through any dirty values and see if they are still dirty by
comparing them to the model. Any values that are still dirty will be
persisted into the new editing session.

Fixes #2449