### PR TITLE
[B] Fix project counts when ranked by collection

### DIFF
--- a/api/app/models/collection_project_ranking.rb
+++ b/api/app/models/collection_project_ranking.rb
@@ -7,4 +7,5 @@ class CollectionProjectRanking < ApplicationRecord
 
   scope :globally_ranked, -> { reorder(:global_ranking) }
   scope :ranked, -> { reorder(:ranking) }
+  scope :by_collection, ->(collection = nil) { where(project_collection: collection) if collection.present? }
 end

--- a/api/spec/models/project_spec.rb
+++ b/api/spec/models/project_spec.rb
@@ -444,4 +444,20 @@ RSpec.describe Project, type: :model do
   it_should_behave_like "a model that stores its fingerprint" do
     subject { FactoryBot.create :project }
   end
+
+  describe ".with_collection_order" do
+    context "when a project is in more than one collection" do
+      let!(:project_1) { FactoryBot.create :project }
+      let!(:project_2) { FactoryBot.create :project }
+      let!(:collection_1) { FactoryBot.create :project_collection }
+      let!(:collection_2) { FactoryBot.create :project_collection }
+
+      it "returns the correct count" do
+        expect do
+          collection_1.projects = [project_1, project_2]
+          collection_2.projects = [project_1, project_2]
+        end.to change { Project.with_collection_order(collection_1.slug).count }.by(2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This removes an extraneous join Rails was adding
that caused duplicate records to be aggregated
when counting on the scope.

Resolves #2818