### PR TITLE
[B] Fix heading level in Overlay

### DIFF
--- a/client/src/global/components/Overlay/Title.js
+++ b/client/src/global/components/Overlay/Title.js
@@ -4,10 +4,10 @@ import IconComposer from "global/components/utility/IconComposer";
 
 function Title({ title, icon }) {
   return (
-    <h3 className="overlay-title">
+    <h2 className="overlay-title">
       <IconComposer icon={icon} size={24} iconClass="overlay-title__icon" />
       <span className="overlay-title__text">{title}</span>
-    </h3>
+    </h2>
   );
 }
 


### PR DESCRIPTION
Change global overlay title from `h3` to `h2`.

Resolves: #2757 