### PR TITLE
[C] Split mixins from structure utility classes

### DIFF
--- a/client/src/theme/styles/base/structure/_index.scss
+++ b/client/src/theme/styles/base/structure/_index.scss
@@ -1,51 +1,11 @@
 // Component Structure
 // -------------------
+// Structure-only utility classes with parameters for margins, padding, position, display, etc.
 
-// Structure-only mixins/utility classes, with parameters for margins, padding, position, display, etc.
-
-// Contents
-// --------------------------
-// - Prototypes
-// - Utilities
-// - Layout
-// - Type
-// - Images
-// - Lists
-// - Buttons/Links
-// - Tables
-// - Forms
-// - Imports
+@import 'mixins';
 
 // Utilities
 // --------------------------------------------------------
-// Media queries
-// Respond to viewport size
-// $size -> viewport size
-// $operator -> 'min' or 'max'
-// $aspect -> 'width' or 'height'
-// --------------------------
-@mixin respond($size, $operator: min, $aspect: width) {
-  @media all and (#{$operator}-#{$aspect}: $size) {
-    @content;
-  }
-}
-
-// Media show/hide classes, media-query variable dependent
-// --------------------------
-@mixin hide($breakpoint) {
-  @include respond($breakpoint) {
-    display: none;
-  }
-}
-
-@mixin show($breakpoint, $default: inherit) {
-  display: none;
-
-  @include respond($breakpoint) {
-    display: $default;
-  }
-}
-
 .show-50 {
   @include show($break50);
 }
@@ -66,7 +26,6 @@
   @include show($break75, block);
 }
 
-
 .rel {
   position: relative;
 }
@@ -79,61 +38,8 @@
   overflow: hidden;
 }
 
-// Clearfix
-// $mode accepts 'light' or 'heavy'
-// 'light' is sufficient for clearing floats, while 'heavy' is required to
-// prevent margin collapsing
-// --------------------------
-@mixin clearfix($mode: light) {
-  @if $mode == heavy {
-    &::before,
-    &::after {
-      display: table;
-      content: '';
-    }
-
-    &::after {
-      clear: both;
-    }
-  } @else {
-    &::after {
-      display: block;
-      clear: both;
-      content: '';
-    }
-  }
-}
-
-
 // Layout
 // --------------------------------------------------------
-@mixin containerPrototype {
-  max-width: $containerWidthFull;
-  padding-right: $containerPaddingNarrow;
-  padding-left: $containerPaddingNarrow;
-  margin-right: auto;
-  margin-left: auto;
-
-  @include respond($break35) {
-    padding-right: $containerPaddingResp;
-    padding-left: $containerPaddingResp;
-  }
-
-  @include respond($break120) {
-    padding-right: $containerPaddingFull;
-    padding-left: $containerPaddingFull;
-  }
-}
-
-@mixin containerFocus {
-  // Default max width
-  max-width: $containerWidthFocus;
-  padding-right: $containerPaddingMin;
-  padding-left: $containerPaddingMin;
-  margin-right: auto;
-  margin-left: auto;
-}
-
 .container {
   @include containerPrototype;
 
@@ -215,16 +121,6 @@ $readerContainerWidths: (1063px, 916px, 790px, 680px, 500px);
   }
 }
 
-@mixin headerContainerPrimary {
-  @include containerPrototype;
-  position: relative;
-  padding-top: header-layout(padding-vertical-mobile);
-
-  @include respond($break40) {
-    padding-top: header-layout(padding-vertical-desktop);
-  }
-}
-
 .align-left {
   text-align: left;
 }
@@ -241,123 +137,4 @@ $readerContainerWidths: (1063px, 916px, 790px, 680px, 500px);
   float: right;
 }
 
-@mixin drawerPadding($parameter, $scale: 'wide') {
-  #{$parameter}: 20px;
-
-  @include respond($break95) {
-    @if ($scale == 'wide') {
-      #{$parameter}: 5.859vw;
-    } @else {
-      #{$parameter}: 3.906vw;
-    }
-  }
-
-  @include respond($break120) {
-    @if ($scale == 'wide') {
-      #{$parameter}: 60px;
-    } @else {
-      #{$parameter}: 40px;
-    }
-  }
-}
-
-@mixin drawerIndent($parameter, $dimension: 1) {
-  #{$parameter}: (50px * $dimension);
-}
-
-// Lists
-// --------------------------------------------------------
-@mixin listUnstyled {
-  padding-left: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  list-style-type: none;
-}
-
-@mixin listHorizontal {
-  @include listUnstyled;
-
-  li {
-    display: inline-block;
-  }
-}
-
-
-// Form Layout
-// --------------------------------------------------------
-// TODO: This combines appearance mixins and should be a shared class or mixin
-@mixin loginFormPrimary {
-  .field + .field {
-    margin-top: 27px;
-  }
-
-  .login-links {
-    margin-top: 25px;
-
-    button {
-      @include buttonUnstyled;
-      @include outlineOnFocusVisible;
-      display: block;
-      font-style: italic;
-      text-decoration: underline;
-
-      + button {
-        margin-top: 14px;
-        margin-left: 0;
-      }
-    }
-
-    a {
-      font-style: italic;
-
-      + a {
-        margin-top: 14px;
-        margin-left: 0;
-      }
-    }
-  }
-
-  .login-external {
-    margin-top: 45px;
-  }
-
-  .button-secondary--dark {
-    display: flex;
-    width: 100%;
-  }
-
-  label {
-    @include inputLabelPrimary;
-  }
-
-  input[type='text'], input[type='password'], input[type='email'] {
-    @include inputPrimary;
-  }
-
-  .button-secondary {
-    display: block;
-    margin-top: 30px;
-  }
-}
-
-// Pagination
-// --------------------------------------------------------
-// Show/hide pagination button text
-@mixin constrainedPaginationResponsive {
-  span {
-    display: inline-block;
-
-    @include respond($break65) {
-      display: none;
-    }
-
-    @include respond($break90) {
-      display: inline-block;
-    }
-  }
-}
-
-
-// Imports
-// --------------------------------------------------------
 @import 'grids';

--- a/client/src/theme/styles/base/structure/_mixins.scss
+++ b/client/src/theme/styles/base/structure/_mixins.scss
@@ -1,0 +1,216 @@
+// Component Structure
+// -------------------
+// Structure-only mixins with parameters for margins, padding, position, display, etc.
+// The mixins are kept separately from the utility classes so someone can import mixins
+// without worrying that the structure utilites will overwrite previously defined values.
+
+// Utilities
+// --------------------------------------------------------
+// Media queries
+// Respond to viewport size
+// $size -> viewport size
+// $operator -> 'min' or 'max'
+// $aspect -> 'width' or 'height'
+// --------------------------
+@mixin respond($size, $operator: min, $aspect: width) {
+  @media all and (#{$operator}-#{$aspect}: $size) {
+    @content;
+  }
+}
+
+// Media show/hide classes, media-query variable dependent
+// --------------------------
+@mixin hide($breakpoint) {
+  @include respond($breakpoint) {
+    display: none;
+  }
+}
+
+@mixin show($breakpoint, $default: inherit) {
+  display: none;
+
+  @include respond($breakpoint) {
+    display: $default;
+  }
+}
+
+// Clearfix
+// $mode accepts 'light' or 'heavy'
+// 'light' is sufficient for clearing floats, while 'heavy' is required to
+// prevent margin collapsing
+// --------------------------
+@mixin clearfix($mode: light) {
+  @if $mode == heavy {
+    &::before,
+    &::after {
+      display: table;
+      content: '';
+    }
+
+    &::after {
+      clear: both;
+    }
+  } @else {
+    &::after {
+      display: block;
+      clear: both;
+      content: '';
+    }
+  }
+}
+
+
+// Layout
+// --------------------------------------------------------
+@mixin containerPrototype {
+  max-width: $containerWidthFull;
+  padding-right: $containerPaddingNarrow;
+  padding-left: $containerPaddingNarrow;
+  margin-right: auto;
+  margin-left: auto;
+
+  @include respond($break35) {
+    padding-right: $containerPaddingResp;
+    padding-left: $containerPaddingResp;
+  }
+
+  @include respond($break120) {
+    padding-right: $containerPaddingFull;
+    padding-left: $containerPaddingFull;
+  }
+}
+
+@mixin containerFocus {
+  // Default max width
+  max-width: $containerWidthFocus;
+  padding-right: $containerPaddingMin;
+  padding-left: $containerPaddingMin;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+@mixin headerContainerPrimary {
+  @include containerPrototype;
+  position: relative;
+  padding-top: header-layout(padding-vertical-mobile);
+
+  @include respond($break40) {
+    padding-top: header-layout(padding-vertical-desktop);
+  }
+}
+
+@mixin drawerPadding($parameter, $scale: 'wide') {
+  #{$parameter}: 20px;
+
+  @include respond($break95) {
+    @if ($scale == 'wide') {
+      #{$parameter}: 5.859vw;
+    } @else {
+      #{$parameter}: 3.906vw;
+    }
+  }
+
+  @include respond($break120) {
+    @if ($scale == 'wide') {
+      #{$parameter}: 60px;
+    } @else {
+      #{$parameter}: 40px;
+    }
+  }
+}
+
+@mixin drawerIndent($parameter, $dimension: 1) {
+  #{$parameter}: (50px * $dimension);
+}
+
+// Lists
+// --------------------------------------------------------
+@mixin listUnstyled {
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  list-style-type: none;
+}
+
+@mixin listHorizontal {
+  @include listUnstyled;
+
+  li {
+    display: inline-block;
+  }
+}
+
+
+// Form Layout
+// --------------------------------------------------------
+// TODO: This combines appearance mixins and should be a shared class or mixin
+@mixin loginFormPrimary {
+  .field + .field {
+    margin-top: 27px;
+  }
+
+  .login-links {
+    margin-top: 25px;
+
+    button {
+      @include buttonUnstyled;
+      @include outlineOnFocusVisible;
+      display: block;
+      font-style: italic;
+      text-decoration: underline;
+
+      + button {
+        margin-top: 14px;
+        margin-left: 0;
+      }
+    }
+
+    a {
+      font-style: italic;
+
+      + a {
+        margin-top: 14px;
+        margin-left: 0;
+      }
+    }
+  }
+
+  .login-external {
+    margin-top: 45px;
+  }
+
+  .button-secondary--dark {
+    display: flex;
+    width: 100%;
+  }
+
+  label {
+    @include inputLabelPrimary;
+  }
+
+  input[type='text'], input[type='password'], input[type='email'] {
+    @include inputPrimary;
+  }
+
+  .button-secondary {
+    display: block;
+    margin-top: 30px;
+  }
+}
+
+// Pagination
+// --------------------------------------------------------
+// Show/hide pagination button text
+@mixin constrainedPaginationResponsive {
+  span {
+    display: inline-block;
+
+    @include respond($break65) {
+      display: none;
+    }
+
+    @include respond($break90) {
+      display: inline-block;
+    }
+  }
+}


### PR DESCRIPTION
Issue #2831 is a result of the dhdebates manifold instance including the duplicate structure utility classes. The plugin required some mixins, however these mixins came with utility classes that unintentionally took precedence over custom styles in the plugin and caused bugs.

Splitting the utility classes from the mixins allows other files to import mixins without worrying that the structure utilities will overwrite previously defined values.

This issue will be resolved when the dhdebates plugin imports the mixin file rather than the whole structure folder contents.