### PR TITLE
[WIP] Document Me API endpoints

### DIFF
--- a/api/app/serializers/v1/current_user_serializer.rb
+++ b/api/app/serializers/v1/current_user_serializer.rb
@@ -6,7 +6,9 @@ module V1
 
     set_type :user
 
-    typed_attribute :persistent_ui, Types::Serializer::PersistentUI
+    typed_attribute :persistent_ui, Types::Serializer::PersistentUI do |object, _params|
+      object.persistent_ui.as_json
+    end
 
     typed_attribute :notification_preferences, Types::Serializer::NotificationPreferences do |object, _params|
       camelize_hash(object.notification_preferences_by_kind)

--- a/api/app/serializers/v1/current_user_serializer.rb
+++ b/api/app/serializers/v1/current_user_serializer.rb
@@ -6,17 +6,23 @@ module V1
 
     set_type :user
 
-    typed_attribute :persistent_ui, NilClass
+    typed_attribute :persistent_ui, Types::Serializer::PersistentUI
 
-    typed_attribute :notification_preferences, NilClass do |object, _params|
+    typed_attribute :notification_preferences, Types::Serializer::NotificationPreferences do |object, _params|
       camelize_hash(object.notification_preferences_by_kind)
     end
 
-    typed_attribute :current_user, NilClass do
+    typed_attribute :current_user, Types::Bool.meta(read_only: true) do
       true
     end
 
-    typed_attribute :class_abilities, NilClass do |object|
+    typed_attribute :class_abilities, Types::Hash.meta(
+      read_only: true,
+      description: "A wide variety of all the permissions that you as a user have " \
+      "for every kind of resource on the site. For each resource is a hash of keys " \
+      "such as 'create', 'read', 'update', 'delete', and each key has a boolean value" \
+      "attached to it"
+    ) do |object|
       out = models_with_authorization.each_with_object({}) do |klass, abilities|
         abilities[klass.name.underscore] = klass.serialized_abilities_for(object)
       end

--- a/api/app/services/types/serializer.rb
+++ b/api/app/services/types/serializer.rb
@@ -39,5 +39,39 @@ module Types
       ),
       content_type: Types::String.meta(example: "image/png")
     )
+
+    PersistentUI = Types::Hash.schema(
+      reader: Types::Hash.schema(
+        colors: Types::Hash.schema(
+          color_scheme: Types::String.enum("light", "dark")
+        ),
+        typography: Types::Hash.schema(
+          font: Types::String.meta(example: "serif"),
+          margins: Types::Hash.schema(
+            max: Types::Integer,
+            min: Types::Integer,
+            current: Types::Integer
+          ),
+          font_size: Types::Hash.schema(
+            max: Types::Integer,
+            min: Types::Integer,
+            current: Types::Integer
+          )
+        ),
+        reading_groups: Types::Hash.schema(
+          current_reading_group: Types::Serializer::ID
+        )
+      )
+    )
+
+    NotificationPreferences = Types::Hash.schema(
+      projects: Types::String.enum("never", "always"),
+      followedProjects: Types::String.enum("never", "always"),
+      flaggedResources: Types::String.enum("never", "always"),
+      projectCommentsAndAnnotations: Types::String.enum("never", "always"),
+      repliesToMe: Types::String.enum("never", "always"),
+      digest: Types::String.enum("never", "always"),
+      digestCommentsAndAnnotations: Types::String.enum("never", "always")
+    )
   end
 end

--- a/api/spec/api_docs/definitions/resources/current_user.rb
+++ b/api/spec/api_docs/definitions/resources/current_user.rb
@@ -1,0 +1,11 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class CurrentUser
+        class << self
+          include Resource
+        end
+      end
+    end
+  end
+end

--- a/api/spec/api_docs/helpers/request.rb
+++ b/api/spec/api_docs/helpers/request.rb
@@ -100,6 +100,11 @@ module ApiDocs
         @options[:resource_name_plural] || resource_name.pluralize
       end
 
+      def request_id?
+        return options[:request_id] if options.key?(:request_id)
+        true
+      end
+
       def delete_has_response_body?
         !!@options[:delete_has_response_body]
       end
@@ -131,11 +136,16 @@ module ApiDocs
         }
 
         defaults[@action] = remove_request_body(defaults[@action]) unless request_body?
+        defaults[@action] = remove_request_id(defaults[@action]) unless request_id?
         defaults[@action] || []
       end
 
       def remove_request_body(defaults)
         defaults.reject { |parameter| parameter[:in] == :body }
+      end
+
+      def remove_request_id(defaults)
+        defaults.reject { |parameter| parameter[:name] == :id }
       end
 
       def parameters

--- a/api/spec/requests/api/v1/me_spec.rb
+++ b/api/spec/requests/api/v1/me_spec.rb
@@ -1,0 +1,29 @@
+require "swagger_helper"
+
+RSpec.describe "Me", type: :request do
+
+  path "/me" do
+    include_examples "an API show request",
+                      model: User,
+                      resource_name: "CurrentUser",
+                      tags: "Users",
+                      exclude: %w(404),
+                      parameters: [],
+                      included_relationships: [:favorites],
+                      success_description: "Returns the user currently logged in",
+                      summary: "Update the information associated with the user "\
+                      "that is currently logged in based on the provided authorization token",
+                      authorized_user: :admin
+
+    include_examples "an API update request",
+                      model: User,
+                      resource_name: "CurrentUser",
+                      request_id: false,
+                      tags: "Users",
+                      success_description: "Returns the updated user",
+                      included_relationships: [:favorites],
+                      summary: "Returns information about the user that is currently "\
+                      "logged in based on the provided authorization token",
+                      authorized_user: :admin
+  end
+end


### PR DESCRIPTION
While trying to document the `Me` resources, I ran into an error on assigning a dry type to a `typed_attribute`.

I made a note in the serializer_registry where the error is being generated. To replicate the error in a test, run `rspec -fd spec/requests/api/v1/me_spec.rb` from the api folder.