### PR TITLE
[F] Make EntityAvatar atomic component

### DIFF
--- a/client/src/global/components/atomic/EntityAvatar/CoverAvatar.js
+++ b/client/src/global/components/atomic/EntityAvatar/CoverAvatar.js
@@ -9,8 +9,7 @@ const CoverAvatar = ({ entity }) => {
       ? entity.attributes.avatarStyles.smallSquare
       : entity.attributes.avatarStyles.small;
 
-  /* need to fix the alt here */
-  return <Styled.Avatar src={avatarSrc} alt="cover image" />;
+  return <Styled.Avatar src={avatarSrc} alt="" />;
 };
 
 CoverAvatar.propTypes = {

--- a/client/src/global/components/atomic/EntityAvatar/CoverAvatar.js
+++ b/client/src/global/components/atomic/EntityAvatar/CoverAvatar.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import * as Styled from "./styles";
 
-const EntityAvatar = ({ entity }) => {
+const CoverAvatar = ({ entity }) => {
   const meta = entity.attributes.avatarMeta.original;
   const avatarSrc =
     meta.width >= meta.height
@@ -10,12 +10,12 @@ const EntityAvatar = ({ entity }) => {
       : entity.attributes.avatarStyles.small;
 
   /* need to fix the alt here */
-  return <Styled.Avatar src={avatarSrc} alt="" />;
+  return <Styled.Avatar src={avatarSrc} alt="cover image" />;
 };
 
-EntityAvatar.propTypes = {
+CoverAvatar.propTypes = {
   entity: PropTypes.object,
   stack: PropTypes.bool
 };
 
-export default EntityAvatar;
+export default CoverAvatar;

--- a/client/src/global/components/atomic/EntityAvatar/PlaceholderAvatar.js
+++ b/client/src/global/components/atomic/EntityAvatar/PlaceholderAvatar.js
@@ -1,18 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
-import UniqueIcons from "global/components/icon/unique";
 import * as Styled from "./styles";
 
 const PlaceholderAvatar = ({ entity }) => {
   if (!entity.attributes.avatarColor) return null;
   return (
-    <Styled.Placeholder>
-      <UniqueIcons.ProjectPlaceholderUnique
-        mode="responsive"
-        color={entity.attributes.avatarColor}
-        ariaLabel={false}
-      />
-    </Styled.Placeholder>
+    <Styled.Placeholder
+      mode="responsive"
+      color={entity.attributes.avatarColor}
+      ariaLabel={false}
+    />
   );
 };
 

--- a/client/src/global/components/atomic/EntityAvatar/index.js
+++ b/client/src/global/components/atomic/EntityAvatar/index.js
@@ -1,0 +1,18 @@
+import * as React from "react";
+import PropTypes from "prop-types";
+import CoverAvatar from "./CoverAvatar";
+import PlaceholderAvatar from "./PlaceholderAvatar";
+
+export default function EntityAvatar({ entity }) {
+  const placeholder = !entity.attributes.avatarStyles.original;
+
+  return placeholder ? (
+    <PlaceholderAvatar entity={entity} />
+  ) : (
+    <CoverAvatar entity={entity} />
+  );
+}
+
+EntityAvatar.propTypes = {
+  entity: PropTypes.object.isRequired
+};

--- a/client/src/global/components/atomic/EntityAvatar/styles.js
+++ b/client/src/global/components/atomic/EntityAvatar/styles.js
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import UniqueIcons from "global/components/icon/unique";
 
 export const Avatar = styled.img`
   width: var(--Avatar-width);
@@ -8,15 +9,10 @@ export const Avatar = styled.img`
     var(--transition-timing-function);
 `;
 
-export const Placeholder = styled.div`
+export const Placeholder = styled(UniqueIcons.ProjectPlaceholderUnique)`
   width: var(--Avatar-width);
   height: var(--Avatar-height);
-
-  > svg {
-    width: var(--Avatar-width);
-    height: var(--Avatar-height);
-    max-height: 130px;
-    transition: fill var(--transition-duration-default)
-      var(--transition-timing-function);
-  }
+  max-height: 130px;
+  transition: fill var(--transition-duration-default)
+    var(--transition-timing-function);
 `;

--- a/client/src/global/components/atomic/EntityThumbnail/avatar/index.js
+++ b/client/src/global/components/atomic/EntityThumbnail/avatar/index.js
@@ -1,2 +1,0 @@
-export { default as EntityAvatar } from "./EntityAvatar";
-export { default as PlaceholderAvatar } from "./PlaceholderAvatar";

--- a/client/src/global/components/atomic/EntityThumbnail/index.js
+++ b/client/src/global/components/atomic/EntityThumbnail/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Collecting from "frontend/components/collecting";
-import { EntityAvatar, PlaceholderAvatar } from "./avatar";
+import EntityAvatar from "global/components/atomic/EntityAvatar";
 import EntityMetadata from "./EntityMetadata";
 import lh from "helpers/linkHandler";
 import * as Styled from "./styles";
@@ -15,8 +15,6 @@ export default function EntityThumbnail({
   userMock = false,
   stack = true
 }) {
-  const placeholder = !entity.attributes.avatarStyles.original;
-
   return (
     <Styled.Wrapper>
       <Styled.ItemLink
@@ -24,11 +22,7 @@ export default function EntityThumbnail({
         to={lh.link("frontendProjectDetail", entity.attributes.slug)}
       >
         <Styled.Cover $stack={stack}>
-          {placeholder ? (
-            <PlaceholderAvatar entity={entity} />
-          ) : (
-            <EntityAvatar entity={entity} />
-          )}
+          <EntityAvatar entity={entity} />
         </Styled.Cover>
         {!hideMeta && (
           <EntityMetadata


### PR DESCRIPTION
Extract `EntityAvatar` from `EntityThumbnail` for use in heroes and other components. Should be able to completely replace `Project.Avatar`.