### PR TITLE
[WIP] Document Ingestion API endpoints

### DIFF
--- a/api/app/serializers/v1/ingestion_serializer.rb
+++ b/api/app/serializers/v1/ingestion_serializer.rb
@@ -3,17 +3,16 @@ module V1
 
     include ::V1::Concerns::ManifoldSerializer
 
-    typed_attribute :state, NilClass
-    typed_attribute :external_source_url, NilClass
-    typed_attribute :log, NilClass
-    typed_attribute :source_file_name, NilClass
-    typed_attribute :ingestion_type, NilClass
-    typed_attribute :available_events, NilClass
-    typed_attribute :strategy, NilClass
-    typed_attribute :strategy_label, NilClass
-    typed_attribute :text_id, NilClass
-    typed_attribute :creator_id, NilClass
-    typed_attribute :available_events, NilClass do |object, _params|
+    typed_attribute :state, Types::String.enum("sleeping", "processing", "finished").meta(read_only: true)
+    typed_attribute :external_source_url, Types::Serializer::URL.meta(description: "Required if not uploading from a file")
+    typed_attribute :log, Types::Array.of(Types::String).meta(read_only: true)
+    typed_attribute :source_file_name, Types::String.optional.meta(read_only: true)
+    typed_attribute :ingestion_type, Types::String.optional
+    typed_attribute :strategy, Types::String.optional.meta(read_only: true)
+    typed_attribute :strategy_label, Types::String.optional.meta(read_only: true)
+    typed_attribute :text_id, Types::Serializer::ID.optional.meta(read_only: true)
+    typed_attribute :creator_id, Types::Serializer::ID.meta(read_only: true)
+    typed_attribute :available_events, Types::Array.of(Types::String) do |object, _params|
       allowed = [:analyze, :reset, :process, :reingest]
       actions = object.aasm.events.map(&:name)
       actions.select { |action| allowed.include?(action) }

--- a/api/spec/api_docs/definitions/resources/ingestion.rb
+++ b/api/spec/api_docs/definitions/resources/ingestion.rb
@@ -1,0 +1,29 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class Ingestion
+
+        # TODO: Zach should circle back to this to make sure this makes sense
+        REQUEST_ATTRIBUTES = {
+          source: Types::Hash.schema(
+            id: Types::Serializer::URL,
+            storage: Types::String.enum("cache"),
+            metadata: Types::Hash.schema(
+              filename: Types::String.meta(example: "anton-chekhov_the-duel.epub"),
+              size: Types::Integer.meta(example: "683346"),
+              mimeType: Types::String.meta(example: "application/epub+zip")
+            ).meta(
+              description: 'In order to upload a source, first you must post to the "files" '\
+              'route which is our TUS upload endpoint. From that, you will get a file ID, '\
+              'which is included in the post to ingestions.'
+            )
+          )
+        }.freeze
+
+        class << self
+          include Resource
+        end
+      end
+    end
+  end
+end

--- a/api/spec/requests/api/v1/ingestions_spec.rb
+++ b/api/spec/requests/api/v1/ingestions_spec.rb
@@ -1,0 +1,24 @@
+require "swagger_helper"
+
+RSpec.describe "Ingestions", type: :request do
+  path "/ingestions/{id}" do
+    include_examples "an API update request", model: Ingestion, authorized_user: :admin
+    include_examples "an API show request",
+                      model: Ingestion,
+                      authorized_user: :admin,
+                      included_relationships: [:creator]
+  end
+
+  context "for a project" do
+    let!(:ingestion) { FactoryBot.create(:ingestion) }
+    let!(:project_id) { ingestion.project_id }
+
+    path "/projects/{project_id}/relationships/ingestions" do
+      include_examples "an API create request",
+                        model: Ingestion,
+                        url_parameters: [:project_id],
+                        authorized_user: :admin,
+                        included_relationships: [:creator]
+    end
+  end
+end


### PR DESCRIPTION
I'm having a hard time getting an exact definition or example of the structure of the `source` request attribute for an ingestion. Any help would be appreciated.

The structure I have commented out right now was gathered from the validation for an ingestion:

```
  def ingestion_params
    params.require(:data)

    attributes = [
      :external_source_url,
      :ingestion_type,
      {
        source: [
          :id,
          :storage, { metadata: [:filename, :size, :mime_type] }
        ]
      }
    ]
    relationships = [:text]

    param_config = structure_params(
      attributes: attributes,
      relationships: relationships
    )

    params.permit(param_config)
  end
```