### PR TITLE
[WIP] Document Events API endpoints

### DIFF
--- a/api/app/serializers/v1/event_serializer.rb
+++ b/api/app/serializers/v1/event_serializer.rb
@@ -3,22 +3,25 @@ module V1
 
     include ::V1::Concerns::ManifoldSerializer
 
-    typed_attribute :event_type, NilClass
-    typed_attribute :event_url, NilClass
-    typed_attribute :subject_id, NilClass
-    typed_attribute :subject_type, NilClass
-    typed_attribute :subject_slug, NilClass
-    typed_attribute :subject_title, NilClass
-    typed_attribute :subject_subtitle, NilClass
-    typed_attribute :attribution_name, NilClass
-    typed_attribute :attribution_url, NilClass
-    typed_attribute :attribution_identifier, NilClass
-    typed_attribute :excerpt, NilClass
-    typed_attribute :project_id, NilClass
-    typed_attribute :project_slug, NilClass
-    typed_attribute :event_title, NilClass
-    typed_attribute :event_subtitle, NilClass
-    typed_attribute :created_at, NilClass
-    typed_attribute :subject_title_formatted, NilClass
+    typed_attribute :event_type, Types::String.meta(read_only: true, example: "resource_collection_added")
+    typed_attribute :event_url, Types::String.meta(
+      read_only: true,
+      example: "/project/023ebc40-174a-4056-b1e7-de1a1f52d666/ResourceCollection/aec3e2f6-f541-464c-b3cf-08ebba2a4453"
+    )
+    typed_attribute :subject_id, Types::Serializer::ID.meta(read_only: true)
+    typed_attribute :subject_type, Types::String.meta(example: "ResourceCollection", read_only: true)
+    typed_attribute :subject_slug, Types::String.meta(read_only: true)
+    typed_attribute :subject_title, Types::String.meta(read_only: true)
+    typed_attribute :subject_subtitle, Types::String.optional.meta(read_only: true)
+    typed_attribute :attribution_name, Types::String.optional.meta(read_only: true)
+    typed_attribute :attribution_url, Types::String.optional.meta(read_only: true)
+    typed_attribute :attribution_identifier, Types::String.optional.meta(read_only: true)
+    typed_attribute :excerpt, Types::String.optional.meta(read_only: true)
+    typed_attribute :project_id, Types::Serializer::ID.meta(read_only: true)
+    typed_attribute :project_slug, Types::String.meta(read_only: true)
+    typed_attribute :event_title, Types::String.optional.meta(read_only: true)
+    typed_attribute :event_subtitle, Types::String.optional.meta(read_only: true)
+    typed_attribute :created_at, Types::DateTime.meta(read_only: true)
+    typed_attribute :subject_title_formatted, Types::String.meta(read_only: true, example: "<p>string</p>")
   end
 end

--- a/api/spec/api_docs/definitions/resources/event.rb
+++ b/api/spec/api_docs/definitions/resources/event.rb
@@ -1,0 +1,11 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class Event
+        class << self
+          include Resource
+        end
+      end
+    end
+  end
+end

--- a/api/spec/requests/api/v1/events_spec.rb
+++ b/api/spec/requests/api/v1/events_spec.rb
@@ -1,0 +1,19 @@
+require "swagger_helper"
+
+RSpec.describe "Events", type: :request do
+
+  let(:project) { FactoryBot.create(:project) }
+  let(:resource) { FactoryBot.create(:event, project: project) }
+  let(:project_id) { project.id }
+  let(:id) { resource.id }
+
+  path "/events/{id}" do
+    include_examples "an API destroy request", model: Event, authorized_user: :admin
+  end
+
+  context "for a project" do
+    path "/projects/{project_id}/relationships/events" do
+      include_examples "an API index request", model: Event, url_parameters: [:project_id]
+    end
+  end
+end


### PR DESCRIPTION
As far as I know, there are no routes that create an event. I'm assuming that it goes on behind the scenes when a user does something to their project. So I marked each field as read_only.