### PR TITLE
[B] Resolve a11y issues in Form.Picker

### DIFF
--- a/client/src/global/components/form/Picker/List.js
+++ b/client/src/global/components/form/Picker/List.js
@@ -1,11 +1,10 @@
 import React, { PureComponent } from "react";
 import * as EntitiesList from "backend/components/list/EntitiesList";
-import withScreenReaderStatus from "hoc/with-screen-reader-status";
 import Utility from "global/components/utility";
 import has from "lodash/has";
 import isFunction from "lodash/isFunction";
 
-class FormHasManyList extends PureComponent {
+export default class FormHasManyList extends PureComponent {
   static displayName = "Form.Picker.List";
 
   static propTypes = {};
@@ -97,5 +96,3 @@ class FormHasManyList extends PureComponent {
     );
   }
 }
-
-export default withScreenReaderStatus(FormHasManyList);

--- a/client/src/global/components/form/Picker/index.js
+++ b/client/src/global/components/form/Picker/index.js
@@ -439,8 +439,13 @@ export class PickerComponent extends PureComponent {
       error: `${id}-picker-error`,
       textBox: `${id}-picker-textbox`,
       listBox: `${id}-picker-listbox`,
-      comboBox: `${id}-picker-combobox`
+      option: `${id}-picker-option`
     };
+  }
+
+  activeOptionId(formId) {
+    if (!this.activeOptionFromState) return null;
+    return `${this.ids(formId).option}-${this.activeOptionFromState.key}`;
   }
 
   updateSearchInputValue(searchInputValue) {
@@ -553,24 +558,18 @@ export class PickerComponent extends PureComponent {
                 />
               )}
               <div className={wrapperClasses}>
-                <label id={ids.label} htmlFor={ids.textBox}>
-                  {label}
-                </label>
+                <label id={ids.label}>{label}</label>
                 <div
                   ref={this.inputWrapperRef}
-                  id={ids.comboBox}
                   role="combobox"
-                  aria-controls={ids.textBox}
-                  aria-expanded={this.hasOptions}
-                  aria-owns={(this.isListBoxVisible
-                    ? [ids.textBox]
-                    : [ids.textBox, ids.listBox]
-                  ).join(",")}
+                  aria-expanded={this.isListBoxVisible}
+                  aria-owns={ids.listBox}
                   aria-haspopup="listbox"
                   className="picker-input__input"
                 >
                   <input
                     ref={this.searchInputRef}
+                    id={ids.textBox}
                     className="picker-input__text-input text-input"
                     type="text"
                     onClick={this.onSearchInputClick}
@@ -581,10 +580,10 @@ export class PickerComponent extends PureComponent {
                     placeholder={placeholder}
                     onKeyDown={this.listenForListBoxNavigation}
                     onKeyUp={this.stopEscapePropagation}
-                    aria-labelledby={this.ariaLabelledBy}
-                    aria-describedby={this.ariaDescribedBy}
+                    aria-labelledby={ids.label}
                     aria-autocomplete="list"
-                    aria-controls={`${id}-listbox`}
+                    aria-controls={ids.listBox}
+                    aria-activedescendant={this.activeOptionId(id)}
                   />
                   {this.isResetButtonVisible && (
                     <button
@@ -634,7 +633,6 @@ export class PickerComponent extends PureComponent {
                   >
                     {options.length === 0 && (
                       <li
-                        tabIndex="-1"
                         id="no-options"
                         className="picker-input__result picker-input__result--empty"
                       >
@@ -651,8 +649,7 @@ export class PickerComponent extends PureComponent {
                         <li
                           key={option.key}
                           role="option"
-                          tabIndex="-1"
-                          id={option.key}
+                          id={`${ids.option}-${option.key}`}
                           aria-selected={selected}
                           className={classNames("picker-input__result", {
                             "picker-input__result--selected": selected,

--- a/client/src/global/components/form/__stories__/Form.stories.js
+++ b/client/src/global/components/form/__stories__/Form.stories.js
@@ -108,7 +108,7 @@ storiesOf("Backend/Form", module).add("Picker", () => {
       </FormContainer.Form>
 
       <FormContainer.Form
-        name="test-form-select-multiple-resource-options"
+        name="test-form-select-multiple-resource-options-row-style"
         model={{
           id: 1,
           attributes: {


### PR DESCRIPTION
This fixes just a handful of ARIA attributes, and adds a couple missing ones as well. These changes resolved all errors reported in Axe and the Storybook a11y add-on. I also reviewed the accessibility tree for the component in Firefox dev tools and tested it out in VoiceOver/Safari. VoiceOver's read-out was admittedly not great, but given that the component follows the WAI 1.1 combobox design pattern, and it passed all audits, I feel okay with this. Will test with NVDA also to compare.

The last remaining piece is wiring up the picker to the with-screen-reader-status HOC. When entities are added or removed from the multi-select wells, we should expect an announcement for screen readers, like "{entity.label} added."