### PR TITLE
[B] Address pre-v1 ingestion edge case

### DIFF
--- a/api/app/models/ingestion.rb
+++ b/api/app/models/ingestion.rb
@@ -70,6 +70,10 @@ class Ingestion < ApplicationRecord
     valid?
   end
 
+  def reingest?
+    text.present?
+  end
+
   def strategy_label
     return nil if strategy.blank?
 


### PR DESCRIPTION
Prior to V1, we used a different method for calculating the
source_identifier. When ingestion was refactored, we ended up with a
stable source identifier for all document ingestions. This change led
to an edge case bug. If a user reingested a text that had originally
been ingested under v1 and used a document ingestion strategy, Manifold
will insert a new text section instead of updating the existing one
because the source identifiers do not match. This leads to changed URLs
and losing annotations. No good.

If the following conditions are true, this method will make a quick
update to the existing text_section and associated ingestion_source so
that their identifiers match those of the new ingestion. Once the
identifiers match, the compiler will trigger an update instead of an
insert + delete. Conditions that must be met are as follows:

1. We're reingesting, not ingesting
2. The text being updated exists and has one text section that is
   KIND_SECTION
3. None of the text's text sections have the correct source identifier

Fixes #2617