### PR TITLE
[B] Fix See All link render conditions

### DIFF
--- a/client/src/frontend/components/project/Detail.js
+++ b/client/src/frontend/components/project/Detail.js
@@ -24,7 +24,7 @@ class Detail extends Component {
     if (window && window.ScrollTo) window.scrollTo(0, 0);
   }
 
-  isLibraryDisabled() {
+  get isLibraryDisabled() {
     return this.props.settings.attributes.general.libraryDisabled;
   }
 


### PR DESCRIPTION
Fixes a mistake in the conditions for showing the 'See All Projects' link at the bottom of project detail pages. Previously we were just checking for the existence of the function rather than running it, so the condition was always true and the link never showed up.

```jsx
{!this.context.isStandalone && !this.isLibraryDisabled && (
  <Layout.ButtonNavigation />
)}
```

I've just switched the function to a getter to solve this.