### PR TITLE
[WIP] Document ResourceCollection API endpoints

### DIFF
--- a/api/app/serializers/v1/resource_collection_serializer.rb
+++ b/api/app/serializers/v1/resource_collection_serializer.rb
@@ -5,20 +5,19 @@ module V1
 
     abilities
 
-    typed_attribute :title, NilClass
-    typed_attribute :title_formatted, NilClass
-    typed_attribute :created_at, NilClass
-    typed_attribute :description, NilClass
-    typed_attribute :description_formatted, NilClass
-    typed_attribute :project_id, NilClass
-    typed_attribute :resource_kinds, NilClass
-    typed_attribute :resource_tags, NilClass
-    typed_attribute :collection_resources_count, NilClass
-    typed_attribute :slug, NilClass
-    typed_attribute :pending_slug, NilClass
-    typed_attribute :thumbnail_styles, Types::Hash
+    typed_attribute :title, Types::String
+    typed_attribute :title_formatted, Types::String.meta(read_only: true)
+    typed_attribute :created_at, Types::DateTime.meta(read_only: true)
+    typed_attribute :description, Types::String.optional
+    typed_attribute :description_formatted, Types::String.meta(read_only: true)
+    typed_attribute :project_id, Types::Serializer::ID.meta(read_only: true)
+    typed_attribute :resource_kinds, Types::Array.of(Types::String).meta(read_only: true)
+    typed_attribute :collection_resources_count, Types::Integer.meta(read_only: true)
+    typed_attribute :slug, Types::String.meta(read_only: true)
+    typed_attribute :pending_slug, Types::String
+    typed_attribute :thumbnail_styles, Types::Serializer::Attachment.meta(read_only: true)
 
-    typed_attribute :resource_tags, NilClass do |object, _params|
+    typed_attribute :resource_tags, Types::Array.of(Types::String) do |object, _params|
       object.resource_tags.sort
     end
 

--- a/api/spec/api_docs/definitions/resource.rb
+++ b/api/spec/api_docs/definitions/resource.rb
@@ -133,7 +133,7 @@ module ApiDocs
 
         data = {
           id: ::Types::Serializer::ID,
-          type: ::Types::String.meta(example: type),
+          type: ::Types::String.meta(example: type.camelize(:lower)),
           attributes: (::Types::Hash.schema(attributes) unless attributes.nil?),
           relationships: (::Types::Hash.schema(relationships) unless relationships.nil?),
           meta: ::Types::Serializer::Meta

--- a/api/spec/api_docs/definitions/resources/resource_collection.rb
+++ b/api/spec/api_docs/definitions/resources/resource_collection.rb
@@ -1,0 +1,23 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class ResourceCollection
+
+        REQUEST_ATTRIBUTES = {
+          thumbnail: Types::Serializer::Upload,
+          remove_thumbnail: Types::Bool
+        }
+
+        class << self
+
+          include Resource
+
+          def create_attributes
+            request_attributes.except(:remove_thumbnail)
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/api/spec/requests/api/v1/resource_collections_spec.rb
+++ b/api/spec/requests/api/v1/resource_collections_spec.rb
@@ -1,0 +1,56 @@
+require "swagger_helper"
+
+RSpec.describe "Resource Collections", type: :request do
+
+  let(:resource) { FactoryBot.create(:resource_collection) }
+  included_relationships = [:project, :resource]
+
+  path "/resource_collections/{id}" do
+    include_examples "an API show request",
+                      model: ResourceCollection,
+                      included_relationships: included_relationships
+
+    include_examples "an API update request",
+                      model: ResourceCollection,
+                      included_relationships: included_relationships,
+                      auth_type: :admin
+
+    include_examples "an API destroy request",
+                      model: ResourceCollection,
+                      auth_type: :admin
+  end
+
+  context "for a project" do
+    let(:parent) { FactoryBot.create(:project) }
+    let(:project_id) { parent.id }
+
+    path "/projects/{project_id}/relationships/resource_collections" do
+      include_examples "an API create request",
+                        model: ResourceCollection,
+                        tags: "Projects",
+                        url_parameters: [:project_id],
+                        auth_type: :admin
+
+      include_examples "an API index request",
+                        model: ResourceCollection,
+                        tags: "Projects",
+                        url_parameters: [:project_id],
+                        paginated: true
+    end
+  end
+
+  context "for a text section" do
+    let(:parent) { FactoryBot.create(:text_section) }
+    let(:text_section_id) { parent.id }
+    let(:annotation) {
+      FactoryBot.create(:annotation, text_section_id: text_section_id, resource_id: resource.id)
+    }
+
+    path "/text_sections/{text_section_id}/relationships/resource_collections" do
+      include_examples "an API index request",
+                        model: ResourceCollection,
+                        tags: "Text Sections",
+                        url_parameters: [:text_section_id]
+    end
+  end
+end


### PR DESCRIPTION
I hit two sticking points in documenting these routes.

1. A 500 response on POST for `/resource_collections` route
2. Not knowing how to attach a `resource_collection` to a `text_section`. 

I looked around in the UI as well as the factory bot and there didn't seem to be an obvious place to attach a resource_collection to a text_section. All tests pass as is, I want to make sure that I am using the `/text_sections/{text_section_id}/relationships/resource_collections` route correctly.

I am happy to go back and fix these if you have some suggestions, or move on and leave them to you.