### PR TITLE
[B] Remove legacy centering method

### DIFF
--- a/client/src/frontend/components/resource-player/Video.js
+++ b/client/src/frontend/components/resource-player/Video.js
@@ -44,16 +44,7 @@ export default class ResourcePlayerVideo extends Component {
         />
       );
     }
-    return (
-      <div
-        className="figure-video"
-        ref={c => {
-          this._figure = c;
-        }}
-      >
-        {output}
-      </div>
-    );
+    return <div className="figure-video">{output}</div>;
   }
 
   renderFileVideo(resource) {

--- a/client/src/frontend/components/resource-slide/Loading.js
+++ b/client/src/frontend/components/resource-slide/Loading.js
@@ -1,27 +1,13 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import Utility from "global/components/utility";
 
 export default class ResourceListSlideFigureLoading extends Component {
   static displayName = "ResourceList.Slide.Loading";
 
-  static propTypes = {
-    resource: PropTypes.object
-  };
-
-  componentDidMount() {
-    if (!this._figure) return null;
-    const parentWidth = this._figure.parentNode.offsetWidth;
-    this._figure.style.width = parentWidth + "px";
-  }
-
   render() {
     return (
       <figure>
         <div
-          ref={c => {
-            this._figure = c;
-          }}
           className="figure-default"
           style={{ backgroundImage: "url(/static/images/resource-splash.png)" }}
         >

--- a/client/src/frontend/components/resource-slide/Slide.js
+++ b/client/src/frontend/components/resource-slide/Slide.js
@@ -51,9 +51,6 @@ export default class ResourceListSlideFigure extends Component {
           </ResourcePreview>
         ) : null}
         <div
-          ref={c => {
-            this._figure = c;
-          }}
           className="figure-default"
           style={{ backgroundImage: `url(${bgImage})` }}
         >

--- a/client/src/frontend/components/resource-slide/SlideImage.js
+++ b/client/src/frontend/components/resource-slide/SlideImage.js
@@ -31,9 +31,6 @@ export default class ResourceListSlideFigureImage extends Component {
         ) : null}
         <div
           className="figure-image"
-          ref={c => {
-            this._figure = c;
-          }}
           style={{
             backgroundImage: "url(" + attr.attachmentStyles.medium + ")"
           }}

--- a/client/src/frontend/components/resource-slide/SlidePlaceholder.js
+++ b/client/src/frontend/components/resource-slide/SlidePlaceholder.js
@@ -1,25 +1,13 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import Utility from "global/components/utility";
 
 export default class ResourceListSlidePlaceholder extends Component {
   static displayName = "ResourceSlide.Placeholder";
 
-  static propTypes = {};
-
-  componentDidMount() {
-    if (!this._figure) return null;
-    const parentWidth = this._figure.parentNode.offsetWidth;
-    this._figure.style.width = parentWidth + "px";
-  }
-
   render() {
     return (
       <figure>
         <div
-          ref={c => {
-            this._figure = c;
-          }}
           className="figure-default"
           style={{
             backgroundImage: "url(/static/images/resource-collection.jpg)"


### PR DESCRIPTION
Before Manifold used CSS flex, this code was used to center content in resource slides. After some CSS refactoring, this code is no longer needed. In some cases the `componentDidMount` function was removed and the `ref` was left behind.

Resizing these slides were tested on the newest versions of Chrome, Firefox, Edge and Safari and all work as expected.