### PR TITLE
[C] Unify behavior of annotation and comment

### DIFF
--- a/client/src/global/components/comment/meta/__tests__/__snapshots__/Meta-test.js.snap
+++ b/client/src/global/components/comment/meta/__tests__/__snapshots__/Meta-test.js.snap
@@ -15,7 +15,7 @@ exports[`global/components/comment/meta matches the snapshot 1`] = `
     <h4
       className="annotation-meta__author-name"
     >
-      Rowan Ida
+      Me
     </h4>
     <span
       className="annotation-meta__datetime"

--- a/client/src/global/components/comment/meta/index.js
+++ b/client/src/global/components/comment/meta/index.js
@@ -26,8 +26,18 @@ export default class CommentMeta extends PureComponent {
     });
   }
 
+  get name() {
+    const {
+      creator: {
+        attributes: { isCurrentUser, fullName }
+      }
+    } = this.props;
+    if (isCurrentUser) return "Me";
+    return fullName;
+  }
+
   render() {
-    const { comment, creator } = this.props;
+    const { comment } = this.props;
 
     return (
       <section className="annotation-meta">
@@ -35,9 +45,7 @@ export default class CommentMeta extends PureComponent {
           <div className={this.avatarClassNames}>
             <Avatar url={this.avatarUrl} />
           </div>
-          <h4 className="annotation-meta__author-name">
-            {creator.attributes.fullName}
-          </h4>
+          <h4 className="annotation-meta__author-name">{this.name}</h4>
           <span className="annotation-meta__datetime">
             <FormattedDate
               format="distanceInWords"


### PR DESCRIPTION
This addition synchronizes the functionality between the two meta components so the author of both an annotation and a comment will see the listed author as "Me". 

This resolves a discrepancy between them, but I think it would be a good idea to combine the annotation and comment meta component into a single generic meta component at some point. They both appear to have the same functionality and the comment meta uses the annotation meta classes for styling.