### PR TITLE
[B] Allow text subtitle to be cleared

### DIFF
--- a/api/app/models/text.rb
+++ b/api/app/models/text.rb
@@ -179,6 +179,8 @@ class Text < ApplicationRecord
   end
 
   def set_title_value(kind, value)
+    return titles.where(kind: kind).destroy_all if value.blank? && kind == TextTitle::KIND_SUBTITLE
+
     title = titles.find_or_initialize_by(kind: kind)
     title.value = value
     title.save


### PR DESCRIPTION
This commit addresses an issue where a text subtitle could not be
deleted. However, there is a broader issue here that still needs to be
addressed. If a user removes a title from a text and saves it, the API
does not return a proper error message and mark the text as invalid,
which leads to a confusing user experience. The change we made in
9e18e818bd20640649e4a6ae8f685ff7e81c08d2 complicates this. On save, the
invalid blank title is not removed, and there is no error message. We
should solve htis by adjusting the refresh method in the store reducer
to take into account whether the response object has errors, and by
ensuring that a missing title on a text invalidates the model.

Resolves #2661