### PR TITLE
[WIP] Document Pages API endpoints

### DIFF
--- a/api/app/serializers/v1/page_serializer.rb
+++ b/api/app/serializers/v1/page_serializer.rb
@@ -5,23 +5,23 @@ module V1
 
     abilities
 
-    typed_attribute :slug, NilClass
-    typed_attribute :pending_slug, NilClass
-    typed_attribute :title, NilClass
-    typed_attribute :nav_title, NilClass
-    typed_attribute :show_in_footer, NilClass
-    typed_attribute :show_in_header, NilClass
-    typed_attribute :created_at, NilClass
-    typed_attribute :updated_at, NilClass
-    typed_attribute :hidden, NilClass
-    typed_attribute :body_formatted, NilClass
-    typed_attribute :purpose, NilClass
-    typed_attribute :is_external_link, NilClass
-    typed_attribute :external_link, NilClass
-    typed_attribute :open_in_new_tab, NilClass
+    typed_attribute :slug, Types::String.meta(read_only: true)
+    typed_attribute :pending_slug, Types::String
+    typed_attribute :title, Types::String
+    typed_attribute :nav_title, Types::String
+    typed_attribute :show_in_footer, Types::Bool
+    typed_attribute :show_in_header, Types::Bool
+    typed_attribute :created_at, Types::DateTime.meta(read_only: true)
+    typed_attribute :updated_at, Types::DateTime.meta(read_only: true)
+    typed_attribute :hidden, Types::Bool
+    typed_attribute :body_formatted, Types::String.meta(example: "<p>string</p>", read_only: true)
+    typed_attribute :purpose, Types::String.enum("terms_and_conditions", "privacy_policy", "supplemental_content")
+    typed_attribute :is_external_link, Types::Bool
+    typed_attribute :external_link, Types::Serializer::URL.meta(description: "Required if is_external_link is true")
+    typed_attribute :open_in_new_tab, Types::Bool
 
     when_full do
-      typed_attribute :body, NilClass
+      typed_attribute :body, Types::String
     end
 
   end

--- a/api/spec/api_docs/definitions/resource.rb
+++ b/api/spec/api_docs/definitions/resource.rb
@@ -147,6 +147,10 @@ module ApiDocs
         attributes.except(*write_only_attributes)
       end
 
+      def id_type
+        const_defined?(:ID_TYPE) ? self::ID_TYPE : ::Types::Serializer::ID
+      end
+
       ####################################
       ############# HELPERS ##############
       ####################################
@@ -156,7 +160,7 @@ module ApiDocs
         attributes = attributes.merge(metadata_handler.response_metadata) if metadata_handler.metadata?
 
         data = {
-          id: ::Types::Serializer::ID,
+          id: id_type,
           type: ::Types::String.meta(example: type.camelize(:lower)),
           attributes: (::Types::Hash.schema(attributes) unless attributes.nil?),
           relationships: (::Types::Hash.schema(relationships) unless relationships.nil?),

--- a/api/spec/api_docs/definitions/resources/page.rb
+++ b/api/spec/api_docs/definitions/resources/page.rb
@@ -1,0 +1,18 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class Page
+
+        REQUIRED_CREATE_ATTRIBUTES = [
+          :title
+        ].freeze
+
+        ID_TYPE = ::Types::String.meta(example: "1")
+
+        class << self
+          include Resource
+        end
+      end
+    end
+  end
+end

--- a/api/spec/requests/api/v1/pages_spec.rb
+++ b/api/spec/requests/api/v1/pages_spec.rb
@@ -1,0 +1,14 @@
+require "swagger_helper"
+
+RSpec.describe "Pages", type: :request do
+  path "/pages" do
+    include_examples "an API create request", model: Page, authorized_user: :admin
+    include_examples "an API index request", model: Page
+  end
+
+  path "/pages/{id}" do
+    include_examples "an API show request", model: Page
+    include_examples "an API update request", model: Page, authorized_user: :admin
+    include_examples "an API destroy request", model: Page, authorized_user: :admin
+  end
+end


### PR DESCRIPTION
These pages have are unique in the aspect that the ID is simply an auto incrementing number. The Resource helper module needed to be adjusted to allow an overwrite of the ID type.