### PR TITLE
[WIP] Document Statistics API endpoints

### DIFF
--- a/api/app/serializers/v1/statistics_serializer.rb
+++ b/api/app/serializers/v1/statistics_serializer.rb
@@ -3,16 +3,16 @@ module V1
 
     include ::V1::Concerns::ManifoldSerializer
 
-    typed_attribute :readers_this_week, NilClass
-    typed_attribute :reader_increase, NilClass
-    typed_attribute :new_highlights_count, NilClass
-    typed_attribute :new_annotations_count, NilClass
-    typed_attribute :new_texts_count, NilClass
-    typed_attribute :total_text_count, NilClass
-    typed_attribute :total_resource_count, NilClass
-    typed_attribute :total_annotation_count, NilClass
-    typed_attribute :total_comment_count, NilClass
-    typed_attribute :total_user_count, NilClass
-    typed_attribute :total_project_count, NilClass
+    typed_attribute :readers_this_week, Types::Float.meta(read_only: true)
+    typed_attribute :reader_increase, Types::Integer.meta(read_only: true)
+    typed_attribute :new_highlights_count, Types::Integer.meta(read_only: true)
+    typed_attribute :new_annotations_count, Types::Integer.meta(read_only: true)
+    typed_attribute :new_texts_count, Types::Integer.meta(read_only: true)
+    typed_attribute :total_text_count, Types::Integer.meta(read_only: true)
+    typed_attribute :total_resource_count, Types::Integer.meta(read_only: true)
+    typed_attribute :total_annotation_count, Types::Integer.meta(read_only: true)
+    typed_attribute :total_comment_count, Types::Integer.meta(read_only: true)
+    typed_attribute :total_user_count, Types::Integer.meta(read_only: true)
+    typed_attribute :total_project_count, Types::Integer.meta(read_only: true)
   end
 end

--- a/api/spec/api_docs/definitions/resources/statistic.rb
+++ b/api/spec/api_docs/definitions/resources/statistic.rb
@@ -1,0 +1,14 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class Statistics
+
+        ID_TYPE = ::Types::String.meta(example: "0")
+
+        class << self
+          include Resource
+        end
+      end
+    end
+  end
+end

--- a/api/spec/api_docs/examples/show.rb
+++ b/api/spec/api_docs/examples/show.rb
@@ -4,10 +4,13 @@ shared_examples_for "an API show request" do |options|
 
   api_spec_helper = ApiDocs::Helpers::Request.new(options, :show)
 
-  let(:resource_instance) do
-    defined?(resource) ? resource : FactoryBot.create(api_spec_helper.factory)
+  if api_spec_helper.instantiate_before_test?
+    let(:resource_instance) do
+      defined?(resource) ? resource : FactoryBot.create(api_spec_helper.factory)
+    end
+    let(:id) { resource_instance.id }
   end
-  let(:id) { resource_instance.id }
+
   let(:body) { json_structure_for(api_spec_helper.factory) }
 
   get api_spec_helper.summary do

--- a/api/spec/api_docs/helpers/request.rb
+++ b/api/spec/api_docs/helpers/request.rb
@@ -28,6 +28,11 @@ module ApiDocs
         options.key?(:response_body) ? !!@options[:response_body] : true
       end
 
+      def instantiate_before_test?
+        return !!options[:instantiate_before_test] if options.has_key? :instantiate_before_test
+        true
+      end
+
       def authorized_user
         auth = @options[:authorized_user]
         raise "authorized_user requires inputs that can be converted to a string" unless auth.respond_to?(:to_s)

--- a/api/spec/api_docs/helpers/request.rb
+++ b/api/spec/api_docs/helpers/request.rb
@@ -67,6 +67,7 @@ module ApiDocs
 
       def success_description
         return @options[:success_description] if @options[:success_description]
+        return options[:summary] if options.has_key? :summary
 
         I18n.t("swagger.#{@action}.success", type: human_resource_name, attribute: "ID")
       end

--- a/api/spec/requests/api/v1/statistics_spec.rb
+++ b/api/spec/requests/api/v1/statistics_spec.rb
@@ -1,0 +1,13 @@
+require "swagger_helper"
+
+RSpec.describe "Statistics", type: :request do
+  path "/statistics" do
+    include_examples "an API show request",
+                      model: Statistics,
+                      exclude: ["404"],
+                      summary: "Return statistics for this instance of manifold",
+                      request_id: false,
+                      instantiate_before_test: false,
+                      authorized_user: :admin
+  end
+end

--- a/api/spec/requests/api/v1/twitter_queries_spec.rb
+++ b/api/spec/requests/api/v1/twitter_queries_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Twitter Queries", type: :request do
                         model: TwitterQuery,
                         authorized_user: :admin,
                         tags: "Projects",
-                        summary: "Gets all twitter queries associated with a project",
+                        summary: "Returns all twitter queries associated with a project",
                         url_parameters: [:project_id]
     end
   end


### PR DESCRIPTION
This PR:
* Documents the Statistics API endpoints
* Creates a new optional parameter called `instantiate_before_test`, which allows the default behavior of creating a resource with FactoryBot before attempting a `show` request. In this case, the app generates the statistics and there is no factory that would create a statistics database entry, so `instantiate_before_test: false` turns off the attempt to create a statistic.
* To make the response success descriptions line up a little better with the route summary (since they are usually very closely related), if the route does not have a custom success description, it will fall back on the provided summary, and finally the default success description