### PR TITLE
[POC] Create EntityResources container for projects and issues

### DIFF
--- a/client/src/frontend/containers/EntityResources/EntityResourcesContainer.js
+++ b/client/src/frontend/containers/EntityResources/EntityResourcesContainer.js
@@ -1,0 +1,54 @@
+import React from "react";
+import {
+  useFetch,
+  usePaginationState,
+  useFromStore,
+  useFilterState,
+  useSetLocation
+} from "hooks";
+import { projectsAPI } from "api";
+import HeadContent from "global/components/HeadContent";
+import { RegisterBreadcrumbs } from "global/components/atomic/Breadcrumbs";
+import EntityCollection from "frontend/components/composed/EntityCollection";
+import LoadingBlock from "global/components/loading-block";
+
+export default function EntityResourcesContainer({ entity, breadcrumbs }) {
+  const settings = useFromStore("settings", "select");
+  const [pagination, setPageNumber] = usePaginationState();
+  const [filters, setFilters] = useFilterState();
+  const { data: resources, meta } = useFetch({
+    request: [projectsAPI.resources, entity.id, filters, pagination]
+  });
+
+  useSetLocation({ filters, page: pagination.number });
+
+  if (!entity || !resources || !meta) return <LoadingBlock />;
+
+  const { titlePlaintext, description, heroStyles } = entity.attributes ?? {};
+
+  return (
+    <div>
+      <HeadContent
+        title={`View \u201c${titlePlaintext}\u201d Resources on ${settings.attributes.general.installationName}`}
+        description={description}
+        image={heroStyles?.medium}
+      />
+      <RegisterBreadcrumbs breadcrumbs={breadcrumbs} />
+      <EntityCollection.ProjectResources
+        project={entity}
+        resources={resources}
+        resourcesMeta={meta}
+        filterProps={{
+          filterChangeHandler: param => setFilters({ newState: param }),
+          initialFilterState: filters,
+          resetFilterState: {}
+        }}
+        paginationProps={{
+          paginationClickHandler: page => () => setPageNumber(page),
+          paginationTarget: "#"
+        }}
+        itemHeadingLevel={3}
+      />
+    </div>
+  );
+}

--- a/client/src/frontend/containers/EntityResources/EntityResourcesWrapper.js
+++ b/client/src/frontend/containers/EntityResources/EntityResourcesWrapper.js
@@ -1,0 +1,58 @@
+import React from "react";
+import EntityResourcesContainer from "./EntityResourcesContainer";
+import lh from "helpers/linkHandler";
+import LoadingBlock from "global/components/loading-block";
+
+const getBreadcrumbs = entity => {
+  if (entity.type === "projects") {
+    const { slug, titlePlaintext } = entity.attributes;
+    return [
+      {
+        to: lh.link("frontendProjectDetail", slug),
+        label: titlePlaintext
+      }
+    ];
+  }
+  if (entity.type === "journalIssues") {
+    const { number } = entity.attributes;
+    const parentJournal = entity.relationships.journal;
+    const parentVolume = entity.relationships.journalVolume;
+
+    return [
+      {
+        to: lh.link("frontendJournals"),
+        label: "All Journals"
+      },
+      parentJournal && {
+        to: lh.link("frontendJournalDetail", parentJournal.id),
+        label: parentJournal.attributes.titlePlaintext
+      },
+      parentVolume && {
+        to: lh.link("frontendVolumeDetail", parentJournal.id, parentVolume.id),
+        label: `Volume ${parentVolume.attributes.number}`
+      },
+      {
+        to: lh.link("frontendIssueDetail", entity.id),
+        label: `Issue ${number}`
+      },
+      {
+        to: lh.link("frontendIssueResources", entity.id),
+        label: `Resources`
+      }
+    ].filter(Boolean);
+  }
+};
+
+export default function EntityResourcesWrapper({ issue, project }) {
+  const entity = project ?? issue?.relationships?.project;
+  if (!entity) return null;
+
+  return entity ? (
+    <EntityResourcesContainer
+      entity={entity}
+      breadcrumbs={getBreadcrumbs(project ?? issue)}
+    />
+  ) : (
+    <LoadingBlock />
+  );
+}

--- a/client/src/frontend/containers/EntityResources/index.js
+++ b/client/src/frontend/containers/EntityResources/index.js
@@ -1,0 +1,1 @@
+export { default } from "./EntityResourcesWrapper";

--- a/client/src/frontend/containers/route-containers.js
+++ b/client/src/frontend/containers/route-containers.js
@@ -40,6 +40,7 @@ import IssueWrapper from "frontend/containers/IssueWrapper";
 import IssueDetail from "frontend/containers/IssueDetail";
 import JournalVolumesList from "frontend/containers/JournalVolumesList";
 import JournalIssuesList from "frontend/containers/JournalIssuesList";
+import EntityResources from "frontend/containers/EntityResources";
 
 export default {
   NotFound,
@@ -91,5 +92,6 @@ export default {
   Login,
   SignUp,
   MyStarred,
-  MyAnnotations
+  MyAnnotations,
+  EntityResources
 };

--- a/client/src/frontend/routes.js
+++ b/client/src/frontend/routes.js
@@ -78,7 +78,7 @@ const routes = {
             {
               name: "frontendProjectResources",
               exact: true,
-              component: "ProjectResources",
+              component: "EntityResources",
               path: "/projects/:id/resources",
               helper: (p, params = {}) => {
                 const query = queryString.stringify(params);
@@ -185,15 +185,71 @@ const routes = {
           exact: false,
           component: "IssueWrapper",
           path: "/journals/issues/:id",
-          helper: p => `/journals/issues/${p}`,
+          helper: i => `/journals/issues/${i}`,
           routes: [
             {
               name: "frontendIssueDetail",
               exact: true,
               component: "IssueDetail",
               path: "/journals/issues/:id",
-              helper: p => `/journals/issues/${p}`
+              helper: i => `/journals/issues/${i}`
+            },
+            {
+              name: "frontendIssueResources",
+              exact: true,
+              component: "EntityResources",
+              path: "/journals/issues/:id/resources",
+              helper: (i, params = {}) => {
+                const query = queryString.stringify(params);
+                if (!query) return `/journals/issues/${i}/resources`;
+                return `/journals/issues/${i}/resources/?${query}`;
+              }
             }
+            // {
+            //   name: "frontendIssueResourceCollections",
+            //   exact: true,
+            //   component: "IssueResourceCollections",
+            //   path: "/journals/issues/:id/resource-collections",
+            //   helper: i => {
+            //     return `/journals/issues/${i}/resource-collections`;
+            //   }
+            // },
+            // {
+            //   name: "frontendIssueCollectionResource",
+            //   exact: true,
+            //   component: "ResourceDetail",
+            //   path:
+            //     "journals/issues/:id/resource-collection/:resourceCollectionId/resource/:resourceId",
+            //   helper: (i, c, r) =>
+            //     `/projects/${i}/resource-collection/${c}/resource/${r}`
+            // },
+            // {
+            //   name: "frontendIssueResource",
+            //   exact: true,
+            //   component: "ResourceDetail",
+            //   path: "/journals/issues/:id/resource/:resourceId",
+            //   helpers: {
+            //     frontendIssueResource: (i, r) =>
+            //       `/journals/issues/${i}/resource/${r}`,
+            //     frontendIssueResourceRelative: r => `resource/${r}`
+            //   }
+            // },
+            // {
+            //   name: "frontendIssueResourceCollection",
+            //   exact: true,
+            //   component: "ResourceCollectionDetail",
+            //   path:
+            //     "/journals/issues/:id/resource-collection/:resourceCollectionId",
+            //   helpers: {
+            //     frontendIssueResourceCollection: (i, c, params = {}) => {
+            //       const query = queryString.stringify(params);
+            //       if (!query) return `/projects/${i}/resource-collection/${c}`;
+            //       return `/projects/${i}/resource-collection/${c}?${query}`;
+            //     },
+            //     frontendIssueResourceCollectionRelative: c =>
+            //       `resource-collection/${c}`
+            //   }
+            // }
           ]
         },
         {


### PR DESCRIPTION
Refactors the `ProjectResources` container into a generic `EntityResourcesContainer` using the new hooks, and adds a simple wrapper component to wait until issues are fetched, so we can grab the project id. Additional project-issue differences, e.g. breadcrumbs, can also be handled in this wrapper. The new container is implemented on both the relevant project and issue routes.