### PR TITLE
[WIP] Document Contacts API endpoint

### DIFF
--- a/api/spec/requests/api/v1/contacts_spec.rb
+++ b/api/spec/requests/api/v1/contacts_spec.rb
@@ -1,0 +1,50 @@
+require "swagger_helper"
+
+RSpec.describe "Contacts", type: :request do
+  path "/contacts" do
+    post "Sends an email to the provided address" do
+      consumes "application/json"
+      tags "Contacts"
+      parameter name: :body, in: :body, schema: ApiDocumentation::DryTypesParser.convert(
+        Types::Hash.schema(
+          data: Types::Hash.schema(
+            attributes: Types::Hash.schema(
+              email: Types::String,
+              full_name: Types::String,
+              message: Types::String
+            )
+          )
+        )
+      )
+
+      response "204", "Sent the email" do
+        let(:body) do
+          {
+          	data: {
+          		attributes: {
+          			email: "email@email.com",
+          			full_name: "John Rambo",
+          			message: "Hello world"
+          		}
+          	}
+          }
+        end
+        run_test!
+      end
+
+      response "422", "Improper request information" do
+        let(:body) do
+          {
+            data: {
+              attributes: {
+                full_name: "John Rambo",
+                message: "Hello world"
+              }
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end


### PR DESCRIPTION
This route was a very special case.

* It does not have a serializer
* It has an irregular model file name in an irregular place (manifold/api/app/services/contacts/send_message.rb)
* It does not provide any json response on success
* It is the only route of its kind (there is no delete, create, update, get)

As such, it would require many modifications to the code that automates the process of testing and documenting routes, so in this case I decided it was best to keep it very simple and interact with the rswag library directly. 

I don't have any attachments to this solution, so any suggestions on how to improve it is welcome. I'm opening this PR for assistance or discussion on desgin more than I am expecting a quick review for errors. 

If you could also point me to where this is used in the front end and who might be using it, that would be helpful for me to come up with a better description of what the route does.