### PR TITLE
[WIP] Document Resources API endpoints

### DIFF
--- a/api/app/controllers/api/v1/resources_controller.rb
+++ b/api/app/controllers/api/v1/resources_controller.rb
@@ -18,11 +18,6 @@ module Api
                                include: includes
       end
 
-      def create
-        @resource = authorize_and_create_zresource(resource_params)
-        render_single_resource @resource
-      end
-
       def update
         @resource = load_and_authorize_zresource
         project = @resource.project

--- a/api/app/controllers/concerns/validation.rb
+++ b/api/app/controllers/concerns/validation.rb
@@ -154,10 +154,10 @@ module Validation
                   attachment(:variant_thumbnail), :remove_variant_thumbnail,
                   attachment(:variant_poster), :remove_variant_poster,
                   :title, :caption, :description, :tag_list, :kind, :sub_kind,
-                  :alt_text, :copyright_status, :copyright_holder, :credit,
+                  :alt_text, :copyright_status, :credit,
                   :allow_download, :external_type, :external_url, :external_id,
-                  :embed_code, :subject, :minimum_width, :maximum_width, :minimum_height,
-                  :maximum_height, :iframe_allow_fullscreen, metadata(Resource),
+                  :embed_code, :minimum_width, :minimum_height,
+                  :iframe_allow_fullscreen, metadata(Resource),
                   :fingerprint, :pending_slug, :pending_sort_title]
     relationships = [:project, :creators]
     param_config = structure_params(attributes: attributes, relationships: relationships)

--- a/api/app/serializers/v1/resource_serializer.rb
+++ b/api/app/serializers/v1/resource_serializer.rb
@@ -5,32 +5,32 @@ module V1
 
     metadata(metadata: false, properties: false, formatted: true)
 
-    typed_attribute :alt_text, NilClass
-    typed_attribute :caption, NilClass
-    typed_attribute :caption_formatted, NilClass
-    typed_attribute :caption_plaintext, NilClass
-    typed_attribute :created_at, NilClass
-    typed_attribute :external_id, NilClass
-    typed_attribute :external_type, NilClass
-    typed_attribute :external_url, NilClass
-    typed_attribute :kind, NilClass
-    typed_attribute :minimum_height, NilClass
-    typed_attribute :minimum_width, NilClass
-    typed_attribute :pending_slug, NilClass
-    typed_attribute :pending_sort_title, NilClass
-    typed_attribute :project_id, NilClass
-    typed_attribute :project_slug, NilClass
-    typed_attribute :slug, NilClass
-    typed_attribute :sort_title, NilClass
-    typed_attribute :sub_kind, NilClass
-    typed_attribute :title, NilClass
-    typed_attribute :title_formatted, NilClass
-    typed_attribute :title_plaintext, NilClass
-    typed_attribute :downloadable, NilClass, &:downloadable?
+    typed_attribute :alt_text, Types::String.optional
+    typed_attribute :caption, Types::String.optional
+    typed_attribute :caption_formatted, Types::String.meta(read_only: true)
+    typed_attribute :caption_plaintext, Types::String.meta(read_only: true)
+    typed_attribute :created_at, Types::DateTime.meta(read_only: true)
+    typed_attribute :external_id, Types::String.optional
+    typed_attribute :external_type, Types::String.optional
+    typed_attribute :external_url, Types::Serializer::URL
+    typed_attribute :kind, Types::String.enum("link")
+    typed_attribute :minimum_height, Types::String.optional
+    typed_attribute :minimum_width, Types::String.optional
+    typed_attribute :pending_slug, Types::String
+    typed_attribute :pending_sort_title, Types::String.optional
+    typed_attribute :project_id, Types::Serializer::ID.meta(read_only: true)
+    typed_attribute :project_slug, Types::String.meta(read_only: true)
+    typed_attribute :slug, Types::String.meta(read_only: true)
+    typed_attribute :sort_title, Types::String.meta(read_only: true)
+    typed_attribute :sub_kind, Types::String.optional
+    typed_attribute :title, Types::String
+    typed_attribute :title_formatted, Types::String.meta(read_only: true)
+    typed_attribute :title_plaintext, Types::String.meta(read_only: true)
+    typed_attribute :downloadable, Types::Bool.meta(read_only: true), &:downloadable?
 
-    typed_attribute :attachment_styles, Types::Hash
-    typed_attribute :variant_poster_styles, Types::Hash
-    typed_attribute :variant_thumbnail_styles, Types::Hash
+    typed_attribute :attachment_styles, Types::Serializer::Attachment.meta(read_only: true)
+    typed_attribute :variant_poster_styles, Types::Serializer::Attachment.meta(read_only: true)
+    typed_attribute :variant_thumbnail_styles, Types::Serializer::Attachment.meta(read_only: true)
 
     typed_has_many :collection_resources
 
@@ -39,45 +39,45 @@ module V1
       abilities
       metadata(metadata: true, properties: true)
 
-      typed_attribute :allow_download, NilClass
-      typed_attribute :allow_high_res, NilClass
-      typed_attribute :attachment_content_type, NilClass
-      typed_attribute :attachment_extension, NilClass
-      typed_attribute :attachment_file_size, NilClass
-      typed_attribute :description, NilClass
-      typed_attribute :description_formatted, NilClass
-      typed_attribute :description_plaintext, NilClass
-      typed_attribute :embed_code, NilClass
-      typed_attribute :fingerprint, NilClass
-      typed_attribute :high_res_content_type, NilClass
-      typed_attribute :high_res_file_name, NilClass
-      typed_attribute :high_res_file_size, NilClass
-      typed_attribute :high_res_url, NilClass
-      typed_attribute :iframe_allow_fullscreen, NilClass
-      typed_attribute :tag_list, NilClass
-      typed_attribute :transcript_content_type, NilClass
-      typed_attribute :transcript_file_name, NilClass
-      typed_attribute :transcript_file_size, NilClass
-      typed_attribute :translation_content_type, NilClass
-      typed_attribute :translation_file_name, NilClass
-      typed_attribute :translation_file_size, NilClass
-      typed_attribute :updated_at, NilClass
-      typed_attribute :variant_format_one_content_type, NilClass
-      typed_attribute :variant_format_one_file_name, NilClass
-      typed_attribute :variant_format_one_file_size, NilClass
-      typed_attribute :variant_format_one_url, NilClass
-      typed_attribute :variant_format_two_content_type, NilClass
-      typed_attribute :variant_format_two_file_name, NilClass
-      typed_attribute :variant_format_two_file_size, NilClass
-      typed_attribute :variant_format_two_url, NilClass
-      typed_attribute :variant_poster_content_type, NilClass
-      typed_attribute :variant_poster_file_name, NilClass
-      typed_attribute :variant_poster_file_size, NilClass
-      typed_attribute :variant_thumbnail_content_type, NilClass
-      typed_attribute :variant_thumbnail_file_name, NilClass
-      typed_attribute :variant_thumbnail_file_size, NilClass
-      typed_attribute :attachment_file_name, NilClass
-      typed_attribute :downloadable_kind, NilClass, &:downloadable_kind?
+      typed_attribute :allow_download, Types::Bool
+      typed_attribute :allow_high_res, Types::Bool.meta(read_only: true)
+      typed_attribute :attachment_content_type, Types::String.optional.meta(read_only: true)
+      typed_attribute :attachment_extension, Types::String.optional.meta(read_only: true)
+      typed_attribute :attachment_file_size, Types::String.optional.meta(read_only: true)
+      typed_attribute :description, Types::String.optional
+      typed_attribute :description_formatted, Types::String.optional.meta(read_only: true)
+      typed_attribute :description_plaintext, Types::String.optional.meta(read_only: true)
+      typed_attribute :embed_code, Types::String.optional
+      typed_attribute :fingerprint, Types::String
+      typed_attribute :high_res_content_type, Types::String.optional.meta(read_only: true)
+      typed_attribute :high_res_file_name, Types::String.optional.meta(read_only: true)
+      typed_attribute :high_res_file_size, Types::String.optional.meta(read_only: true)
+      typed_attribute :high_res_url, Types::String.optional.meta(read_only: true)
+      typed_attribute :iframe_allow_fullscreen, Types::Bool
+      typed_attribute :tag_list, Types::Array.of(Types::String)
+      typed_attribute :transcript_content_type, Types::String.optional.meta(read_only: true)
+      typed_attribute :transcript_file_name, Types::String.optional.meta(read_only: true)
+      typed_attribute :transcript_file_size, Types::String.optional.meta(read_only: true)
+      typed_attribute :translation_content_type, Types::String.optional.meta(read_only: true)
+      typed_attribute :translation_file_name, Types::String.optional.meta(read_only: true)
+      typed_attribute :translation_file_size, Types::String.optional.meta(read_only: true)
+      typed_attribute :updated_at, Types::DateTime.meta(read_only: true)
+      typed_attribute :variant_format_one_content_type, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_format_one_file_name, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_format_one_file_size, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_format_one_url, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_format_two_content_type, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_format_two_file_name, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_format_two_file_size, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_format_two_url, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_poster_content_type, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_poster_file_name, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_poster_file_size, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_thumbnail_content_type, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_thumbnail_file_name, Types::String.optional.meta(read_only: true)
+      typed_attribute :variant_thumbnail_file_size, Types::String.optional.meta(read_only: true)
+      typed_attribute :attachment_file_name, Types::String.optional.meta(read_only: true)
+      typed_attribute :downloadable_kind, Types::Bool.meta(read_only: true), &:downloadable_kind?
 
       typed_has_many :resource_collections
       typed_belongs_to :project

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -86,13 +86,13 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :resources do
+      resources :resources, only: [:show, :update, :destroy] do
         namespace :relationships do
           resources :comments, controller: "/api/v1/comments"
         end
       end
 
-      resources :resource_collections do
+      resources :resource_collections, only: [:show, :update, :destroy] do
         scope module: :resource_collections do
           namespace :relationships do
             resources :collection_resources, only: [:index, :show]

--- a/api/spec/api_docs/definitions/resources/action_callout.rb
+++ b/api/spec/api_docs/definitions/resources/action_callout.rb
@@ -18,7 +18,7 @@ module ApiDocs
 
         class << self
 
-          include Resource
+          include ApiDocs::Definitions::Resource
 
           def create_attributes
             request_attributes.except(:remove_attachment)

--- a/api/spec/api_docs/definitions/resources/annotation.rb
+++ b/api/spec/api_docs/definitions/resources/annotation.rb
@@ -19,7 +19,7 @@ module ApiDocs
 
         class << self
 
-          include Resource
+          include ApiDocs::Definitions::Resource
 
         end
       end

--- a/api/spec/api_docs/definitions/resources/category.rb
+++ b/api/spec/api_docs/definitions/resources/category.rb
@@ -3,7 +3,7 @@ module ApiDocs
     module Resources
       class Category
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/collaborator.rb
+++ b/api/spec/api_docs/definitions/resources/collaborator.rb
@@ -6,7 +6,7 @@ module ApiDocs
         REQUIRED_CREATE_ATTRIBUTES = [:role].freeze
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/collection_project.rb
+++ b/api/spec/api_docs/definitions/resources/collection_project.rb
@@ -3,7 +3,7 @@ module ApiDocs
     module Resources
       class CollectionProject
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/collection_resource.rb
+++ b/api/spec/api_docs/definitions/resources/collection_resource.rb
@@ -3,7 +3,7 @@ module ApiDocs
     module Resources
       class CollectionResource
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/comment.rb
+++ b/api/spec/api_docs/definitions/resources/comment.rb
@@ -7,7 +7,7 @@ module ApiDocs
 
         class << self
 
-          include Resource
+          include ApiDocs::Definitions::Resource
 
           def create_attributes
             request_attributes.except(:deleted)

--- a/api/spec/api_docs/definitions/resources/content_block.rb
+++ b/api/spec/api_docs/definitions/resources/content_block.rb
@@ -8,7 +8,7 @@ module ApiDocs
         ].freeze
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/current_user.rb
+++ b/api/spec/api_docs/definitions/resources/current_user.rb
@@ -3,7 +3,7 @@ module ApiDocs
     module Resources
       class CurrentUser
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/event.rb
+++ b/api/spec/api_docs/definitions/resources/event.rb
@@ -3,7 +3,7 @@ module ApiDocs
     module Resources
       class Event
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/favorite.rb
+++ b/api/spec/api_docs/definitions/resources/favorite.rb
@@ -6,7 +6,7 @@ module ApiDocs
         REQUIRED_CREATE_RELATIONSHIPS = [:favoritable].freeze
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
 
           def create_relationships
             {

--- a/api/spec/api_docs/definitions/resources/feature.rb
+++ b/api/spec/api_docs/definitions/resources/feature.rb
@@ -11,7 +11,7 @@ module ApiDocs
         }.freeze
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
 
           def create_attributes
             request_attributes.except(:remove_background, :remove_foreground)

--- a/api/spec/api_docs/definitions/resources/ingestion.rb
+++ b/api/spec/api_docs/definitions/resources/ingestion.rb
@@ -21,7 +21,7 @@ module ApiDocs
         }.freeze
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/maker.rb
+++ b/api/spec/api_docs/definitions/resources/maker.rb
@@ -11,7 +11,7 @@ module ApiDocs
         }
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
 
           def create_attributes
             request_attributes.except(:remove_avatar)

--- a/api/spec/api_docs/definitions/resources/page.rb
+++ b/api/spec/api_docs/definitions/resources/page.rb
@@ -10,7 +10,7 @@ module ApiDocs
         ID_TYPE = ::Types::String.meta(example: "1")
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/password.rb
+++ b/api/spec/api_docs/definitions/resources/password.rb
@@ -3,7 +3,7 @@ module ApiDocs
     module Resources
       class Password
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
 
           def serializer
             ::V1::UserSerializer

--- a/api/spec/api_docs/definitions/resources/permission.rb
+++ b/api/spec/api_docs/definitions/resources/permission.rb
@@ -6,7 +6,7 @@ module ApiDocs
         REQUIRED_CREATE_ATTRIBUTES = [:role_names].freeze
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/project.rb
+++ b/api/spec/api_docs/definitions/resources/project.rb
@@ -39,7 +39,7 @@ module ApiDocs
 
         class << self
 
-          include Resource
+          include ApiDocs::Definitions::Resource
 
           def create_attributes
             request_attributes.except(

--- a/api/spec/api_docs/definitions/resources/reading_group.rb
+++ b/api/spec/api_docs/definitions/resources/reading_group.rb
@@ -10,7 +10,7 @@ module ApiDocs
 
         class << self
 
-          include Resource
+          include ApiDocs::Definitions::Resource
 
         end
       end

--- a/api/spec/api_docs/definitions/resources/reading_group_membership.rb
+++ b/api/spec/api_docs/definitions/resources/reading_group_membership.rb
@@ -3,7 +3,7 @@ module ApiDocs
     module Resources
       class ReadingGroupMembership
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
 
           def create_relationships
             {

--- a/api/spec/api_docs/definitions/resources/resource.rb
+++ b/api/spec/api_docs/definitions/resources/resource.rb
@@ -1,0 +1,58 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class Resource
+
+        REQUEST_ATTRIBUTES = {
+          attachment: Types::Serializer::Upload,
+          remove_attachment: Types::Bool,
+
+          high_res: Types::Serializer::Upload,
+          remove_high_res: Types::Bool,
+
+          variant_format_one: Types::Serializer::Upload,
+          remove_variant_format_one: Types::Bool,
+
+          variant_format_two: Types::Serializer::Upload,
+          remove_variant_format_two: Types::Bool,
+
+          variant_thumbnail: Types::Serializer::Upload,
+          remove_variant_thumbnail: Types::Bool,
+
+          variant_poster: Types::Serializer::Upload,
+          remove_variant_poster: Types::Bool
+        }
+
+        METADATA_ATTRIBUTES = {
+          series_title: Types::String,
+          container_title: Types::String,
+          isbn: Types::String,
+          issn: Types::String,
+          doi: Types::String,
+          original_publisher: Types::String,
+          original_publisher_place: Types::String,
+          original_title: Types::String,
+          publisher: Types::String,
+          publisher_place: Types::String,
+          version: Types::String,
+          series_number: Types::String,
+          edition: Types::String,
+          issue: Types::String,
+          volume: Types::String,
+          rights: Types::String,
+          rights_territory: Types::String,
+          restrictions: Types::String,
+          rights_holder: Types::String,
+          creator: Types::String,
+          alt_text: Types::String,
+          credit: Types::String,
+          copyright_status: Types::String,
+        }
+
+        class << self
+          include ::ApiDocs::Definitions::Resource
+        end
+      end
+    end
+  end
+end

--- a/api/spec/api_docs/definitions/resources/resource_collection.rb
+++ b/api/spec/api_docs/definitions/resources/resource_collection.rb
@@ -10,7 +10,7 @@ module ApiDocs
 
         class << self
 
-          include Resource
+          include ApiDocs::Definitions::Resource
 
           def create_attributes
             request_attributes.except(:remove_thumbnail)

--- a/api/spec/api_docs/definitions/resources/setting.rb
+++ b/api/spec/api_docs/definitions/resources/setting.rb
@@ -17,7 +17,7 @@ module ApiDocs
 
         class << self
 
-          include Resource
+          include ApiDocs::Definitions::Resource
 
           def create_attributes
             request_attributes.except(

--- a/api/spec/api_docs/definitions/resources/statistic.rb
+++ b/api/spec/api_docs/definitions/resources/statistic.rb
@@ -6,7 +6,7 @@ module ApiDocs
         ID_TYPE = ::Types::String.meta(example: "0")
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/stylesheet.rb
+++ b/api/spec/api_docs/definitions/resources/stylesheet.rb
@@ -8,7 +8,7 @@ module ApiDocs
         READ_ONLY_RELATIONSHIPS = [:text].freeze
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/subject.rb
+++ b/api/spec/api_docs/definitions/resources/subject.rb
@@ -6,7 +6,7 @@ module ApiDocs
         REQUIRED_CREATE_ATTRIBUTES = [:name].freeze
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/tag.rb
+++ b/api/spec/api_docs/definitions/resources/tag.rb
@@ -6,7 +6,7 @@ module ApiDocs
         ID_TYPE = ::Types::String.meta(example: "0")
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/text.rb
+++ b/api/spec/api_docs/definitions/resources/text.rb
@@ -30,7 +30,7 @@ module ApiDocs
 
         class << self
 
-          include Resource
+          include ApiDocs::Definitions::Resource
 
         end
       end

--- a/api/spec/api_docs/definitions/resources/text_category.rb
+++ b/api/spec/api_docs/definitions/resources/text_category.rb
@@ -7,7 +7,7 @@ module ApiDocs
 
         class << self
 
-          include Resource
+          include ApiDocs::Definitions::Resource
 
         end
       end

--- a/api/spec/api_docs/definitions/resources/text_section.rb
+++ b/api/spec/api_docs/definitions/resources/text_section.rb
@@ -3,7 +3,7 @@ module ApiDocs
     module Resources
       class TextSection
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/twitter_query.rb
+++ b/api/spec/api_docs/definitions/resources/twitter_query.rb
@@ -6,7 +6,7 @@ module ApiDocs
         REQUIRED_CREATE_ATTRIBUTES = [:query].freeze
 
         class << self
-          include Resource
+          include ApiDocs::Definitions::Resource
         end
       end
     end

--- a/api/spec/api_docs/definitions/resources/user.rb
+++ b/api/spec/api_docs/definitions/resources/user.rb
@@ -57,7 +57,7 @@ module ApiDocs
 
         class << self
 
-          include Resource
+          include ApiDocs::Definitions::Resource
 
           def create_attributes
             request_attributes.except(:unsubscribe, :remove_avatar)

--- a/api/spec/requests/api/v1/resources_spec.rb
+++ b/api/spec/requests/api/v1/resources_spec.rb
@@ -1,19 +1,6 @@
 require "swagger_helper"
 
 RSpec.describe "Resources", type: :request do
-  path "/resources" do
-
-    # TODO: Remove or figure out how to pass in the projectID on this route.
-    # The response from the server is an denial for authorization, likely because
-    # the user is not authorized to attach a resource to a undefined project
-    # include_examples "an API create request",
-    #                   model: Resource,
-    #                   authorized_user: :admin
-
-    include_examples "an API index request",
-                      model: Resource,
-                      paginated: true
-  end
 
   path "/resources/{id}" do
     include_examples "an API show request", model: Resource

--- a/api/spec/requests/api/v1/resources_spec.rb
+++ b/api/spec/requests/api/v1/resources_spec.rb
@@ -1,0 +1,64 @@
+require "swagger_helper"
+
+RSpec.describe "Resources", type: :request do
+  path "/resources" do
+
+    # TODO: Remove or figure out how to pass in the projectID on this route.
+    # The response from the server is an denial for authorization, likely because
+    # the user is not authorized to attach a resource to a undefined project
+    # include_examples "an API create request",
+    #                   model: Resource,
+    #                   authorized_user: :admin
+
+    include_examples "an API index request",
+                      model: Resource,
+                      paginated: true
+  end
+
+  path "/resources/{id}" do
+    include_examples "an API show request", model: Resource
+    include_examples "an API destroy request", model: Resource, authorized_user: :admin
+    include_examples "an API update request", model: Resource, authorized_user: :admin
+  end
+
+  context "when relating to a project" do
+    let(:project) { FactoryBot.create(:project) }
+    let(:resource) { FactoryBot.create(:resource, project: project) }
+    let(:project_id) { project.id }
+
+    path "/projects/{project_id}/relationships/resources" do
+      include_examples "an API create request",
+                        model: Resource,
+                        authorized_user: :admin,
+                        url_parameters: [:project_id]
+
+      include_examples "an API index request",
+                        model: Resource,
+                        url_parameters: [:project_id]
+    end
+  end
+
+  context "when relating to a resource collection" do
+    let(:resource_collection) { FactoryBot.create(:resource_collection) }
+    let(:resource) { FactoryBot.create(:resource, resource_collection: resource_collection) }
+    let(:resource_collection_id) { resource_collection.id }
+
+    path "/resource_collections/{resource_collection_id}/relationships/resources" do
+      include_examples "an API index request",
+                        model: Resource,
+                        url_parameters: [:resource_collection_id]
+    end
+  end
+
+  context "when relating to a text section" do
+    let(:text_section) { FactoryBot.create(:text_section) }
+    let(:resource) { FactoryBot.create(:resource, text_section: text_section) }
+    let(:text_section_id) { text_section.id }
+
+    path "/text_sections/{text_section_id}/relationships/resources" do
+      include_examples "an API index request",
+                        model: Resource,
+                        url_parameters: [:text_section_id]
+    end
+  end
+end

--- a/api/spec/requests/resource_collections_spec.rb
+++ b/api/spec/requests/resource_collections_spec.rb
@@ -7,15 +7,6 @@ RSpec.describe "Resource Collections API", type: :request do
 
   let(:collection) { FactoryBot.create(:resource_collection) }
 
-  describe "sends a list of resource collections" do
-    describe "the response" do
-      it "has a 200 status code" do
-        get api_v1_resource_collections_path
-        expect(response).to have_http_status(200)
-      end
-    end
-  end
-
   describe "updates a collection" do
 
     let(:path) { api_v1_resource_collection_path(collection) }

--- a/api/spec/requests/resources_spec.rb
+++ b/api/spec/requests/resources_spec.rb
@@ -7,15 +7,6 @@ RSpec.describe "Resources API", type: :request do
 
   let(:resource) { FactoryBot.create(:resource) }
 
-  describe "sends a list of resources" do
-    describe "the response" do
-      it "has a 200 status code" do
-        get api_v1_resources_path
-        expect(response).to have_http_status(200)
-      end
-    end
-  end
-
   describe "updates a resource" do
 
     let(:path) { api_v1_resource_path(resource) }

--- a/client/src/api/resources/resources.js
+++ b/client/src/api/resources/resources.js
@@ -1,14 +1,4 @@
 export default {
-  index(filter = {}, page = {}) {
-    return {
-      endpoint: "/api/v1/resources",
-      method: "GET",
-      options: {
-        params: { filter, page }
-      }
-    };
-  },
-
   show(id) {
     return {
       endpoint: `/api/v1/resources/${id}`,


### PR DESCRIPTION
Resource name collision needs to be resolved.  Now that there is a module and a class called Resource, it is trickier to get each `Resource` to point to the right one. Any suggestions on how to separate them?

If there is any additional setup you would like me to do to explain the problem, do let me know and I'll add it in. The issue can be replicated by running `rspec -fd spec/requests/api/v1/resources_spec.rb` from the api folder.