### PR TITLE
[B] Allow annotation comments when engagement is disabled

### DIFF
--- a/api/app/authorizers/comment_authorizer.rb
+++ b/api/app/authorizers/comment_authorizer.rb
@@ -7,11 +7,15 @@ class CommentAuthorizer < ApplicationAuthorizer
   end
 
   def creatable_by?(user, options = {})
-    with_project { |p| p.publicly_engageable_by? user, options }
+    return comment_is_on_readable_annotation_for?(user) if comment_is_on_annotation?
+
+    parent_project_is_publicly_engageable_by?(user, options)
   end
 
   def readable_by?(user, options = {})
-    with_project { |p| p.publicly_engageable_by? user, options }
+    return comment_is_on_readable_annotation_for?(user) if comment_is_on_annotation?
+
+    parent_project_is_publicly_engageable_by?(user, options)
   end
 
   def deletable_by?(user, _options = {})
@@ -24,6 +28,20 @@ class CommentAuthorizer < ApplicationAuthorizer
 
   def deleted_readable_by?(user, _options = {})
     editor_permissions?(user)
+  end
+
+  private
+
+  def comment_is_on_readable_annotation_for?(user)
+    comment_is_on_annotation? && resource.subject.readable_by?(user)
+  end
+
+  def parent_project_is_publicly_engageable_by?(user, options)
+    with_project { |p| p.publicly_engageable_by? user, options }
+  end
+
+  def comment_is_on_annotation?
+    resource.on_annotation?
   end
 
 end

--- a/api/spec/authorizers/comment_authorizer_spec.rb
+++ b/api/spec/authorizers/comment_authorizer_spec.rb
@@ -30,6 +30,20 @@ RSpec.describe "Comment Abilities", :authorizer do
     the_subject_behaves_like "instance abilities", Comment, all: true
   end
 
+  context "when the comment is on an annotation in a closed project with disabled engagement" do
+    let!(:project) { FactoryBot.create(:project, :with_restricted_access, disable_engagement: true ) }
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:reading_group) { FactoryBot.create(:reading_group)}
+    let!(:reading_group_membership) { FactoryBot.create(:reading_group_membership, reading_group: reading_group, user: user)}
+    let!(:entitlement) { FactoryBot.create :entitlement, :project_read_access, :for_reading_group, target: reading_group.reload, subject: project }
+    let(:text) { FactoryBot.create(:text, project: project) }
+    let(:annotation) { FactoryBot.create(:annotation, creator: user, reading_group: reading_group, text: text) }
+    let!(:object) { FactoryBot.build(:comment, creator: user, subject: annotation) }
+    let!(:subject) { user.reload }
+    # abilities = { create: true, read: true, update: true, delete: true }
+    the_subject_behaves_like "instance abilities", Comment, all: true
+  end
+
   context "when the comment is for a project that has disabled engagement" do
     let(:subject) { FactoryBot.create(:user) }
     let(:project) { FactoryBot.create(:project, disable_engagement: true) }
@@ -44,7 +58,7 @@ RSpec.describe "Comment Abilities", :authorizer do
       let(:text) { FactoryBot.create(:text, project: project) }
       let(:text_section) { FactoryBot.create(:text_section, text: text) }
       let(:comment_subject) { FactoryBot.create(:annotation, text_section: text_section) }
-      the_subject_behaves_like "instance abilities", Comment, none: true
+      the_subject_behaves_like "instance abilities", Comment, { create: true, read: true, update: false, delete: false}
     end
   end
 end


### PR DESCRIPTION
Resolves #2832

If a user can read an annotation, they can comment on it, even if public engagement is disabled on the project.