### PR TITLE
[WIP] Document Favorite API endpoints

### DIFF
--- a/api/app/serializers/v1/favorite_serializer.rb
+++ b/api/app/serializers/v1/favorite_serializer.rb
@@ -3,9 +3,9 @@ module V1
 
     include ::V1::Concerns::ManifoldSerializer
 
-    typed_attribute :favoritable_type, NilClass
-    typed_attribute :favoritable_id, NilClass
-    typed_attribute :subject_ids, NilClass do |object, _params|
+    typed_attribute :favoritable_type, Types::String
+    typed_attribute :favoritable_id, Types::Serializer::ID
+    typed_attribute :subject_ids, Types::Array.of(Types::Serializer::ID).optional do |object, _params|
       object.favorite_subjects
         .select { |arr| arr.include?(object.favoritable_id) }
         .flatten

--- a/api/spec/api_docs/definitions/resources/favorite.rb
+++ b/api/spec/api_docs/definitions/resources/favorite.rb
@@ -1,0 +1,25 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class Favorite
+
+        REQUIRED_CREATE_RELATIONSHIPS = [:favoritable].freeze
+
+        class << self
+          include Resource
+
+          def create_relationships
+            {
+              favoritable: Types::Hash.schema(
+                data: Types::Hash.schema(
+                  id: Types::Serializer::ID,
+                  type: Types::String.meta(example: "comment")
+                )
+              )
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/api/spec/requests/api/v1/favorites_spec.rb
+++ b/api/spec/requests/api/v1/favorites_spec.rb
@@ -1,0 +1,44 @@
+require "swagger_helper"
+
+RSpec.describe "Favorites", type: :request do
+  context "my favorites" do
+    let(:resource) { FactoryBot.create(:favorite, user: admin) }
+
+    path "/me/relationships/favorites" do
+      include_examples "an API index request",
+                       model: Favorite,
+                       authorized_user: :admin
+
+      include_examples "an API create request",
+                       model: Favorite,
+                       authorized_user: :admin,
+                       description: "If the favorite is valid, it will return the current user. "\
+                       "If not, it will return the favorite. If the resource has already been "\
+                       "favorited, the server will respond with a 422 code and a message that "\
+                       "the resource is already taken.",
+                       included_relationships: [:creator] do
+        let(:comment) { FactoryBot.create(:comment) }
+        let(:body) do
+          json_structure(relationships: {
+                           favoritable: {
+                             data: {
+                               id: comment.id,
+                               type: "comment"
+                             }
+                           }
+                         })
+        end
+      end
+    end
+
+    path "/me/relationships/favorites/{id}" do
+      include_examples "an API show request",
+                       model: Favorite,
+                       authorized_user: :admin
+
+      include_examples "an API destroy request",
+                       model: Favorite,
+                       authorized_user: :admin
+    end
+  end
+end


### PR DESCRIPTION
I had to make a few adjustments to the resource module in order to be able to set relationships as a required field in the request. 

I also figured it wise to not attempt to programmatically document the response behavior for creating a favorite.  In the favorites controller, there is a comment that says the response behavior is rather unexpected and should be refactored at some point, so I documented the response behavior with a simple description on the swagger route.