### PR TITLE
[WIP] Document ResourceImport API endpoints

### DIFF
--- a/api/app/serializers/v1/resource_import_serializer.rb
+++ b/api/app/serializers/v1/resource_import_serializer.rb
@@ -3,23 +3,37 @@ module V1
 
     include ::V1::Concerns::ManifoldSerializer
 
-    typed_attribute :source, NilClass
-    typed_attribute :data, NilClass
-    typed_attribute :column_map, NilClass
-    typed_attribute :column_automap, NilClass
-    typed_attribute :header_row, NilClass
-    typed_attribute :headers, NilClass
-    typed_attribute :available_columns, NilClass
-    typed_attribute :data_filename, NilClass
-    typed_attribute :storage_type, NilClass
-    typed_attribute :storage_identifier, NilClass
-    typed_attribute :url, NilClass
-    typed_attribute :parse_error, NilClass
-    typed_attribute :import_results, NilClass do |object|
+    typed_attribute :source, Types::String.enum("google_sheet", "attached_data")
+    typed_attribute :data, Types::Hash.schema(
+      original: Types::Hash.schema(
+        id: Types::String.meta(
+          example: "resourceimport/151747a1-ec84-492d-bf1f-7cb407881f5a/data/original-248172aeb6805275060ad0f6283afee1.csv"
+        ),
+        storage: Types::String.meta(example: "store"),
+        metadata: Types::Hash.schema(
+          size: Types::Integer,
+          width: Types::Integer.optional,
+          height: Types::Integer.optional,
+          sha256: Types::String,
+          filename: Types::String,
+          mime_type: Types::String.meta(example: "application/octet-stream")
+        )
+      )
+    ).meta(description: "Required if source is an attachment", read_only: true)
+    typed_attribute :column_map, Types::Hash
+    typed_attribute :column_automap, Types::Hash.meta(read_only: true)
+    typed_attribute :header_row, Types::Integer
+    typed_attribute :headers, Types::Hash.meta(read_only: true)
+    typed_attribute :available_columns, Types::Array.of(Types::String).meta(read_only: true)
+    typed_attribute :storage_type, Types::String
+    typed_attribute :storage_identifier, Types::String
+    typed_attribute :url, Types::Serializer::URL.optional.meta(description: "Required if source is a google sheet")
+    typed_attribute :parse_error, Types::Bool.meta(read_only: true)
+    typed_attribute :import_results, Types::Array.of(Types::String).meta(read_only: true) do |object|
       object.import_results.map { |r| camelize_hash(r) }
     end
-    typed_attribute :data_filename, NilClass, &:data_file_name
-    typed_attribute :state, NilClass do |object|
+    typed_attribute :data_filename, Types::String.meta(read_only: true), &:data_file_name
+    typed_attribute :state, Types::String.meta(example: "pending") do |object|
       object.state_machine.current_state
     end
 

--- a/api/app/serializers/v1/resource_import_serializer.rb
+++ b/api/app/serializers/v1/resource_import_serializer.rb
@@ -4,22 +4,6 @@ module V1
     include ::V1::Concerns::ManifoldSerializer
 
     typed_attribute :source, Types::String.enum("google_sheet", "attached_data")
-    typed_attribute :data, Types::Hash.schema(
-      original: Types::Hash.schema(
-        id: Types::String.meta(
-          example: "resourceimport/151747a1-ec84-492d-bf1f-7cb407881f5a/data/original-248172aeb6805275060ad0f6283afee1.csv"
-        ),
-        storage: Types::String.meta(example: "store"),
-        metadata: Types::Hash.schema(
-          size: Types::Integer,
-          width: Types::Integer.optional,
-          height: Types::Integer.optional,
-          sha256: Types::String,
-          filename: Types::String,
-          mime_type: Types::String.meta(example: "application/octet-stream")
-        )
-      )
-    ).meta(description: "Required if source is an attachment", read_only: true)
     typed_attribute :column_map, Types::Hash
     typed_attribute :column_automap, Types::Hash.meta(read_only: true)
     typed_attribute :header_row, Types::Integer

--- a/api/spec/api_docs/definitions/resources/resource_import.rb
+++ b/api/spec/api_docs/definitions/resources/resource_import.rb
@@ -5,6 +5,11 @@ module ApiDocs
 
         REQUIRED_CREATE_ATTRIBUTES = [:header_row].freeze
 
+        REQUEST_ATTRIBUTES = {
+            data: Types::Serializer::Upload
+        }.freeze
+
+
         class << self
           include Resource
         end

--- a/api/spec/api_docs/definitions/resources/resource_import.rb
+++ b/api/spec/api_docs/definitions/resources/resource_import.rb
@@ -1,0 +1,14 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class ResourceImport
+
+        REQUIRED_CREATE_ATTRIBUTES = [:header_row].freeze
+
+        class << self
+          include Resource
+        end
+      end
+    end
+  end
+end

--- a/api/spec/api_docs/examples/create.rb
+++ b/api/spec/api_docs/examples/create.rb
@@ -4,7 +4,7 @@ shared_examples_for "an API create request" do |options|
 
   api_spec_helper = ApiDocs::Helpers::Request.new(options, :create)
 
-  let(:body) { json_structure_for(api_spec_helper.factory) } if api_spec_helper.response_body?
+  let(:body) { json_structure_from_factory(api_spec_helper.factory, type: :request) } if api_spec_helper.response_body?
 
   post api_spec_helper.summary do
     api_spec_helper.parameters.each do |parameter_options|

--- a/api/spec/api_docs/examples/show.rb
+++ b/api/spec/api_docs/examples/show.rb
@@ -11,7 +11,7 @@ shared_examples_for "an API show request" do |options|
     let(:id) { resource_instance.id }
   end
 
-  let(:body) { json_structure_for(api_spec_helper.factory) }
+  let(:body) { json_structure_from_factory(api_spec_helper.factory) }
 
   get api_spec_helper.summary do
     api_spec_helper.parameters.each do |parameter_options|

--- a/api/spec/api_docs/examples/update.rb
+++ b/api/spec/api_docs/examples/update.rb
@@ -8,7 +8,7 @@ shared_examples_for "an API update request" do |options|
     defined?(resource) ? resource : FactoryBot.create(api_spec_helper.factory)
   end
   let(:id) { resource_instance.id }
-  let(:body) { json_structure_for(api_spec_helper.factory) }
+  let(:body) { json_structure_from_factory(api_spec_helper.factory, type: :request) }
 
   patch api_spec_helper.summary do
     api_spec_helper.parameters.each do |parameter_options|

--- a/api/spec/models/ingestion_spec.rb
+++ b/api/spec/models/ingestion_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Ingestion, type: :model do
 
   let(:ingestion) do
     ingestion = Ingestion.new(creator: admin)
-    Updaters::Ingestion.new(json_structure(attributes: attributes)).update(ingestion)
+    Updaters::Ingestion.new(build_json_structure(attributes: attributes)).update(ingestion)
     return ingestion
   end
 

--- a/api/spec/requests/action_callouts_spec.rb
+++ b/api/spec/requests/action_callouts_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Action Callout API", type: :request do
 
       describe "the response" do
         it "has a 200 OK status code" do
-          patch path, headers: headers, params: json_payload
+          patch path, headers: headers, params: build_json_payload
           expect(response).to have_http_status(200)
         end
 
@@ -35,7 +35,7 @@ RSpec.describe "Action Callout API", type: :request do
               }
             }
 
-            patch path, headers: headers, params: json_payload(relationships: params)
+            patch path, headers: headers, params: build_json_payload(relationships: params)
             api_response = JSON.parse(response.body)
             expect(api_response.dig("data", "relationships", "text", "data", "id")).to eq new_text.id
           end

--- a/api/spec/requests/api/v1/favorites_spec.rb
+++ b/api/spec/requests/api/v1/favorites_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Favorites", type: :request do
                        included_relationships: [:creator] do
         let(:comment) { FactoryBot.create(:comment) }
         let(:body) do
-          json_structure(relationships: {
+          build_json_structure(relationships: {
                            favoritable: {
                              data: {
                                id: comment.id,

--- a/api/spec/requests/api/v1/resource_imports_spec.rb
+++ b/api/spec/requests/api/v1/resource_imports_spec.rb
@@ -2,8 +2,10 @@ require "swagger_helper"
 
 RSpec.describe "Resource Imports", type: :request do
 
+  let(:factory) { :resource_import }
   let(:resource) { FactoryBot.create(:resource_import) }
   let(:project_id) { resource.project_id }
+
 
   path "/projects/{project_id}/relationships/resource_imports" do
     include_examples "an API create request",
@@ -16,8 +18,7 @@ RSpec.describe "Resource Imports", type: :request do
     include_examples "an API show request",
                       model: ResourceImport,
                       url_parameters: [:project_id],
-                      authorized_user: :admin,
-                      focus: true
+                      authorized_user: :admin
 
     include_examples "an API update request",
                       model: ResourceImport,

--- a/api/spec/requests/api/v1/resource_imports_spec.rb
+++ b/api/spec/requests/api/v1/resource_imports_spec.rb
@@ -1,0 +1,27 @@
+require "swagger_helper"
+
+RSpec.describe "Resource Imports", type: :request do
+
+  let(:resource) { FactoryBot.create(:resource_import) }
+  let(:project_id) { resource.project_id }
+
+  path "/projects/{project_id}/relationships/resource_imports" do
+    include_examples "an API create request",
+                      model: ResourceImport,
+                      url_parameters: [:project_id],
+                      authorized_user: :admin
+  end
+
+  path "/projects/{project_id}/relationships/resource_imports/{id}" do
+    include_examples "an API show request",
+                      model: ResourceImport,
+                      url_parameters: [:project_id],
+                      authorized_user: :admin,
+                      focus: true
+
+    include_examples "an API update request",
+                      model: ResourceImport,
+                      url_parameters: [:project_id],
+                      authorized_user: :admin
+  end
+end

--- a/api/spec/requests/comments_spec.rb
+++ b/api/spec/requests/comments_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Comments API", type: :request do
           end
 
           it "has a 200 OK status code" do
-            patch path, headers: headers, params: json_payload()
+            patch path, headers: headers, params: build_json_payload()
             expect(response).to have_http_status(200)
           end
         end
@@ -71,7 +71,7 @@ RSpec.describe "Comments API", type: :request do
           end
 
           it "has a 200 OK status code" do
-            patch path, headers: headers, params: json_payload()
+            patch path, headers: headers, params: build_json_payload()
             expect(response).to have_http_status(200)
           end
         end
@@ -83,7 +83,7 @@ RSpec.describe "Comments API", type: :request do
 
         describe "the response" do
           it "has a 403 status code" do
-            patch path, headers: headers, params: json_payload()
+            patch path, headers: headers, params: build_json_payload()
             expect(response).to have_http_status(403)
           end
         end
@@ -95,7 +95,7 @@ RSpec.describe "Comments API", type: :request do
       let(:path) { api_v1_annotation_relationships_comments_path(annotation, comment_a) }
 
       let(:params) {
-        json_payload(attributes: {
+        build_json_payload(attributes: {
           body: "John Rambo was here.",
         })
       }
@@ -166,7 +166,7 @@ RSpec.describe "Comments API", type: :request do
           end
 
           it "has a 200 OK status code" do
-            patch path, headers: headers, params: json_payload()
+            patch path, headers: headers, params: build_json_payload()
             expect(response).to have_http_status(200)
           end
         end
@@ -182,7 +182,7 @@ RSpec.describe "Comments API", type: :request do
           end
 
           it "has a 200 OK status code" do
-            patch path, headers: headers, params: json_payload()
+            patch path, headers: headers, params: build_json_payload()
             expect(response).to have_http_status(200)
           end
         end
@@ -194,7 +194,7 @@ RSpec.describe "Comments API", type: :request do
 
         describe "the response" do
           it "has a 403 status code" do
-            patch path, headers: headers, params: json_payload()
+            patch path, headers: headers, params: build_json_payload()
             expect(response).to have_http_status(403)
           end
         end
@@ -206,7 +206,7 @@ RSpec.describe "Comments API", type: :request do
       let(:path) { api_v1_resource_relationships_comments_path(resource, comment_b) }
 
       let(:params) {
-        json_payload(attributes: {
+        build_json_payload(attributes: {
           body: "John Rambo was here.",
         })
       }

--- a/api/spec/requests/contacts_controller_spec.rb
+++ b/api/spec/requests/contacts_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Contacts API", type: :request do
     context "when params are valid" do
       describe "the response" do
         it "has a 204 status code" do
-          post api_v1_contacts_path, headers: headers, params: json_payload(valid_params)
+          post api_v1_contacts_path, headers: headers, params: build_json_payload(valid_params)
           expect(response).to have_http_status(204)
         end
       end
@@ -31,7 +31,7 @@ RSpec.describe "Contacts API", type: :request do
 
     context "when params are invalid" do
       before(:each) do
-        post api_v1_contacts_path, headers: headers, params: json_payload(invalid_params)
+        post api_v1_contacts_path, headers: headers, params: build_json_payload(invalid_params)
       end
       describe "the response" do
         it "has a 422 status code" do

--- a/api/spec/requests/content_blocks_spec.rb
+++ b/api/spec/requests/content_blocks_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "ContentBlocks API", type: :request do
 
       describe "the response" do
         it "has a 200 OK status code" do
-          patch path, headers: headers, params: json_payload
+          patch path, headers: headers, params: build_json_payload
           expect(response).to have_http_status(200)
         end
 
@@ -59,7 +59,7 @@ RSpec.describe "ContentBlocks API", type: :request do
               }
             }
 
-            patch path, headers: headers, params: json_payload(relationships: params)
+            patch path, headers: headers, params: build_json_payload(relationships: params)
             api_response = JSON.parse(response.body)
             expect(api_response.dig("data", "relationships", "text", "data", "id")).to eq new_text.id
           end

--- a/api/spec/requests/export_targets_spec.rb
+++ b/api/spec/requests/export_targets_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "ExportTargets API", type: :request do
       end
 
       let(:valid_params) do
-        json_payload(
+        build_json_payload(
           attributes: FactoryBot.attributes_for(:export_target, :sftp_password).merge(
             configuration: valid_configuration_params
           )
@@ -74,7 +74,7 @@ RSpec.describe "ExportTargets API", type: :request do
       let!(:new_name) { "A New Name" }
 
       let(:valid_params) do
-        json_payload(attributes: { name: new_name })
+        build_json_payload(attributes: { name: new_name })
       end
 
       it "updates successfully given valid params" do

--- a/api/spec/requests/ingestion_spec.rb
+++ b/api/spec/requests/ingestion_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Ingestions API", type: :request do
     }
   }
   let(:valid_params) {
-    json_payload(attributes: attributes)
+    build_json_payload(attributes: attributes)
   }
 
   describe "creates an ingestion" do

--- a/api/spec/requests/makers_spec.rb
+++ b/api/spec/requests/makers_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Makers API", type: :request do
         end
 
         it "has a 200 OK status code" do
-          patch path, headers: headers, params: json_payload()
+          patch path, headers: headers, params: build_json_payload()
           expect(response).to have_http_status(200)
         end
       end
@@ -63,7 +63,7 @@ RSpec.describe "Makers API", type: :request do
   describe "creates a maker" do
     let(:path) { api_v1_makers_path }
     let(:params) {
-      json_payload(attributes: {
+      build_json_payload(attributes: {
         firstName: "John",
         lastName: "Rambo"
       })

--- a/api/spec/requests/me/relationships/favorites_spec.rb
+++ b/api/spec/requests/me/relationships/favorites_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "My Favorites API", type: :request do
         }
       }
     }
-    json_payload(relationships: relationships)
+    build_json_payload(relationships: relationships)
   }
 
   describe "sends my favorites" do

--- a/api/spec/requests/me_spec.rb
+++ b/api/spec/requests/me_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Me API", type: :request do
     let(:first_name) { "John" }
     let(:last_name) { "Rambozo" }
     let(:update_params) do
-      json_payload(attributes: { firstName: first_name, lastName: last_name })
+      build_json_payload(attributes: { firstName: first_name, lastName: last_name })
     end
     let(:api_response) { JSON.parse(response.body) }
 
@@ -35,7 +35,7 @@ RSpec.describe "Me API", type: :request do
         it("contains the updated first name") { expect_updated_param("firstName", "Janko") }
         it("contains the updated last name") { expect_updated_param("lastName", "Rambozo") }
         describe "the avatar" do
-          let(:params) { json_payload(attributes: { avatar: image_params }) }
+          let(:params) { build_json_payload(attributes: { avatar: image_params }) }
           before(:each) { patch path, headers: reader_headers, params: params }
 
           it("has an updated avatar") {

--- a/api/spec/requests/project_collections/relationships/collection_projects_controller_spec.rb
+++ b/api/spec/requests/project_collections/relationships/collection_projects_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "ProjectCollection CollectionProject API", type: :request do
 
       describe "the response" do
         it "has a 201 CREATED status code" do
-          post path, headers: headers, params: json_payload(collectionProject)
+          post path, headers: headers, params: build_json_payload(collectionProject)
           expect(response).to have_http_status(201)
         end
       end
@@ -25,7 +25,7 @@ RSpec.describe "ProjectCollection CollectionProject API", type: :request do
     context "when the user is a reader" do
       let(:headers) { reader_headers }
       it "has a 403 FORBIDDEN status code" do
-        post path, headers: headers, params: json_payload(collectionProject)
+        post path, headers: headers, params: build_json_payload(collectionProject)
         expect(response).to have_http_status(403)
       end
     end

--- a/api/spec/requests/project_collections_spec.rb
+++ b/api/spec/requests/project_collections_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Project Collections API", type: :request do
       }
     end
     let(:valid_params) do
-      json_payload(attributes: attributes, relationships: relationships)
+      build_json_payload(attributes: attributes, relationships: relationships)
     end
 
     it "has a 201 CREATED status code" do
@@ -90,7 +90,7 @@ RSpec.describe "Project Collections API", type: :request do
         end
 
         it "has a 200 OK status code" do
-          patch path, headers: headers, params: json_payload
+          patch path, headers: headers, params: build_json_payload
           expect(response).to have_http_status(200)
         end
       end

--- a/api/spec/requests/project_exportations_spec.rb
+++ b/api/spec/requests/project_exportations_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "ProjectExportations API", type: :request do
       let!(:export_target) { FactoryBot.create :export_target, :sftp_password }
 
       let(:valid_params) do
-        json_payload(
+        build_json_payload(
           attributes: { project_id: project.id, export_target_id: export_target.id }
         )
       end

--- a/api/spec/requests/projects/relationships/action_callouts_spec.rb
+++ b/api/spec/requests/projects/relationships/action_callouts_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Project ActionCallout API", type: :request do
 
       describe "the response" do
         it "has a 201 CREATED status code" do
-          post path, headers: headers, params: json_payload(params)
+          post path, headers: headers, params: build_json_payload(params)
           expect(response).to have_http_status(201)
         end
       end
@@ -44,7 +44,7 @@ RSpec.describe "Project ActionCallout API", type: :request do
 
       describe "the response" do
         it "has a 403 FORBIDDEN status code" do
-          post path, headers: headers, params: json_payload(params)
+          post path, headers: headers, params: build_json_payload(params)
           expect(response).to have_http_status(403)
         end
       end

--- a/api/spec/requests/projects/relationships/content_blocks_spec.rb
+++ b/api/spec/requests/projects/relationships/content_blocks_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Project ContentBlocks API", type: :request do
 
       describe "the response" do
         it "has a 201 CREATED status code" do
-          post path, headers: headers, params: json_payload(params)
+          post path, headers: headers, params: build_json_payload(params)
           expect(response).to have_http_status(201)
         end
       end
@@ -44,7 +44,7 @@ RSpec.describe "Project ContentBlocks API", type: :request do
 
       describe "the response" do
         it "has a 403 FORBIDDEN status code" do
-          post path, headers: headers, params: json_payload(params)
+          post path, headers: headers, params: build_json_payload(params)
           expect(response).to have_http_status(403)
         end
       end

--- a/api/spec/requests/projects/relationships/permissions_controller_spec.rb
+++ b/api/spec/requests/projects/relationships/permissions_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Project Permissions API", type: :request do
   include_context("param helpers")
   let(:project) { FactoryBot.create(:project) }
   let(:user) { FactoryBot.create(:user, role: Role::ROLE_EDITOR) }
-  let(:params) { json_payload(attributes: { role_names: [Role::ROLE_PROJECT_EDITOR] }, relationships: { user: { data: { id: user.id, type: "users" } } }) }
+  let(:params) { build_json_payload(attributes: { role_names: [Role::ROLE_PROJECT_EDITOR] }, relationships: { user: { data: { id: user.id, type: "users" } } }) }
 
   describe "sends a list of project permissions" do
     let(:path) { api_v1_project_relationships_permissions_path(project) }
@@ -95,7 +95,7 @@ RSpec.describe "Project Permissions API", type: :request do
       @permission = Permission.fetch(project, user)
       @path = api_v1_project_relationships_permission_path(project, @permission)
     end
-    let(:valid_params) { json_payload(attributes: { role_names: [Role::ROLE_PROJECT_EDITOR, Role::ROLE_PROJECT_AUTHOR] }) }
+    let(:valid_params) { build_json_payload(attributes: { role_names: [Role::ROLE_PROJECT_EDITOR, Role::ROLE_PROJECT_AUTHOR] }) }
 
     context "when the user is an admin" do
       let(:headers) { admin_headers }

--- a/api/spec/requests/projects/relationships/resource_imports_spec.rb
+++ b/api/spec/requests/projects/relationships/resource_imports_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Resource Import API", type: :request do
   }
 
   let(:valid_params) {
-    json_payload(attributes: attributes)
+    build_json_payload(attributes: attributes)
   }
 
   let(:project) { FactoryBot.create(:project) }
@@ -50,7 +50,7 @@ RSpec.describe "Resource Import API", type: :request do
     end
 
     it "changes the state of the import model" do
-      valid_params = json_payload(attributes: { state: "parsing" })
+      valid_params = build_json_payload(attributes: { state: "parsing" })
       put path, headers: admin_headers, params: valid_params
       @resource_import.reload
       expect(@resource_import.state_machine.in_state?(:parsed)).to be true

--- a/api/spec/requests/projects/relationships/resources_spec.rb
+++ b/api/spec/requests/projects/relationships/resources_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Project Resources API", type: :request do
 
       describe "the response" do
         it "has a 201 CREATED status code" do
-          post path, headers: headers, params: json_payload(resource)
+          post path, headers: headers, params: build_json_payload(resource)
           expect(response).to have_http_status(201)
         end
       end
@@ -42,7 +42,7 @@ RSpec.describe "Project Resources API", type: :request do
 
       describe "the response" do
         it "has a 403 FORBIDDEN status code" do
-          post path, headers: headers, params: json_payload(resource)
+          post path, headers: headers, params: build_json_payload(resource)
           expect(response).to have_http_status(403)
         end
       end

--- a/api/spec/requests/projects/relationships/text_categories_spec.rb
+++ b/api/spec/requests/projects/relationships/text_categories_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Project Text Categories API", type: :request do
 
     context "when the user is an admin" do
       let(:headers) { admin_headers }
-      before(:each) { post path, headers: headers, params: json_payload(post_model) }
+      before(:each) { post path, headers: headers, params: build_json_payload(post_model) }
 
       describe "the response" do
         it "has a 201 CREATED status code" do
@@ -35,7 +35,7 @@ RSpec.describe "Project Text Categories API", type: :request do
 
     context "when the user is an reader" do
       let(:headers) { reader_headers }
-      before(:each) { post path, headers: headers, params: json_payload(post_model) }
+      before(:each) { post path, headers: headers, params: build_json_payload(post_model) }
 
       describe "the response" do
         it "has a 403 FORBIDDEN status code" do

--- a/api/spec/requests/projects/relationships/twitter_queries_spec.rb
+++ b/api/spec/requests/projects/relationships/twitter_queries_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Project Twitter Queries API", type: :request do
       let(:headers) { admin_headers }
       describe "the response" do
         it "has a 201 CREATED status code" do
-          post path, headers: headers, params: json_payload(resource)
+          post path, headers: headers, params: build_json_payload(resource)
           expect(response).to have_http_status(201)
         end
       end
@@ -78,7 +78,7 @@ RSpec.describe "Project Twitter Queries API", type: :request do
       let(:headers) { reader_headers }
       describe "the response" do
         it "has a 403 FORBIDDEN status code" do
-          post path, headers: headers, params: json_payload(resource)
+          post path, headers: headers, params: build_json_payload(resource)
           expect(response).to have_http_status(403)
         end
       end
@@ -90,7 +90,7 @@ RSpec.describe "Project Twitter Queries API", type: :request do
       @twitter_query = FactoryBot.create(:twitter_query, project: project)
     end
     let(:path) { api_v1_twitter_query_path(@twitter_query) }
-    let(:valid_params) { json_payload(attributes: { query: "from:rambostoolz" }) }
+    let(:valid_params) { build_json_payload(attributes: { query: "from:rambostoolz" }) }
 
     context "when the user is an admin" do
       let(:headers) { admin_headers }

--- a/api/spec/requests/projects_spec.rb
+++ b/api/spec/requests/projects_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Projects API", type: :request do
       let(:headers) { admin_headers }
 
       it "has a 201 SUCCESS status code" do
-        params = json_payload(attributes: { title: "foo" })
+        params = build_json_payload(attributes: { title: "foo" })
         post path, headers: headers, params: params
         expect(response).to have_http_status(201)
       end
@@ -66,7 +66,7 @@ RSpec.describe "Projects API", type: :request do
     context "when the user is not logged in" do
 
       it "has a 401 status code" do
-        params = json_payload(attributes: { title: "foo" })
+        params = build_json_payload(attributes: { title: "foo" })
         post path, params: params
         expect(response).to have_http_status(401)
       end
@@ -76,7 +76,7 @@ RSpec.describe "Projects API", type: :request do
       let(:headers) { reader_headers }
 
       it "has a 403 status code" do
-        params = json_payload(attributes: { title: "foo" })
+        params = build_json_payload(attributes: { title: "foo" })
         post path, headers: headers, params: params
         expect(response).to have_http_status(403)
       end
@@ -104,7 +104,7 @@ RSpec.describe "Projects API", type: :request do
       describe "its creator association" do
         it("can be replaced") do
           project.creators << jenny
-          params = json_payload(relationships: { creators: { data: [
+          params = build_json_payload(relationships: { creators: { data: [
                                   { type: "makers", id: john.id },
                                   { type: "makers", id: jim.id }
                                 ] } })
@@ -116,7 +116,7 @@ RSpec.describe "Projects API", type: :request do
       describe "its contributors" do
         it("can be replaced") do
           project.contributors << jenny
-          params = json_payload(relationships: { contributors: { data: [
+          params = build_json_payload(relationships: { contributors: { data: [
                                   { type: "makers", id: john.id },
                                   { type: "makers", id: jim.id }
                                 ] } })
@@ -129,7 +129,7 @@ RSpec.describe "Projects API", type: :request do
           project.contributors << john
           project.save
           expect(project.contributors.reload.pluck(:id)).to eq([jenny.id, john.id])
-          params = json_payload(relationships: { contributors: { data: [
+          params = build_json_payload(relationships: { contributors: { data: [
                                   { type: "makers", id: john.id },
                                   { type: "makers", id: jenny.id }
                                 ] } })
@@ -141,7 +141,7 @@ RSpec.describe "Projects API", type: :request do
       describe "its creators" do
         it("can be replaced") do
           project.creators << jenny
-          params = json_payload(relationships: { creators: { data: [
+          params = build_json_payload(relationships: { creators: { data: [
                                   { type: "makers", id: john.id },
                                   { type: "makers", id: jim.id }
                                 ] } })
@@ -154,7 +154,7 @@ RSpec.describe "Projects API", type: :request do
           project.creators << john
           project.save
           expect(project.creators.pluck(:id)).to eq([jenny.id, john.id])
-          params = json_payload(relationships: { creators: { data: [
+          params = build_json_payload(relationships: { creators: { data: [
                                   { type: "makers", id: john.id },
                                   { type: "makers", id: jenny.id }
                                 ] } })
@@ -175,7 +175,7 @@ RSpec.describe "Projects API", type: :request do
         end
 
         it "has a 200 OK status code" do
-          patch path, headers: headers, params: json_payload
+          patch path, headers: headers, params: build_json_payload
           expect(response).to have_http_status(200)
         end
       end
@@ -186,7 +186,7 @@ RSpec.describe "Projects API", type: :request do
 
       describe "the response" do
         it "has a 403 forbidden status code" do
-          patch path, headers: headers, params: json_payload
+          patch path, headers: headers, params: build_json_payload
           expect(response).to have_http_status(403)
         end
       end

--- a/api/spec/requests/reading_group_memberships_spec.rb
+++ b/api/spec/requests/reading_group_memberships_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Reading Group Memberships API", type: :request do
     }
 
     let(:valid_params) {
-      json_payload(attributes: attributes, relationships: relationships)
+      build_json_payload(attributes: attributes, relationships: relationships)
     }
 
     it "has a 201 CREATED status code when the membership is for the authenticated user" do

--- a/api/spec/requests/reading_groups_spec.rb
+++ b/api/spec/requests/reading_groups_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Reading Groups API", type: :request do
         end
 
         it "has a 200 OK status code" do
-          patch path, headers: headers, params: json_payload()
+          patch path, headers: headers, params: build_json_payload()
           expect(response).to have_http_status(200)
         end
       end
@@ -108,7 +108,7 @@ RSpec.describe "Reading Groups API", type: :request do
 
       describe "the response" do
         it "has a 403 status code" do
-          patch path, headers: headers, params: json_payload()
+          patch path, headers: headers, params: build_json_payload()
           expect(response).to have_http_status(403)
         end
       end
@@ -121,7 +121,7 @@ RSpec.describe "Reading Groups API", type: :request do
 
       describe "the response" do
         it "has a 200 status code" do
-          patch path, headers: headers, params: json_payload()
+          patch path, headers: headers, params: build_json_payload()
           expect(response).to have_http_status(200)
         end
       end
@@ -136,7 +136,7 @@ RSpec.describe "Reading Groups API", type: :request do
       }
     }
     let(:valid_params) {
-      json_payload(attributes: attributes)
+      build_json_payload(attributes: attributes)
     }
 
     it "has a 201 CREATED status code" do

--- a/api/spec/requests/resource_collections_spec.rb
+++ b/api/spec/requests/resource_collections_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Resource Collections API", type: :request do
         end
 
         it "has a 200 OK status code" do
-          patch path, headers: headers, params: json_payload()
+          patch path, headers: headers, params: build_json_payload()
           expect(response).to have_http_status(200)
         end
       end

--- a/api/spec/requests/resources_spec.rb
+++ b/api/spec/requests/resources_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Resources API", type: :request do
         end
 
         it "has a 200 OK status code" do
-          patch path, headers: headers, params: json_payload()
+          patch path, headers: headers, params: build_json_payload()
           expect(response).to have_http_status(200)
         end
       end

--- a/api/spec/requests/stylesheets_spec.rb
+++ b/api/spec/requests/stylesheets_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Stylesheets API", type: :request do
     }
   }
   let(:valid_params) {
-    json_payload(attributes: attributes)
+    build_json_payload(attributes: attributes)
   }
 
   let(:text) { FactoryBot.create(:text) }
@@ -47,7 +47,7 @@ RSpec.describe "Stylesheets API", type: :request do
     let(:api_response) { JSON.parse(response.body) }
 
     it "updates the name attribute" do
-      valid_params = json_payload(attributes: { name: "Rambo Stoolz"})
+      valid_params = build_json_payload(attributes: { name: "Rambo Stoolz"})
       put api_v1_stylesheet_path(stylesheet.id), headers: admin_headers, params: valid_params
       expect(api_response["data"]["attributes"]["name"]).to eq("Rambo Stoolz")
     end

--- a/api/spec/requests/text_sections/relationships/annotations_spec.rb
+++ b/api/spec/requests/text_sections/relationships/annotations_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Text Section Annotations API", type: :request do
 
   describe "creates an annotation" do
     context "when the user is an reader" do
-      before(:each) { post path, headers: reader_headers, params: json_payload(annotation_params) }
+      before(:each) { post path, headers: reader_headers, params: build_json_payload(annotation_params) }
       describe "the response" do
         it "has a 201 status code" do
           expect(response).to have_http_status(201)
@@ -87,7 +87,7 @@ RSpec.describe "Text Section Annotations API", type: :request do
     end
 
     context "when the user is not authenticated" do
-      before(:each) { post path, params: json_payload(annotation_params) }
+      before(:each) { post path, params: build_json_payload(annotation_params) }
       describe "the response" do
         it "has a 401 status code" do
           expect(response).to have_http_status(401)
@@ -96,7 +96,7 @@ RSpec.describe "Text Section Annotations API", type: :request do
     end
 
     context "when the user is an admin" do
-      before(:each) { post path, headers: admin_headers, params: json_payload(annotation_params) }
+      before(:each) { post path, headers: admin_headers, params: build_json_payload(annotation_params) }
       describe "the response" do
         it "has a 201 status code" do
           expect(response).to have_http_status(201)
@@ -107,7 +107,7 @@ RSpec.describe "Text Section Annotations API", type: :request do
 
   describe "creates a resource annotation" do
     context "when the user is an reader" do
-      before(:each) { post path, headers: reader_headers, params: json_payload(resource_params) }
+      before(:each) { post path, headers: reader_headers, params: build_json_payload(resource_params) }
       describe "the response" do
         it "has a 403 FORBIDDEN status code" do
           a = response.body
@@ -117,7 +117,7 @@ RSpec.describe "Text Section Annotations API", type: :request do
     end
 
     context "when the user is an admin" do
-      before(:each) { post path, headers: admin_headers, params: json_payload(resource_params) }
+      before(:each) { post path, headers: admin_headers, params: build_json_payload(resource_params) }
       describe "the response" do
         it "has a 201 status code" do
           expect(response).to have_http_status(201)
@@ -128,7 +128,7 @@ RSpec.describe "Text Section Annotations API", type: :request do
 
   describe "creates a collection annotation" do
     context "when the user is an reader" do
-      before(:each) { post path, headers: reader_headers, params: json_payload(collection_params) }
+      before(:each) { post path, headers: reader_headers, params: build_json_payload(collection_params) }
       describe "the response" do
         it "has a 403 FORBIDDEN status code" do
           a = response.body
@@ -138,7 +138,7 @@ RSpec.describe "Text Section Annotations API", type: :request do
     end
 
     context "when the user is an admin" do
-      before(:each) { post path, headers: admin_headers, params: json_payload(collection_params) }
+      before(:each) { post path, headers: admin_headers, params: build_json_payload(collection_params) }
       describe "the response" do
         it "has a 201 status code" do
           expect(response).to have_http_status(201)

--- a/api/spec/requests/users_spec.rb
+++ b/api/spec/requests/users_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Users API", type: :request do
     }
   }
   let(:valid_params) {
-    json_payload(attributes: attributes)
+    build_json_payload(attributes: attributes)
   }
 
   describe "sends a list of users" do
@@ -62,14 +62,14 @@ RSpec.describe "Users API", type: :request do
     end
 
     it "tells the welcome mailer that the user was created by the admin when meta[createdByAdmin] is true" do
-      valid_params = json_payload(attributes: attributes, meta: { created_by_admin: true })
+      valid_params = build_json_payload(attributes: attributes, meta: { created_by_admin: true })
       allow(AccountMailer).to receive(:welcome).and_call_original
       post path, headers: anonymous_headers, params: valid_params
       expect(AccountMailer).to have_received(:welcome).with(anything, true)
     end
 
     it "does not tell the welcome mailer that the user was created by the admin when meta[createdByAdmin] is absent" do
-      valid_params = json_payload(attributes: attributes)
+      valid_params = build_json_payload(attributes: attributes)
       allow(AccountMailer).to receive(:welcome).and_call_original
       post path, headers: anonymous_headers, params: valid_params
       expect(AccountMailer).to have_received(:welcome).with(anything, false)

--- a/api/spec/support/shared_examples/orderable_record.rb
+++ b/api/spec/support/shared_examples/orderable_record.rb
@@ -11,13 +11,13 @@ shared_examples_for "orderable api requests" do
 
   context "when the position attribute is set to" do
     it "\"up\", it returns the new position" do
-      valid_params = json_payload(attributes: { position: "up"})
+      valid_params = build_json_payload(attributes: { position: "up"})
       put __send__(path, object_b.id), headers: admin_headers, params: valid_params
       expect(api_response["data"]["attributes"]["position"]).to eq 1
     end
 
     it "\"down\", it returns the new position" do
-      valid_params = json_payload(attributes: { position: "down"})
+      valid_params = build_json_payload(attributes: { position: "down"})
       put __send__(path, object_a.id), headers: admin_headers, params: valid_params
       expect(api_response["data"]["attributes"]["position"]).to eq 2
     end


### PR DESCRIPTION
I'm getting this error on the GET for the `/projects/{project_id}/relationships/resource_imports/{id}` route:

```
Rswag::Specs::UnexpectedResponse:
      Expected response code '500' to match '200'
      Response body: {
        "status": 500,
        "error": "Internal Server Error",
        "exception":"#RuntimeError: The typed attribute :data on SerializerRegistry is not a hash. 
                     Consider changing the type to AttachmentUploader::UploadedFile",
```

Here is a snippet from a sample response on the the GET for the `/projects/{project_id}/relationships/resource_imports/{id}` route:
```
"attributes": {
  "source": "attached_data",
  "data": {
    "original": {
      "id": "resourceimport/151747a1-ec84-492d-bf1f-7cb407881f5a/data/original-248172aeb6805275060ad0f6283afee1.csv",
      "storage": "store",
      "metadata": {
        "size": 17816,
        "width": null,
        "height": null,
        "sha256": "d77ff3c1d5cf4958b371fa7f38f256b651b7846c915b5dea7651f3adba91c236",
        "filename": "resources.csv",
        "mime_type": "application/octet-stream"
      }
    }
  },
```

Running `rspec -fd spec/requests/api/v1/resource_imports_spec.rb` from the api folder will reproduce my issue.