### PR TITLE
[B] Fix missing buttons for annotation and comments

### DIFF
--- a/api/app/serializers/v1/annotation_serializer.rb
+++ b/api/app/serializers/v1/annotation_serializer.rb
@@ -59,6 +59,10 @@ module V1
 
     class << self
 
+      def include_abilities?(_object, _params)
+        true
+      end
+
       def moderator?(object, params)
         params[:current_user]&.can_update? object.reading_group
       end

--- a/api/app/serializers/v1/comment_serializer.rb
+++ b/api/app/serializers/v1/comment_serializer.rb
@@ -23,6 +23,10 @@ module V1
     has_one_creator
 
     class << self
+      def include_abilities?(_object, _params)
+        true
+      end
+
       def deleted_body(object, params)
         return object.body if params[:current_user]&.can_read_deleted?(object)
 


### PR DESCRIPTION
Resolves #2819.

Includes the full serialized attributes for the annotation and comment so the UI knows that the user has permission to update and delete a comment or annotation they created. This fixes a regression introduced in cce22253eb1559f3bec496960bc3bab9af75d0f2 when abilities were simplified for performance reasons.