### PR TITLE
[C] Remove unneeded wrapper from BE ProjectsList

### DIFF
--- a/client/src/backend/containers/projects/ProjectsList.js
+++ b/client/src/backend/containers/projects/ProjectsList.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import connectAndFetch from "utils/connectAndFetch";
 import { entityStoreActions } from "actions";
-import Layout from "backend/components/layout";
 import { select, meta } from "utils/entityUtils";
 import { projectsAPI, requests } from "api";
 import lh from "helpers/linkHandler";
@@ -86,45 +85,37 @@ class ProjectsListContainerImplementation extends PureComponent {
   };
 
   render() {
-    if (!this.props.projectsMeta) return null;
+    if (!this.props.projectsMeta || !this.props.projects) return null;
     const { totalCount } = this.props.projectsMeta.pagination;
     const label = totalCount > 1 || totalCount === 0 ? " Projects" : " Project";
 
     return (
-      <div>
-        <Layout.BackendPanel flush>
-          {this.props.projects && this.props.projectsMeta ? (
-            <EntitiesList
-              entityComponent={ProjectRow}
-              listStyle="grid"
-              title={label}
-              titleStyle="bar"
-              titleIcon="BEProject64"
-              entities={this.props.projects}
-              unit="project"
-              pagination={this.props.projectsMeta.pagination}
-              showCountInTitle
-              showCount
-              callbacks={{
-                onPageClick: this.updateHandlerCreator
-              }}
-              search={
-                <Search
-                  {...this.props.entitiesListSearchProps("projectsList")}
-                />
-              }
-              buttons={[
-                <Button
-                  path={lh.link("backendProjectsNew")}
-                  text="Add a new project"
-                  authorizedFor="project"
-                  type="add"
-                />
-              ]}
-            />
-          ) : null}
-        </Layout.BackendPanel>
-      </div>
+      <EntitiesList
+        entityComponent={ProjectRow}
+        listStyle="grid"
+        title={label}
+        titleStyle="bar"
+        titleIcon="BEProject64"
+        entities={this.props.projects}
+        unit="project"
+        pagination={this.props.projectsMeta.pagination}
+        showCountInTitle
+        showCount
+        callbacks={{
+          onPageClick: this.updateHandlerCreator
+        }}
+        search={
+          <Search {...this.props.entitiesListSearchProps("projectsList")} />
+        }
+        buttons={[
+          <Button
+            path={lh.link("backendProjectsNew")}
+            text="Add a new project"
+            authorizedFor="project"
+            type="add"
+          />
+        ]}
+      />
     );
   }
 }


### PR DESCRIPTION
As I was getting the app set up on my local, I noticed these two backend pages (Projects/Records) were rendering with slightly different padding.

As far as I can tell, `Layout.BackendPanel` isn't doing much in this case and seems like it shouldn't be here.  Other way to go might be adding that wrapper to these record child components.

![projects](https://user-images.githubusercontent.com/8389445/84712065-93182680-af1c-11ea-9110-8ed0c32436a9.gif)
