### PR TITLE
[B] Fix analytics top search results sorting

### DIFF
--- a/api/app/services/analytics/reports/top_searches.rb
+++ b/api/app/services/analytics/reports/top_searches.rb
@@ -12,6 +12,7 @@ module Analytics
         WHERE #{VISIT_DATE_PLACEHOLDER}
           AND analytics_events.name = '#{Analytics::Event::SEARCH_EVENT_NAME}'
         GROUP BY keyword
+        ORDER BY count DESC
         #{PAGINATION_PLACEHOLDER}
       SQL
 

--- a/api/spec/services/analytics/reports/global_spec.rb
+++ b/api/spec/services/analytics/reports/global_spec.rb
@@ -68,6 +68,26 @@ RSpec.describe Analytics::Reports::Global do
       }
     end
 
+    context "with different values for search counts" do
+      let(:search_events) do
+        [3, 1, 2].each do |count|
+          word = Faker::Lorem.word
+
+          count.times do
+            FactoryBot.create(:analytics_event, visit: visits.first, name: "search", properties: { keyword: word })
+          end
+        end
+      end
+
+      it "should sort search results by count" do
+        outcome = run_the_interaction!
+        search_results = outcome.result.find { |r| r["name"] == "top_search_terms" }["data"]
+        sorted = search_results.sort_by { |d| d["count"] }.reverse
+
+        expect(sorted.map.with_index { |d, i| d["count"] == search_results.dig(i, "count") }).to all(be true)
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
Applies sorting for dedicated view (no change needed for global analytics list)