### PR TITLE
[B] Fix failed API test

### DIFF
--- a/api/spec/services/api_documentation/dry_types_parser_spec.rb
+++ b/api/spec/services/api_documentation/dry_types_parser_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe ::ApiDocumentation::DryTypesParser do
           ).to eq({
             type: 'object',
             properties: {
-              data: described_class.convert(serializer_types::Pointer)
+              data: described_class.convert(serializer_types::Pointer.optional)
             }
           })
         end


### PR DESCRIPTION
The pointer type of a resource was set to optional and the test needs to reflect that.

Feel free to add any other failed tests fixes to this PR before merging it, or merge this as is.