### PR TITLE
[WIP] Document Annotation API endpoints

### DIFF
--- a/api/app/serializers/serializer_registry.rb
+++ b/api/app/serializers/serializer_registry.rb
@@ -69,7 +69,7 @@ class SerializerRegistry
   end
 
   def current_user_is_creator?
-    typed_attribute :current_user_is_creator, ::Types::Bool do |object, params|
+    typed_attribute :current_user_is_creator, ::Types::Bool.meta(read_only: true) do |object, params|
       klass.calculate_current_user_is_creator?(object, params)
     end
   end

--- a/api/app/serializers/v1/annotation_serializer.rb
+++ b/api/app/serializers/v1/annotation_serializer.rb
@@ -5,51 +5,49 @@ module V1
     current_user_is_creator?
     abilities
 
-    typed_attribute :created_at, NilClass
-    typed_attribute :updated_at, NilClass
-    typed_attribute :start_char, NilClass
-    typed_attribute :start_node, NilClass
-    typed_attribute :end_char, NilClass
-    typed_attribute :end_node, NilClass
-    typed_attribute :id, NilClass
-    typed_attribute :flags_count, NilClass
-    typed_attribute :format, NilClass
-    typed_attribute :subject, NilClass
-    typed_attribute :body, NilClass
-    typed_attribute :private, NilClass
-    typed_attribute :comments_count, NilClass
-    typed_attribute :author_created, NilClass
-    typed_attribute :reading_group_name, NilClass
-    typed_attribute :reading_group_privacy, NilClass
-    typed_attribute :reading_group_id, NilClass
-    typed_attribute :creator_id, NilClass
-    typed_attribute :project_id, NilClass
-    typed_attribute :text_id, NilClass
-    typed_attribute :text_section_id, NilClass
-    typed_attribute :resource_id, NilClass
-    typed_attribute :resource_collection_id, NilClass
-    typed_attribute :text_slug, NilClass
-    typed_attribute :project_title, NilClass
-    typed_attribute :text_title, NilClass
-    typed_attribute :text_title_formatted, NilClass
-    typed_attribute :text_section_title, NilClass
-    typed_attribute :is_anonymous, NilClass
-    typed_attribute :orphaned, NilClass, &:orphaned?
-    typed_attribute :is_anonymous, NilClass do |object, params|
+    typed_attribute :created_at, Types::DateTime.meta(read_only: true)
+    typed_attribute :updated_at, Types::DateTime.meta(read_only: true)
+    typed_attribute :start_char, Types::Integer
+    typed_attribute :start_node, Types::String.meta(example: "start")
+    typed_attribute :end_char, Types::Integer
+    typed_attribute :end_node, Types::String.meta(example: "end")
+    typed_attribute :flags_count, Types::Integer.meta(read_only: true)
+    typed_attribute :format, Types::String.enum("annotation", "highlight", "resource", "resource_collection")
+    typed_attribute :subject, Types::String
+    typed_attribute :body, Types::String.meta(description: "Only required if format is annotation")
+    typed_attribute :private, Types::Bool
+    typed_attribute :comments_count, Types::Integer.meta(read_only: true)
+    typed_attribute :author_created, Types::Bool.meta(read_only: true)
+    typed_attribute :reading_group_name, Types::String.optional.meta(read_only: true)
+    typed_attribute :reading_group_privacy, Types::String.meta(read_only: true).optional
+    typed_attribute :reading_group_id, Types::Serializer::ID.optional
+    typed_attribute :creator_id, Types::Serializer::ID.meta(read_only: true)
+    typed_attribute :project_id, Types::Serializer::ID.meta(read_only: true)
+    typed_attribute :text_id, Types::Serializer::ID.meta(read_only: true)
+    typed_attribute :text_section_id, Types::Serializer::ID.meta(read_only: true)
+    typed_attribute :resource_id, Types::Serializer::ID.optional.meta(read_only: true)
+    typed_attribute :resource_collection_id, Types::Serializer::ID.optional.meta(read_only: true)
+    typed_attribute :text_slug, Types::String.meta(read_only: true)
+    typed_attribute :project_title, Types::String.meta(read_only: true)
+    typed_attribute :text_title, Types::String.meta(read_only: true)
+    typed_attribute :text_title_formatted, Types::String.optional.meta(read_only: true)
+    typed_attribute :text_section_title, Types::String.optional.meta(read_only: true)
+    typed_attribute :orphaned, Types::Bool.meta(read_only: true), &:orphaned?
+    typed_attribute :is_anonymous, Types::Bool.optional.meta(read_only: true) do |object, params|
       anonymous?(object, params)
     end
-    typed_attribute :creator_name, NilClass do |object, params|
+    typed_attribute :creator_name, Types::String.meta(read_only: true) do |object, params|
       next object.creator.full_name if creator_identity_visible?(object, params)
 
       object.anonymous_label
     end
 
-    typed_attribute :creator_avatar_styles, Types::Hash do |object, params|
+    typed_attribute :creator_avatar_styles, Types::Serializer::Attachment.meta(read_only: true) do |object, params|
       creator_identity_visible?(object, params) ? camelize_hash(object.creator_avatar_styles) : {}
     end
 
-    typed_attribute :flagged, NilClass do |object, params|
-      next 0 unless authenticated?(params)
+    typed_attribute :flagged, Types::Bool.meta(read_only: true) do |object, params|
+      next false unless authenticated?(params)
 
       object.flags.where(creator: params[:current_user]).count.positive?
     end

--- a/api/spec/api_docs/definitions/resources/annotation.rb
+++ b/api/spec/api_docs/definitions/resources/annotation.rb
@@ -1,0 +1,28 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class Annotation
+
+        REQUIRED_CREATE_ATTRIBUTES = [
+          :start_node,
+          :end_node,
+          :start_char,
+          :end_char,
+          :format,
+          :subject,
+          :body
+        ]
+
+        REQUEST_ATTRIBUTES = {
+          section_id: Types::Serializer::ID
+        }
+
+        class << self
+
+          include Resource
+
+        end
+      end
+    end
+  end
+end

--- a/api/spec/requests/api/v1/annotations_spec.rb
+++ b/api/spec/requests/api/v1/annotations_spec.rb
@@ -1,0 +1,77 @@
+require "swagger_helper"
+
+RSpec.describe "Annotations", type: :request do
+
+  path "/annotations/{id}" do
+    include_examples "an API update request", model: Annotation, auth_type: :admin
+    include_examples "an API destroy request", model: Annotation, auth_type: :admin
+  end
+
+  describe "for a text section" do
+    let(:parent) { FactoryBot.create(:text_section) }
+    let(:annotation) { FactoryBot.create(:annotation, text_section: parent) }
+    let(:text_section_id) { parent.id }
+
+    path "/text_sections/{text_section_id}/relationships/annotations" do
+      include_examples "an API index request",
+                       model: Annotation,
+                       url_parameters: [:text_section_id],
+                       tags: "Text Sections"
+
+      include_examples "an API create request",
+                       model: Annotation,
+                       url_parameters: [:text_section_id],
+                       tags: "Text Sections",
+                       auth_type: :admin
+    end
+
+    path "/text_sections/{text_section_id}/relationships/annotations/{id}" do
+      include_examples "an API update request",
+                       model: Annotation,
+                       url_parameters: [:text_section_id],
+                       tags: "Text Sections",
+                       auth_type: :admin
+    end
+  end
+
+  describe "for me" do
+    text = FactoryBot.create(:text)
+    let(:text_section) { FactoryBot.create(:text_section, text: text) }
+    let(:annotation) {
+      FactoryBot.create(:annotation, creator: admin, text_section: text_section)
+    }
+
+    path "/me/relationships/annotations" do
+      let(:'filter[text]') { nil }
+
+      include_examples "an API index request",
+                        model: Annotation,
+                        auth_type: :admin,
+                        included_relationships: [:creator],
+                        additional_parameters: [
+                          {
+                            name: "filter[text]",
+                            in: :query,
+                            type: :string,
+                            required: true
+                          }
+                        ]
+    end
+
+  end
+
+  describe "for a reading group" do
+    let(:parent) { FactoryBot.create(:reading_group) }
+    let(:annotation) { FactoryBot.create(:annotation, reading_group: parent) }
+    let(:reading_group_id) { parent.id }
+
+    path "/reading_groups/{reading_group_id}/relationships/annotations" do
+      include_examples "an API index request",
+                        model: Annotation,
+                        tags: "Reading Groups",
+                        url_parameters: [:reading_group_id],
+                        paginated: true,
+                        included_relationships: [:creator]
+    end
+  end
+end


### PR DESCRIPTION
Two issues for this group of routes:

1. It appears the show method on the controller that manages the `/annotations/{id}` route requests does not exist
2. I get a 500 response on an index request to `/me/relationships/annotations`. I am not sure if there is something wrong with that one or if I am just accessing the route incorrectly.