### PR TITLE
[F] Document Entitlements

### DIFF
--- a/api/app/authorizers/entitlement_authorizer.rb
+++ b/api/app/authorizers/entitlement_authorizer.rb
@@ -65,7 +65,11 @@ class EntitlementAuthorizer < ApplicationAuthorizer
 
     # @param [User] user
     # @param [Hash] _options
-    def readable_by?(_user, _options = {})
+    def readable_by?(user, options = {})
+      return true unless options
+      return admin_permissions?(user) if options[:unscoped]
+      return options[:for].updatable_by? user if options[:for]
+
       true
     end
 

--- a/api/app/controllers/api/v1/entitlements_controller.rb
+++ b/api/app/controllers/api/v1/entitlements_controller.rb
@@ -1,11 +1,12 @@
 module Api
   module V1
     class EntitlementsController < ApplicationController
-      resourceful! Entitlement do
+      resourceful! Entitlement, authorize_options: { except: [:index] } do
         Entitlement.all
       end
 
       def index
+        authorize_action_for Entitlement, unscoped: true
         @entitlements = load_entitlements
 
         render_multiple_resources @entitlements, includes: %i[entitler subject target]

--- a/api/app/controllers/api/v1/projects/relationships/entitlements_controller.rb
+++ b/api/app/controllers/api/v1/projects/relationships/entitlements_controller.rb
@@ -5,7 +5,7 @@ module Api
         class EntitlementsController < AbstractProjectChildController
           include Api::V1::BuildsScopedEntitlements
 
-          resourceful! Entitlement do
+          resourceful! Entitlement, authorize_options: { except: [:index] } do
             Entitlement.filtered(
               with_pagination!(entitlement_filter_params),
               scope: Entitlement.where(subject_type: "Project", subject_id: params[:project_id])
@@ -13,6 +13,7 @@ module Api
           end
 
           def index
+            authorize_action_for Entitlement, for: @project
             @entitlements = load_entitlements
 
             location = api_v1_project_relationships_entitlements_url(project_id: params[:project_id])

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -32,8 +32,8 @@ class ApplicationController < ActionController::API
         nil
       end
 
-      def can_read?(resource, *_other)
-        resource.readable_by? self
+      def can_read?(resource, *other)
+        resource.readable_by? self, *other
       end
     end.new
   end

--- a/api/app/serializers/v1/entitlement_serializer.rb
+++ b/api/app/serializers/v1/entitlement_serializer.rb
@@ -4,7 +4,8 @@ module V1
 
     ID = Types::Serializer::ID.meta(read_only: true)
 
-    CURRENT_STATE = Types::Coercible::String.enum(EntitlementState.map(&:to_s)).meta(example: "active", read_only: true)
+    ENTITLEMENT_STATE_OPTIONS = EntitlementState.map(&:to_s)
+    CURRENT_STATE = Types::Coercible::String.enum(*ENTITLEMENT_STATE_OPTIONS).meta(example: "active", read_only: true)
 
     typed_belongs_to :entitler
 
@@ -12,8 +13,7 @@ module V1
     typed_attribute :subject_id, ID
     typed_attribute :subject_type, Types::String.meta(example: "Project", read_only: true)
     typed_attribute :subject_url, Types::String.meta(
-      example: "gid://entitlements/Project/d5dd1398-ab9c-426b-bebc-25a596e3ca1e",
-      read_only: true
+      example: "gid://entitlements/Project/d5dd1398-ab9c-426b-bebc-25a596e3ca1e"
     )
 
     typed_belongs_to :target, polymorphic: true
@@ -21,13 +21,12 @@ module V1
     typed_attribute :target_name, Types::String.meta(example: "Maya Angelou", read_only: true)
     typed_attribute :target_type, Types::String.meta(example: "User", read_only: true)
     typed_attribute :target_url, Types::String.meta(
-      example: "gid://manifold-api/User/18588cc5-7761-43d2-9d3f-6aaabb46a59a",
-      read_only: true
+      example: "gid://manifold-api/User/18588cc5-7761-43d2-9d3f-6aaabb46a59a"
     )
 
     typed_attribute :current_state, CURRENT_STATE
 
-    typed_attribute :expiration, Types::String.optional.meta(example: "2025-01-01", read_only: true)
+    typed_attribute :expiration, Types::String.optional.meta(example: "2025-01-01")
 
     typed_attribute :role_names, Types::Array.of(Types::String).meta(example: %w[read_access], read_only: true) do |entitlement|
       entitlement.granted_role_names
@@ -35,13 +34,13 @@ module V1
 
     typed_attribute :global_roles, Types::Coercible::Hash.schema(
       subscriber: Types::Bool
-    ).meta(read_only: true) do |entitlement|
+    ) do |entitlement|
       entitlement.global_roles.as_json
     end
 
     typed_attribute :scoped_roles, Types::Coercible::Hash.schema(
       read_access: Types::Bool
-    ).meta(read_only: true) do |entitlement|
+    ) do |entitlement|
       entitlement.scoped_roles.as_json
     end
   end

--- a/api/public/api/static/docs/v1/swagger.json
+++ b/api/public/api/static/docs/v1/swagger.json
@@ -6604,6 +6604,1074 @@
         }
       }
     },
+    "/entitlements": {
+      "post": {
+        "summary": "Create an entitlement",
+        "parameters": [
+          {
+            "name": "body",
+            "description": "",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "attributes": {
+                      "type": "object",
+                      "properties": {
+                        "subjectUrl": {
+                          "type": "string",
+                          "example": "gid://entitlements/Project/d5dd1398-ab9c-426b-bebc-25a596e3ca1e"
+                        },
+                        "targetUrl": {
+                          "type": "string",
+                          "example": "gid://manifold-api/User/18588cc5-7761-43d2-9d3f-6aaabb46a59a"
+                        },
+                        "expiration": {
+                          "x-nullable": true,
+                          "type": "string",
+                          "example": "2025-01-01"
+                        },
+                        "globalRoles": {
+                          "type": "object",
+                          "properties": {
+                            "subscriber": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "scopedRoles": {
+                          "type": "object",
+                          "properties": {
+                            "readAccess": {
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "target_url",
+                        "scoped_roles"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "tags": [
+          "Entitlements"
+        ],
+        "responses": {
+          "201": {
+            "description": "Returns the Entitlement resource.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                    },
+                    "type": {
+                      "type": "string",
+                      "example": "entitlements"
+                    },
+                    "attributes": {
+                      "type": "object",
+                      "properties": {
+                        "subjectId": {
+                          "type": "string",
+                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                        },
+                        "subjectType": {
+                          "type": "string",
+                          "example": "Project"
+                        },
+                        "subjectUrl": {
+                          "type": "string",
+                          "example": "gid://entitlements/Project/d5dd1398-ab9c-426b-bebc-25a596e3ca1e"
+                        },
+                        "targetId": {
+                          "type": "string",
+                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                        },
+                        "targetName": {
+                          "type": "string",
+                          "example": "Maya Angelou"
+                        },
+                        "targetType": {
+                          "type": "string",
+                          "example": "User"
+                        },
+                        "targetUrl": {
+                          "type": "string",
+                          "example": "gid://manifold-api/User/18588cc5-7761-43d2-9d3f-6aaabb46a59a"
+                        },
+                        "currentState": {
+                          "type": "string",
+                          "example": "active",
+                          "enum": [
+                            "pending",
+                            "expiring_soon",
+                            "expired",
+                            "active"
+                          ]
+                        },
+                        "expiration": {
+                          "x-nullable": true,
+                          "type": "string",
+                          "example": "2025-01-01"
+                        },
+                        "roleNames": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            "read_access"
+                          ]
+                        },
+                        "globalRoles": {
+                          "type": "object",
+                          "properties": {
+                            "subscriber": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "scopedRoles": {
+                          "type": "object",
+                          "properties": {
+                            "readAccess": {
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "relationships": {
+                      "type": "object",
+                      "properties": {
+                        "entitler": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "x-nullable": true,
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "subject": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "x-nullable": true,
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "target": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "x-nullable": true,
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "partial": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Valid API key was not provided."
+          }
+        }
+      },
+      "get": {
+        "summary": "List all entitlements",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Entitlements"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns an array of Entitlement resources.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                      },
+                      "type": {
+                        "type": "string",
+                        "example": "entitlements"
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "subjectId": {
+                            "type": "string",
+                            "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                          },
+                          "subjectType": {
+                            "type": "string",
+                            "example": "Project"
+                          },
+                          "subjectUrl": {
+                            "type": "string",
+                            "example": "gid://entitlements/Project/d5dd1398-ab9c-426b-bebc-25a596e3ca1e"
+                          },
+                          "targetId": {
+                            "type": "string",
+                            "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                          },
+                          "targetName": {
+                            "type": "string",
+                            "example": "Maya Angelou"
+                          },
+                          "targetType": {
+                            "type": "string",
+                            "example": "User"
+                          },
+                          "targetUrl": {
+                            "type": "string",
+                            "example": "gid://manifold-api/User/18588cc5-7761-43d2-9d3f-6aaabb46a59a"
+                          },
+                          "currentState": {
+                            "type": "string",
+                            "example": "active",
+                            "enum": [
+                              "pending",
+                              "expiring_soon",
+                              "expired",
+                              "active"
+                            ]
+                          },
+                          "expiration": {
+                            "x-nullable": true,
+                            "type": "string",
+                            "example": "2025-01-01"
+                          },
+                          "roleNames": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "example": [
+                              "read_access"
+                            ]
+                          },
+                          "globalRoles": {
+                            "type": "object",
+                            "properties": {
+                              "subscriber": {
+                                "type": "boolean"
+                              }
+                            }
+                          },
+                          "scopedRoles": {
+                            "type": "object",
+                            "properties": {
+                              "readAccess": {
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "entitler": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "x-nullable": true,
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "subject": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "x-nullable": true,
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "target": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "x-nullable": true,
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "meta": {
+                        "type": "object",
+                        "properties": {
+                          "partial": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entitlements/{id}": {
+      "delete": {
+        "summary": "Delete an entitlement",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "tags": [
+          "Entitlements"
+        ],
+        "responses": {
+          "204": {
+            "description": "Removes the Entitlement resource."
+          },
+          "401": {
+            "description": "Valid API key was not provided."
+          }
+        }
+      },
+      "get": {
+        "summary": "Retrieve an entitlement",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "tags": [
+          "Entitlements"
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieve an Entitlement.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                    },
+                    "type": {
+                      "type": "string",
+                      "example": "entitlements"
+                    },
+                    "attributes": {
+                      "type": "object",
+                      "properties": {
+                        "subjectId": {
+                          "type": "string",
+                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                        },
+                        "subjectType": {
+                          "type": "string",
+                          "example": "Project"
+                        },
+                        "subjectUrl": {
+                          "type": "string",
+                          "example": "gid://entitlements/Project/d5dd1398-ab9c-426b-bebc-25a596e3ca1e"
+                        },
+                        "targetId": {
+                          "type": "string",
+                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                        },
+                        "targetName": {
+                          "type": "string",
+                          "example": "Maya Angelou"
+                        },
+                        "targetType": {
+                          "type": "string",
+                          "example": "User"
+                        },
+                        "targetUrl": {
+                          "type": "string",
+                          "example": "gid://manifold-api/User/18588cc5-7761-43d2-9d3f-6aaabb46a59a"
+                        },
+                        "currentState": {
+                          "type": "string",
+                          "example": "active",
+                          "enum": [
+                            "pending",
+                            "expiring_soon",
+                            "expired",
+                            "active"
+                          ]
+                        },
+                        "expiration": {
+                          "x-nullable": true,
+                          "type": "string",
+                          "example": "2025-01-01"
+                        },
+                        "roleNames": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            "read_access"
+                          ]
+                        },
+                        "globalRoles": {
+                          "type": "object",
+                          "properties": {
+                            "subscriber": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "scopedRoles": {
+                          "type": "object",
+                          "properties": {
+                            "readAccess": {
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "relationships": {
+                      "type": "object",
+                      "properties": {
+                        "entitler": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "x-nullable": true,
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "subject": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "x-nullable": true,
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "target": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "x-nullable": true,
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "partial": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource doesn't exist."
+          },
+          "401": {
+            "description": "Valid API key was not provided."
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/relationships/entitlements": {
+      "post": {
+        "summary": "Create an entitlement for a project",
+        "parameters": [
+          {
+            "name": "body",
+            "description": "",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "attributes": {
+                      "type": "object",
+                      "properties": {
+                        "subjectUrl": {
+                          "type": "string",
+                          "example": "gid://entitlements/Project/d5dd1398-ab9c-426b-bebc-25a596e3ca1e"
+                        },
+                        "targetUrl": {
+                          "type": "string",
+                          "example": "gid://manifold-api/User/18588cc5-7761-43d2-9d3f-6aaabb46a59a"
+                        },
+                        "expiration": {
+                          "x-nullable": true,
+                          "type": "string",
+                          "example": "2025-01-01"
+                        },
+                        "globalRoles": {
+                          "type": "object",
+                          "properties": {
+                            "subscriber": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "scopedRoles": {
+                          "type": "object",
+                          "properties": {
+                            "readAccess": {
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "target_url",
+                        "scoped_roles"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "path",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "description": "\n\nCreates an entitlement to be associated with the project ID provided in the endpoint. The subjectUrl in this case is not needed.\n\n",
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "tags": [
+          "Entitlements"
+        ],
+        "responses": {
+          "201": {
+            "description": "Returns the Entitlement resource.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                    },
+                    "type": {
+                      "type": "string",
+                      "example": "entitlements"
+                    },
+                    "attributes": {
+                      "type": "object",
+                      "properties": {
+                        "subjectId": {
+                          "type": "string",
+                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                        },
+                        "subjectType": {
+                          "type": "string",
+                          "example": "Project"
+                        },
+                        "subjectUrl": {
+                          "type": "string",
+                          "example": "gid://entitlements/Project/d5dd1398-ab9c-426b-bebc-25a596e3ca1e"
+                        },
+                        "targetId": {
+                          "type": "string",
+                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                        },
+                        "targetName": {
+                          "type": "string",
+                          "example": "Maya Angelou"
+                        },
+                        "targetType": {
+                          "type": "string",
+                          "example": "User"
+                        },
+                        "targetUrl": {
+                          "type": "string",
+                          "example": "gid://manifold-api/User/18588cc5-7761-43d2-9d3f-6aaabb46a59a"
+                        },
+                        "currentState": {
+                          "type": "string",
+                          "example": "active",
+                          "enum": [
+                            "pending",
+                            "expiring_soon",
+                            "expired",
+                            "active"
+                          ]
+                        },
+                        "expiration": {
+                          "x-nullable": true,
+                          "type": "string",
+                          "example": "2025-01-01"
+                        },
+                        "roleNames": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            "read_access"
+                          ]
+                        },
+                        "globalRoles": {
+                          "type": "object",
+                          "properties": {
+                            "subscriber": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "scopedRoles": {
+                          "type": "object",
+                          "properties": {
+                            "readAccess": {
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "relationships": {
+                      "type": "object",
+                      "properties": {
+                        "entitler": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "x-nullable": true,
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "subject": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "x-nullable": true,
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "target": {
+                          "type": "object",
+                          "properties": {
+                            "data": {
+                              "x-nullable": true,
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "partial": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Valid API key was not provided."
+          }
+        }
+      },
+      "get": {
+        "summary": "List a project's entitlements",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Entitlements"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns an array of Entitlement resources.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                      },
+                      "type": {
+                        "type": "string",
+                        "example": "entitlements"
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "properties": {
+                          "subjectId": {
+                            "type": "string",
+                            "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                          },
+                          "subjectType": {
+                            "type": "string",
+                            "example": "Project"
+                          },
+                          "subjectUrl": {
+                            "type": "string",
+                            "example": "gid://entitlements/Project/d5dd1398-ab9c-426b-bebc-25a596e3ca1e"
+                          },
+                          "targetId": {
+                            "type": "string",
+                            "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                          },
+                          "targetName": {
+                            "type": "string",
+                            "example": "Maya Angelou"
+                          },
+                          "targetType": {
+                            "type": "string",
+                            "example": "User"
+                          },
+                          "targetUrl": {
+                            "type": "string",
+                            "example": "gid://manifold-api/User/18588cc5-7761-43d2-9d3f-6aaabb46a59a"
+                          },
+                          "currentState": {
+                            "type": "string",
+                            "example": "active",
+                            "enum": [
+                              "pending",
+                              "expiring_soon",
+                              "expired",
+                              "active"
+                            ]
+                          },
+                          "expiration": {
+                            "x-nullable": true,
+                            "type": "string",
+                            "example": "2025-01-01"
+                          },
+                          "roleNames": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "example": [
+                              "read_access"
+                            ]
+                          },
+                          "globalRoles": {
+                            "type": "object",
+                            "properties": {
+                              "subscriber": {
+                                "type": "boolean"
+                              }
+                            }
+                          },
+                          "scopedRoles": {
+                            "type": "object",
+                            "properties": {
+                              "readAccess": {
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "entitler": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "x-nullable": true,
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "subject": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "x-nullable": true,
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "target": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "x-nullable": true,
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "meta": {
+                        "type": "object",
+                        "properties": {
+                          "partial": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/events/{id}": {
       "delete": {
         "summary": "Delete an event",
@@ -31707,6 +32775,43 @@
     }
   },
   "definitions": {
+    "TextCategory": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+            },
+            "type": {
+              "type": "string",
+              "example": "textCategories"
+            },
+            "attributes": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "position": {
+                  "type": "integer"
+                }
+              }
+            },
+            "meta": {
+              "type": "object",
+              "properties": {
+                "partial": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "Maker": {
       "type": "object",
       "properties": {
@@ -33456,257 +34561,6 @@
         }
       }
     },
-    "SearchResult": {
-      "type": "object",
-      "properties": {
-        "data": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-            },
-            "type": {
-              "type": "string",
-              "example": "searchResults"
-            },
-            "attributes": {
-              "type": "object",
-              "properties": {
-                "score": {
-                  "type": "number",
-                  "format": "float"
-                },
-                "searchableId": {
-                  "type": "string",
-                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-                },
-                "searchableType": {
-                  "type": "string",
-                  "example": "textSection"
-                },
-                "fullText": {
-                  "x-nullable": true,
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "keywords": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "parentKeywords": {
-                  "x-nullable": true,
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "makers": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "parents": {
-                  "x-nullable": true,
-                  "type": "object",
-                  "properties": {
-                    "text": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        },
-                        "slug": {
-                          "type": "string"
-                        },
-                        "id": {
-                          "type": "string",
-                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-                        }
-                      }
-                    },
-                    "project": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        },
-                        "slug": {
-                          "type": "string"
-                        },
-                        "id": {
-                          "type": "string",
-                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-                        }
-                      }
-                    }
-                  }
-                },
-                "textNodes": {
-                  "x-nullable": true,
-                  "type": "object",
-                  "properties": {
-                    "total": {
-                      "type": "integer"
-                    },
-                    "hits": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "content": {
-                            "type": "string"
-                          },
-                          "contentHighlighted": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          "nodeUuid": {
-                            "type": "string"
-                          },
-                          "position": {
-                            "type": "integer"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "highlights": {
-                  "x-nullable": true,
-                  "type": "object",
-                  "properties": {
-                    "parentKeywords": {
-                      "x-nullable": true,
-                      "type": "string"
-                    },
-                    "keywords": {
-                      "x-nullable": true,
-                      "type": "string"
-                    },
-                    "makers": {
-                      "x-nullable": true,
-                      "type": "string"
-                    },
-                    "fullText": {
-                      "x-nullable": true,
-                      "type": "string"
-                    },
-                    "title": {
-                      "x-nullable": true,
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            },
-            "relationships": {
-              "type": "object",
-              "properties": {
-                "model": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "x-nullable": true,
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-                        },
-                        "type": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "meta": {
-              "type": "object",
-              "properties": {
-                "partial": {
-                  "type": "boolean"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "Statistics": {
-      "type": "object",
-      "properties": {
-        "data": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "example": "0"
-            },
-            "type": {
-              "type": "string",
-              "example": "statistics"
-            },
-            "attributes": {
-              "type": "object",
-              "properties": {
-                "readersThisWeek": {
-                  "type": "number",
-                  "format": "float"
-                },
-                "readerIncrease": {
-                  "type": "integer"
-                },
-                "newHighlightsCount": {
-                  "type": "integer"
-                },
-                "newAnnotationsCount": {
-                  "type": "integer"
-                },
-                "newTextsCount": {
-                  "type": "integer"
-                },
-                "totalTextCount": {
-                  "type": "integer"
-                },
-                "totalResourceCount": {
-                  "type": "integer"
-                },
-                "totalAnnotationCount": {
-                  "type": "integer"
-                },
-                "totalCommentCount": {
-                  "type": "integer"
-                },
-                "totalUserCount": {
-                  "type": "integer"
-                },
-                "totalProjectCount": {
-                  "type": "integer"
-                }
-              }
-            },
-            "meta": {
-              "type": "object",
-              "properties": {
-                "partial": {
-                  "type": "boolean"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "Event": {
       "type": "object",
       "properties": {
@@ -33788,6 +34642,347 @@
                 "subjectTitleFormatted": {
                   "type": "string",
                   "example": "<p>string</p>"
+                }
+              }
+            },
+            "meta": {
+              "type": "object",
+              "properties": {
+                "partial": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Statistics": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "0"
+            },
+            "type": {
+              "type": "string",
+              "example": "statistics"
+            },
+            "attributes": {
+              "type": "object",
+              "properties": {
+                "readersThisWeek": {
+                  "type": "number",
+                  "format": "float"
+                },
+                "readerIncrease": {
+                  "type": "integer"
+                },
+                "newHighlightsCount": {
+                  "type": "integer"
+                },
+                "newAnnotationsCount": {
+                  "type": "integer"
+                },
+                "newTextsCount": {
+                  "type": "integer"
+                },
+                "totalTextCount": {
+                  "type": "integer"
+                },
+                "totalResourceCount": {
+                  "type": "integer"
+                },
+                "totalAnnotationCount": {
+                  "type": "integer"
+                },
+                "totalCommentCount": {
+                  "type": "integer"
+                },
+                "totalUserCount": {
+                  "type": "integer"
+                },
+                "totalProjectCount": {
+                  "type": "integer"
+                }
+              }
+            },
+            "meta": {
+              "type": "object",
+              "properties": {
+                "partial": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "CurrentUser": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+            },
+            "type": {
+              "type": "string",
+              "example": "currentUsers"
+            },
+            "attributes": {
+              "type": "object",
+              "properties": {
+                "abilities": {
+                  "type": "object"
+                },
+                "nickname": {
+                  "type": "string"
+                },
+                "firstName": {
+                  "type": "string"
+                },
+                "lastName": {
+                  "type": "string"
+                },
+                "updatedAt": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "fullName": {
+                  "type": "string"
+                },
+                "avatarStyles": {
+                  "type": "object",
+                  "properties": {
+                    "small": {
+                      "x-nullable": true,
+                      "type": "string",
+                      "example": "http://some-website.com"
+                    },
+                    "smallSquare": {
+                      "x-nullable": true,
+                      "type": "string",
+                      "example": "http://some-website.com"
+                    },
+                    "smallLandscape": {
+                      "x-nullable": true,
+                      "type": "string",
+                      "example": "http://some-website.com"
+                    },
+                    "smallPortrait": {
+                      "x-nullable": true,
+                      "type": "string",
+                      "example": "http://some-website.com"
+                    },
+                    "medium": {
+                      "x-nullable": true,
+                      "type": "string",
+                      "example": "http://some-website.com"
+                    },
+                    "mediumSquare": {
+                      "x-nullable": true,
+                      "type": "string",
+                      "example": "http://some-website.com"
+                    },
+                    "mediumLandscape": {
+                      "x-nullable": true,
+                      "type": "string",
+                      "example": "http://some-website.com"
+                    },
+                    "mediumPortrait": {
+                      "x-nullable": true,
+                      "type": "string",
+                      "example": "http://some-website.com"
+                    },
+                    "largeLandscape": {
+                      "x-nullable": true,
+                      "type": "string",
+                      "example": "http://some-website.com"
+                    },
+                    "original": {
+                      "x-nullable": true,
+                      "type": "string",
+                      "example": "http://some-website.com"
+                    }
+                  }
+                },
+                "email": {
+                  "type": "string",
+                  "example": "me@email.com"
+                },
+                "createdAt": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "role": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "isCurrentUser": {
+                  "type": "boolean"
+                },
+                "persistentUi": {
+                  "type": "object",
+                  "properties": {
+                    "reader": {
+                      "type": "object",
+                      "properties": {
+                        "colors": {
+                          "type": "object",
+                          "properties": {
+                            "colorScheme": {
+                              "type": "string",
+                              "enum": [
+                                "light",
+                                "dark"
+                              ]
+                            }
+                          }
+                        },
+                        "typography": {
+                          "type": "object",
+                          "properties": {
+                            "font": {
+                              "type": "string",
+                              "example": "serif"
+                            },
+                            "margins": {
+                              "type": "object",
+                              "properties": {
+                                "max": {
+                                  "type": "integer"
+                                },
+                                "min": {
+                                  "type": "integer"
+                                },
+                                "current": {
+                                  "type": "integer"
+                                }
+                              }
+                            },
+                            "fontSize": {
+                              "type": "object",
+                              "properties": {
+                                "max": {
+                                  "type": "integer"
+                                },
+                                "min": {
+                                  "type": "integer"
+                                },
+                                "current": {
+                                  "type": "integer"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "readingGroups": {
+                          "type": "object",
+                          "properties": {
+                            "currentReadingGroup": {
+                              "type": "string",
+                              "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "notificationPreferences": {
+                  "type": "object",
+                  "properties": {
+                    "projects": {
+                      "type": "string",
+                      "enum": [
+                        "never",
+                        "always"
+                      ]
+                    },
+                    "followedProjects": {
+                      "type": "string",
+                      "enum": [
+                        "never",
+                        "always"
+                      ]
+                    },
+                    "flaggedResources": {
+                      "type": "string",
+                      "enum": [
+                        "never",
+                        "always"
+                      ]
+                    },
+                    "projectCommentsAndAnnotations": {
+                      "type": "string",
+                      "enum": [
+                        "never",
+                        "always"
+                      ]
+                    },
+                    "repliesToMe": {
+                      "type": "string",
+                      "enum": [
+                        "never",
+                        "always"
+                      ]
+                    },
+                    "digest": {
+                      "type": "string",
+                      "enum": [
+                        "never",
+                        "always"
+                      ]
+                    },
+                    "digestCommentsAndAnnotations": {
+                      "type": "string",
+                      "enum": [
+                        "never",
+                        "always"
+                      ]
+                    }
+                  }
+                },
+                "currentUser": {
+                  "type": "boolean"
+                },
+                "classAbilities": {
+                  "type": "object",
+                  "description": "A wide variety of all the permissions that you as a user have for every kind of resource on the site. For each resource is a hash of keys such as 'create', 'read', 'update', 'delete', and each key has a boolean valueattached to it"
+                }
+              }
+            },
+            "relationships": {
+              "type": "object",
+              "properties": {
+                "favorites": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
@@ -34617,7 +35812,7 @@
         }
       }
     },
-    "CurrentUser": {
+    "SearchResult": {
       "type": "object",
       "properties": {
         "data": {
@@ -34629,251 +35824,161 @@
             },
             "type": {
               "type": "string",
-              "example": "currentUsers"
+              "example": "searchResults"
             },
             "attributes": {
               "type": "object",
               "properties": {
-                "abilities": {
-                  "type": "object"
+                "score": {
+                  "type": "number",
+                  "format": "float"
                 },
-                "nickname": {
-                  "type": "string"
-                },
-                "firstName": {
-                  "type": "string"
-                },
-                "lastName": {
-                  "type": "string"
-                },
-                "updatedAt": {
+                "searchableId": {
                   "type": "string",
-                  "format": "date-time"
+                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
                 },
-                "fullName": {
+                "searchableType": {
+                  "type": "string",
+                  "example": "textSection"
+                },
+                "fullText": {
+                  "x-nullable": true,
                   "type": "string"
                 },
-                "avatarStyles": {
+                "title": {
+                  "type": "string"
+                },
+                "keywords": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "parentKeywords": {
+                  "x-nullable": true,
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "makers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "parents": {
+                  "x-nullable": true,
                   "type": "object",
                   "properties": {
-                    "small": {
-                      "x-nullable": true,
-                      "type": "string",
-                      "example": "http://some-website.com"
+                    "text": {
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "type": "string"
+                        },
+                        "slug": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string",
+                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                        }
+                      }
                     },
-                    "smallSquare": {
-                      "x-nullable": true,
-                      "type": "string",
-                      "example": "http://some-website.com"
-                    },
-                    "smallLandscape": {
-                      "x-nullable": true,
-                      "type": "string",
-                      "example": "http://some-website.com"
-                    },
-                    "smallPortrait": {
-                      "x-nullable": true,
-                      "type": "string",
-                      "example": "http://some-website.com"
-                    },
-                    "medium": {
-                      "x-nullable": true,
-                      "type": "string",
-                      "example": "http://some-website.com"
-                    },
-                    "mediumSquare": {
-                      "x-nullable": true,
-                      "type": "string",
-                      "example": "http://some-website.com"
-                    },
-                    "mediumLandscape": {
-                      "x-nullable": true,
-                      "type": "string",
-                      "example": "http://some-website.com"
-                    },
-                    "mediumPortrait": {
-                      "x-nullable": true,
-                      "type": "string",
-                      "example": "http://some-website.com"
-                    },
-                    "largeLandscape": {
-                      "x-nullable": true,
-                      "type": "string",
-                      "example": "http://some-website.com"
-                    },
-                    "original": {
-                      "x-nullable": true,
-                      "type": "string",
-                      "example": "http://some-website.com"
+                    "project": {
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "type": "string"
+                        },
+                        "slug": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string",
+                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                        }
+                      }
                     }
                   }
                 },
-                "email": {
-                  "type": "string",
-                  "example": "me@email.com"
-                },
-                "createdAt": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "role": {
-                  "type": "string"
-                },
-                "kind": {
-                  "type": "string"
-                },
-                "isCurrentUser": {
-                  "type": "boolean"
-                },
-                "persistentUi": {
+                "textNodes": {
+                  "x-nullable": true,
                   "type": "object",
                   "properties": {
-                    "reader": {
-                      "type": "object",
-                      "properties": {
-                        "colors": {
-                          "type": "object",
-                          "properties": {
-                            "colorScheme": {
-                              "type": "string",
-                              "enum": [
-                                "light",
-                                "dark"
-                              ]
+                    "total": {
+                      "type": "integer"
+                    },
+                    "hits": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "content": {
+                            "type": "string"
+                          },
+                          "contentHighlighted": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
                             }
-                          }
-                        },
-                        "typography": {
-                          "type": "object",
-                          "properties": {
-                            "font": {
-                              "type": "string",
-                              "example": "serif"
-                            },
-                            "margins": {
-                              "type": "object",
-                              "properties": {
-                                "max": {
-                                  "type": "integer"
-                                },
-                                "min": {
-                                  "type": "integer"
-                                },
-                                "current": {
-                                  "type": "integer"
-                                }
-                              }
-                            },
-                            "fontSize": {
-                              "type": "object",
-                              "properties": {
-                                "max": {
-                                  "type": "integer"
-                                },
-                                "min": {
-                                  "type": "integer"
-                                },
-                                "current": {
-                                  "type": "integer"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "readingGroups": {
-                          "type": "object",
-                          "properties": {
-                            "currentReadingGroup": {
-                              "type": "string",
-                              "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-                            }
+                          },
+                          "nodeUuid": {
+                            "type": "string"
+                          },
+                          "position": {
+                            "type": "integer"
                           }
                         }
                       }
                     }
                   }
                 },
-                "notificationPreferences": {
+                "highlights": {
+                  "x-nullable": true,
                   "type": "object",
                   "properties": {
-                    "projects": {
-                      "type": "string",
-                      "enum": [
-                        "never",
-                        "always"
-                      ]
+                    "parentKeywords": {
+                      "x-nullable": true,
+                      "type": "string"
                     },
-                    "followedProjects": {
-                      "type": "string",
-                      "enum": [
-                        "never",
-                        "always"
-                      ]
+                    "keywords": {
+                      "x-nullable": true,
+                      "type": "string"
                     },
-                    "flaggedResources": {
-                      "type": "string",
-                      "enum": [
-                        "never",
-                        "always"
-                      ]
+                    "makers": {
+                      "x-nullable": true,
+                      "type": "string"
                     },
-                    "projectCommentsAndAnnotations": {
-                      "type": "string",
-                      "enum": [
-                        "never",
-                        "always"
-                      ]
+                    "fullText": {
+                      "x-nullable": true,
+                      "type": "string"
                     },
-                    "repliesToMe": {
-                      "type": "string",
-                      "enum": [
-                        "never",
-                        "always"
-                      ]
-                    },
-                    "digest": {
-                      "type": "string",
-                      "enum": [
-                        "never",
-                        "always"
-                      ]
-                    },
-                    "digestCommentsAndAnnotations": {
-                      "type": "string",
-                      "enum": [
-                        "never",
-                        "always"
-                      ]
+                    "title": {
+                      "x-nullable": true,
+                      "type": "string"
                     }
                   }
-                },
-                "currentUser": {
-                  "type": "boolean"
-                },
-                "classAbilities": {
-                  "type": "object",
-                  "description": "A wide variety of all the permissions that you as a user have for every kind of resource on the site. For each resource is a hash of keys such as 'create', 'read', 'update', 'delete', and each key has a boolean valueattached to it"
                 }
               }
             },
             "relationships": {
               "type": "object",
               "properties": {
-                "favorites": {
+                "model": {
                   "type": "object",
                   "properties": {
                     "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-                          },
-                          "type": {
-                            "type": "string"
-                          }
+                      "x-nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                        },
+                        "type": {
+                          "type": "string"
                         }
                       }
                     }
@@ -37272,6 +38377,164 @@
         }
       }
     },
+    "Entitlement": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+            },
+            "type": {
+              "type": "string",
+              "example": "entitlements"
+            },
+            "attributes": {
+              "type": "object",
+              "properties": {
+                "subjectId": {
+                  "type": "string",
+                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                },
+                "subjectType": {
+                  "type": "string",
+                  "example": "Project"
+                },
+                "subjectUrl": {
+                  "type": "string",
+                  "example": "gid://entitlements/Project/d5dd1398-ab9c-426b-bebc-25a596e3ca1e"
+                },
+                "targetId": {
+                  "type": "string",
+                  "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                },
+                "targetName": {
+                  "type": "string",
+                  "example": "Maya Angelou"
+                },
+                "targetType": {
+                  "type": "string",
+                  "example": "User"
+                },
+                "targetUrl": {
+                  "type": "string",
+                  "example": "gid://manifold-api/User/18588cc5-7761-43d2-9d3f-6aaabb46a59a"
+                },
+                "currentState": {
+                  "type": "string",
+                  "example": "active",
+                  "enum": [
+                    "pending",
+                    "expiring_soon",
+                    "expired",
+                    "active"
+                  ]
+                },
+                "expiration": {
+                  "x-nullable": true,
+                  "type": "string",
+                  "example": "2025-01-01"
+                },
+                "roleNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "example": [
+                    "read_access"
+                  ]
+                },
+                "globalRoles": {
+                  "type": "object",
+                  "properties": {
+                    "subscriber": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "scopedRoles": {
+                  "type": "object",
+                  "properties": {
+                    "readAccess": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            },
+            "relationships": {
+              "type": "object",
+              "properties": {
+                "entitler": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "x-nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "subject": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "x-nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "target": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "x-nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "meta": {
+              "type": "object",
+              "properties": {
+                "partial": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "Permission": {
       "type": "object",
       "properties": {
@@ -37789,43 +39052,6 @@
                 },
                 "isCurrentUser": {
                   "type": "boolean"
-                }
-              }
-            },
-            "meta": {
-              "type": "object",
-              "properties": {
-                "partial": {
-                  "type": "boolean"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "TextCategory": {
-      "type": "object",
-      "properties": {
-        "data": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "example": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-            },
-            "type": {
-              "type": "string",
-              "example": "textCategories"
-            },
-            "attributes": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "position": {
-                  "type": "integer"
                 }
               }
             },

--- a/api/spec/api_docs/definitions/resources/entitlement.rb
+++ b/api/spec/api_docs/definitions/resources/entitlement.rb
@@ -1,0 +1,17 @@
+module ApiDocs
+  module Definitions
+    module Resources
+      class Entitlement
+
+        REQUIRED_CREATE_ATTRIBUTES = [
+          :target_url,
+          :scoped_roles
+        ]
+
+        class << self
+          include ApiDocs::Definitions::Resource
+        end
+      end
+    end
+  end
+end

--- a/api/spec/requests/api/v1/entitlements_spec.rb
+++ b/api/spec/requests/api/v1/entitlements_spec.rb
@@ -1,0 +1,63 @@
+require "swagger_helper"
+
+RSpec.describe "Entitlements", type: :request do
+  let(:project) { FactoryBot.create(:project) }
+  let(:project_id) { project.id }
+  let(:resource) { FactoryBot.create(:entitlement, :project_read_access, subject: project) }
+  let(:id) { resource.id }
+
+  let!(:target_user) { FactoryBot.create(:user) }
+  let(:target_url) { target_user.to_gid.to_s }
+  let(:subject_url) { project.to_entitlement_gid.to_s }
+  let(:scoped_roles) { { read_access: true } }
+
+  path "/entitlements" do
+    include_examples "an API create request",
+                     model: Entitlement,
+                     authorized_user: :admin do
+      let(:body) do
+        {
+          data: {
+            attributes: {
+              subject_url: subject_url,
+              target_url: target_url,
+              scoped_roles: scoped_roles
+            }
+          }
+        }
+      end
+    end
+
+    include_examples "an API index request", model: Entitlement, authorized_user: :admin
+  end
+
+  path "/entitlements/{id}" do
+    include_examples "an API destroy request", model: Entitlement, authorized_user: :admin
+    include_examples "an API show request", model: Entitlement, authorized_user: :admin
+  end
+
+  context "for a project" do
+    path "/projects/{project_id}/relationships/entitlements" do
+      include_examples "an API create request",
+                       parent: "project",
+                       model: Entitlement,
+                       url_parameters: [:project_id],
+                       authorized_user: :admin,
+                       description: "Creates an entitlement to be associated with the project "\
+                       "ID provided in the endpoint." do
+        let(:body) do
+          {
+            data: {
+              attributes: {
+                target_url: target_url,
+                scoped_roles: scoped_roles
+              }
+            }
+          }
+        end
+      end
+
+      include_examples "an API index request", parent: "project", model: Entitlement, url_parameters: [:project_id], authorized_user: :admin
+    end
+  end
+end


### PR DESCRIPTION
Only two things out of the ordinary:

1. The rswag docs were out of sync when I started, so there is a single commit that just updates the docs before I made any documentation changes.
2. There are three GET requests relating to entitlements, `/entitlements`, `/entitlements/{id}` and `/projects/{project_id}/relationships/entitlements`. Only `/entitlements/{id}` requires authorization, out of these three GET requests. The reasoning behind restricting this route does not seem obvious to me, so if you happen to know why the route is restricted, I can add that to the route documentation.
 