### PR TITLE
[WIP] Document ActionCallout API endpoints

### DIFF
--- a/api/app/serializers/v1/action_callout_serializer.rb
+++ b/api/app/serializers/v1/action_callout_serializer.rb
@@ -3,13 +3,14 @@ module V1
 
     include ::V1::Concerns::ManifoldSerializer
 
-    typed_attribute :title, NilClass
-    typed_attribute :kind, NilClass
-    typed_attribute :location, NilClass
-    typed_attribute :position, NilClass
-    typed_attribute :url, NilClass
-    typed_attribute :button, NilClass
-    typed_attribute :attachment_styles, Types::Hash
+    typed_attribute :title, Types::String
+    typed_attribute :kind, Types::String.enum("link", "read", "toc", "download")
+    typed_attribute :location, Types::String.enum("left", "right")
+    typed_attribute :position, Types::Integer
+    typed_attribute :url, Types::Serializer::URL
+    typed_attribute :button, Types::Bool
+    typed_attribute :attachment_styles, Types::Serializer::Attachment.meta(read_only: true)
+
     typed_belongs_to :project
     typed_belongs_to :text
   end

--- a/api/app/services/types/serializer.rb
+++ b/api/app/services/types/serializer.rb
@@ -32,9 +32,12 @@ module Types
     )
 
     Upload = Types::Hash.schema(
-      filename: Types::String.meta(example: "profile_pic.jpg"),
-      data: Types::String.meta(description: "A base 64 encoded image string"),
-      content_type: Types::String.meta(example: "image/jpeg")
+      filename: Types::String.meta(example: "profile_pic.png"),
+      data: Types::String.meta(
+        description: "A base 64 encoded image string",
+        example: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/C/HgAGgwJ/lK3Q6wAAAABJRU5ErkJggg=="
+      ),
+      content_type: Types::String.meta(example: "image/png")
     )
   end
 end

--- a/api/spec/api_docs/definitions/resources/action_callout.rb
+++ b/api/spec/api_docs/definitions/resources/action_callout.rb
@@ -1,0 +1,31 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class ActionCallout
+
+        REQUIRED_CREATE_ATTRIBUTES = [
+          :title,
+          :kind,
+          :location
+        ]
+
+        REQUEST_ATTRIBUTES = {
+          # TODO: Make sure attachment works
+          # tested uploading an image and it did not work
+          attachment: Types::Serializer::Upload,
+          remove_attachment: Types::Bool
+        }
+
+        class << self
+
+          include Resource
+
+          def create_attributes
+            request_attributes.except(:remove_attachment)
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/api/spec/requests/api/v1/action_callouts_spec.rb
+++ b/api/spec/requests/api/v1/action_callouts_spec.rb
@@ -1,0 +1,34 @@
+require "swagger_helper"
+
+RSpec.describe "Action Callouts", type: :request do
+  conditional_requirements = <<~HEREDOC.freeze
+    Requirements:
+    * Requires text relationship if type is read or toc
+    * Requires url if type is link
+  HEREDOC
+
+  path "/action_callouts/{id}" do
+    include_examples "an API show request", model: ActionCallout
+    include_examples "an API update request", model: ActionCallout, auth_type: :admin, description: conditional_requirements
+    include_examples "an API destroy request", model: ActionCallout, auth_type: :admin
+  end
+
+  context "for a project" do
+    let(:parent) { FactoryBot.create(:project) }
+    let(:project_id) { parent.id }
+
+    path "/projects/{project_id}/relationships/action_callouts" do
+      include_examples "an API index request",
+                        model: ActionCallout,
+                        tags: "Projects",
+                        url_parameters: [:project_id]
+
+      include_examples "an API create request",
+                        model: ActionCallout,
+                        auth_type: :admin,
+                        tags: "Projects",
+                        url_parameters: [:project_id],
+                        description: conditional_requirements
+    end
+  end
+end


### PR DESCRIPTION
On PATCH for an `ActionCallout`, I tried sending in data like this:

```
{
  "data": {
    "attributes": {
      "attachment": {
        "filename": "profile_pic.jpg",
        "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPj/HwADBwIAMCbHYQAAAABJRU5ErkJggg==",
        "contentType": "image/jpg"
      }
    }
  }
}
```

The `data` value is a base-64 1x1 blue pixel. This works for setting an avatar image for a user and I was assuming it would work similarly in an `ActionCallout,` but all the `AttachmentStyles` in the `ActionCallout` response are still null.