### PR TITLE
[WIP] Document Texts API endpoints

### DIFF
--- a/api/app/controllers/concerns/validation.rb
+++ b/api/app/controllers/concerns/validation.rb
@@ -251,9 +251,9 @@ module Validation
 
   def text_params
     params.require(:data)
-    attributes = [:title, :language, :position, :description, :publication_date,
-                  metadata(Text), :rights, :section_kind, :subtitle, :published,
-                  :pending_slug, attachment(:cover), :remove_cover]
+    attributes = [:title, :position, :description, :publication_date,
+                  metadata(Text), :section_kind, :subtitle, :published,
+                  :pending_slug]
     relationships = [:category, :contributors, :creators]
     param_config = structure_params(attributes: attributes, relationships: relationships)
     params.permit(param_config)

--- a/api/spec/api_docs/definitions/resources/text.rb
+++ b/api/spec/api_docs/definitions/resources/text.rb
@@ -1,0 +1,39 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class Text
+
+        METADATA_ATTRIBUTES = {
+          series_title: Types::String,
+          container_title: Types::String,
+          isbn: Types::String,
+          issn: Types::String,
+          doi: Types::String,
+          unique_identifier: Types::String,
+          language: Types::String,
+          original_publisher: Types::String,
+          original_publisher_place: Types::String,
+          original_title: Types::String,
+          publisher: Types::String,
+          publisher_place: Types::String,
+          version: Types::String,
+          series_number: Types::String,
+          edition: Types::String,
+          issue: Types::String,
+          volume: Types::String,
+          rights: Types::String,
+          rights_territory: Types::String,
+          restrictions: Types::String,
+          rights_holder: Types::String,
+          original_publication_date: Types::DateTime
+        }
+
+        class << self
+
+          include Resource
+
+        end
+      end
+    end
+  end
+end

--- a/api/spec/requests/api/v1/texts_spec.rb
+++ b/api/spec/requests/api/v1/texts_spec.rb
@@ -1,0 +1,33 @@
+require "swagger_helper"
+
+RSpec.describe "Text", type: :request do
+  path "/texts" do
+    include_examples "an API index request",
+                      model: Text,
+                      included_relationships: [:project]
+  end
+  path "/texts/{id}" do
+    include_examples "an API show request",
+                      model: Text,
+                      included_relationships: [
+                        :project,
+                        :category,
+                        :creators,
+                        :contributors,
+                        :stylesheets
+                      ]
+
+    include_examples "an API update request",
+                      model: Text,
+                      authorized_user: :admin,
+                      included_relationships: [
+                        :project,
+                        :creators,
+                        :contributors
+                      ]
+
+    include_examples "an API destroy request",
+                      model: Text,
+                      authorized_user: :admin
+  end
+end


### PR DESCRIPTION
I'm having trouble defining the type on the `toc` for a text and would appreciate some assistance. It looks like it's similar to the issue I was running into here (daac39f6355a185c3c6bfec3255242b1f7771c97) where it needs to be converted to a hash prior to serialization.