### PR TITLE
[B] Fix Trans implementation in SourceSummary

### DIFF
--- a/client/src/backend/components/ingestion/form/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/backend/components/ingestion/form/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -1207,7 +1207,7 @@ exports[`backend/components/ingestion/form/Wrapper matches the snapshot after mo
                               "annotation_summary": Object {
                                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                                "source": "\\"{{section}}\\" in <0></0>",
+                                "source": "\\"{{section}}\\" in <text></text>",
                               },
                               "cannot_move_down": "Cannot move down. Item is already in the last category.",
                               "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -2116,7 +2116,7 @@ exports[`backend/components/ingestion/form/Wrapper matches the snapshot after mo
                             "annotation_summary": Object {
                               "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                               "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                              "source": "\\"{{section}}\\" in <0></0>",
+                              "source": "\\"{{section}}\\" in <text></text>",
                             },
                             "cannot_move_down": "Cannot move down. Item is already in the last category.",
                             "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -3112,7 +3112,7 @@ exports[`backend/components/ingestion/form/Wrapper matches the snapshot after mo
                                 "annotation_summary": Object {
                                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                                  "source": "\\"{{section}}\\" in <0></0>",
+                                  "source": "\\"{{section}}\\" in <text></text>",
                                 },
                                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -4021,7 +4021,7 @@ exports[`backend/components/ingestion/form/Wrapper matches the snapshot after mo
                               "annotation_summary": Object {
                                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                                "source": "\\"{{section}}\\" in <0></0>",
+                                "source": "\\"{{section}}\\" in <text></text>",
                               },
                               "cannot_move_down": "Cannot move down. Item is already in the last category.",
                               "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -5034,7 +5034,7 @@ exports[`backend/components/ingestion/form/Wrapper matches the snapshot after mo
                                   "annotation_summary": Object {
                                     "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                                     "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                                    "source": "\\"{{section}}\\" in <0></0>",
+                                    "source": "\\"{{section}}\\" in <text></text>",
                                   },
                                   "cannot_move_down": "Cannot move down. Item is already in the last category.",
                                   "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -5943,7 +5943,7 @@ exports[`backend/components/ingestion/form/Wrapper matches the snapshot after mo
                                 "annotation_summary": Object {
                                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                                  "source": "\\"{{section}}\\" in <0></0>",
+                                  "source": "\\"{{section}}\\" in <text></text>",
                                 },
                                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -6969,7 +6969,7 @@ exports[`backend/components/ingestion/form/Wrapper matches the snapshot after mo
                                     "annotation_summary": Object {
                                       "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                                       "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                                      "source": "\\"{{section}}\\" in <0></0>",
+                                      "source": "\\"{{section}}\\" in <text></text>",
                                     },
                                     "cannot_move_down": "Cannot move down. Item is already in the last category.",
                                     "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -7878,7 +7878,7 @@ exports[`backend/components/ingestion/form/Wrapper matches the snapshot after mo
                                   "annotation_summary": Object {
                                     "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                                     "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                                    "source": "\\"{{section}}\\" in <0></0>",
+                                    "source": "\\"{{section}}\\" in <text></text>",
                                   },
                                   "cannot_move_down": "Cannot move down. Item is already in the last category.",
                                   "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/config/app/locale/en/json/messages.json
+++ b/client/src/config/app/locale/en/json/messages.json
@@ -15,7 +15,7 @@
     "annotation_summary": {
       "highlight": "{{creator}} highlighted \"{{section}}\" in <text></text> on <date></date>.",
       "annotation": "{{creator}} annotated \"{{section}}\" in <text></text> on <date></date>.",
-      "source": "\"{{section}}\" in <0></0>"
+      "source": "\"{{section}}\" in <text></text>"
     }
   }
 }

--- a/client/src/frontend/components/resource-collection/__tests__/__snapshots__/Cover-test.js.snap
+++ b/client/src/frontend/components/resource-collection/__tests__/__snapshots__/Cover-test.js.snap
@@ -558,7 +558,7 @@ exports[`frontend/components/resource-collection/Cover matches the snapshot 1`] 
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1467,7 +1467,7 @@ exports[`frontend/components/resource-collection/Cover matches the snapshot 1`] 
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/frontend/components/resource-list/__tests__/__snapshots__/Slideshow-test.js.snap
+++ b/client/src/frontend/components/resource-list/__tests__/__snapshots__/Slideshow-test.js.snap
@@ -594,7 +594,7 @@ exports[`frontend/components/resource-list/Slideshow matches the snapshot 1`] = 
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1503,7 +1503,7 @@ exports[`frontend/components/resource-list/Slideshow matches the snapshot 1`] = 
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/frontend/components/resource-slide/__tests__/__snapshots__/Caption-test.js.snap
+++ b/client/src/frontend/components/resource-slide/__tests__/__snapshots__/Caption-test.js.snap
@@ -561,7 +561,7 @@ exports[`frontend/components/resource-slide/Caption matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1470,7 +1470,7 @@ exports[`frontend/components/resource-slide/Caption matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/frontend/components/resource/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/frontend/components/resource/__tests__/__snapshots__/Detail-test.js.snap
@@ -558,7 +558,7 @@ exports[`frontend/components/resource/Detail matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1467,7 +1467,7 @@ exports[`frontend/components/resource/Detail matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/frontend/components/resource/__tests__/__snapshots__/Link-test.js.snap
+++ b/client/src/frontend/components/resource/__tests__/__snapshots__/Link-test.js.snap
@@ -679,7 +679,7 @@ exports[`frontend/components/resource/Link matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1588,7 +1588,7 @@ exports[`frontend/components/resource/Link matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/frontend/components/resource/__tests__/__snapshots__/Title-test.js.snap
+++ b/client/src/frontend/components/resource/__tests__/__snapshots__/Title-test.js.snap
@@ -558,7 +558,7 @@ exports[`frontend/components/resource/Title matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1467,7 +1467,7 @@ exports[`frontend/components/resource/Title matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/frontend/components/resourceish/__tests__/__snapshots__/Thumbnail-test.js.snap
+++ b/client/src/frontend/components/resourceish/__tests__/__snapshots__/Thumbnail-test.js.snap
@@ -558,7 +558,7 @@ exports[`frontend/components/resourceish/Thumbnail matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1467,7 +1467,7 @@ exports[`frontend/components/resourceish/Thumbnail matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/frontend/components/text/__tests__/__snapshots__/Bibliographic-test.js.snap
+++ b/client/src/frontend/components/text/__tests__/__snapshots__/Bibliographic-test.js.snap
@@ -559,7 +559,7 @@ exports[`frontend/components/text/Bibliographic matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1468,7 +1468,7 @@ exports[`frontend/components/text/Bibliographic matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/frontend/components/text/__tests__/__snapshots__/Counts-test.js.snap
+++ b/client/src/frontend/components/text/__tests__/__snapshots__/Counts-test.js.snap
@@ -558,7 +558,7 @@ exports[`frontend/components/text/Counts matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1467,7 +1467,7 @@ exports[`frontend/components/text/Counts matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/frontend/components/utility/__tests__/__snapshots__/Toggle-test.js.snap
+++ b/client/src/frontend/components/utility/__tests__/__snapshots__/Toggle-test.js.snap
@@ -559,7 +559,7 @@ exports[`frontend/components/utility/Toggle matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1468,7 +1468,7 @@ exports[`frontend/components/utility/Toggle matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/global/components/Annotation/Annotation/SourceSummary/TextTitle.js
+++ b/client/src/global/components/Annotation/Annotation/SourceSummary/TextTitle.js
@@ -1,0 +1,22 @@
+/* This component exists because the i18next Trans component adds a children prop to all components passed through it. This isn't compatible with an element that uses dangerouslySetInnerHTML, so we need a wrapper. --LD */
+
+import React from "react";
+import PropTypes from "prop-types";
+
+export default function TextTitle({ title }) {
+  const maybeHtml = item => {
+    const isHtml = !!item.__html;
+    return isHtml ? { dangerouslySetInnerHTML: { ...item } } : {};
+  };
+
+  const maybeReactNode = item => {
+    const isReactNode = React.isValidElement(item) || typeof item === "string";
+    return isReactNode ? item : null;
+  };
+
+  return <i {...maybeHtml(title)}>{maybeReactNode(title)}</i>;
+}
+
+TextTitle.propTypes = {
+  title: PropTypes.string
+};

--- a/client/src/global/components/Annotation/Annotation/SourceSummary/index.js
+++ b/client/src/global/components/Annotation/Annotation/SourceSummary/index.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { withTranslation, Trans } from "react-i18next";
 import Utility from "global/components/utility";
 import FormattedDate from "global/components/FormattedDate";
+import TextTitle from "./TextTitle";
 import { capitalize } from "utils/string";
 
 class SourceSummary extends React.PureComponent {
@@ -31,7 +32,7 @@ class SourceSummary extends React.PureComponent {
       <Trans
         i18nKey="messages.annotation_summary.source"
         components={{
-          text: <i dangerouslySetInnerHTML={{ __html: textTitle }} />
+          text: <TextTitle title={textTitle} />
         }}
         values={{ section: textSectionTitle }}
       />
@@ -93,7 +94,7 @@ class SourceSummary extends React.PureComponent {
               <Trans
                 i18nKey={this.action}
                 components={{
-                  text: <i dangerouslySetInnerHTML={{ __html: textTitle }} />,
+                  text: <TextTitle title={textTitle} />,
                   date: <FormattedDate date={annotation.attributes.createdAt} />
                 }}
                 values={{ creator: this.creator, section: textSectionTitle }}

--- a/client/src/global/components/Annotation/Annotation/TextContent/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/global/components/Annotation/Annotation/TextContent/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -600,7 +600,7 @@ exports[`global/components/Annotation/Annotation/TextContent/Wrapper matches the
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1509,7 +1509,7 @@ exports[`global/components/Annotation/Annotation/TextContent/Wrapper matches the
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/global/components/FatalError/__tests__/__snapshots__/FatalError-test.js.snap
+++ b/client/src/global/components/FatalError/__tests__/__snapshots__/FatalError-test.js.snap
@@ -568,7 +568,7 @@ exports[`global/components/FatalError matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1477,7 +1477,7 @@ exports[`global/components/FatalError matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/global/components/comment/deleted/__tests__/__snapshots__/Deleted-test.js.snap
+++ b/client/src/global/components/comment/deleted/__tests__/__snapshots__/Deleted-test.js.snap
@@ -689,7 +689,7 @@ exports[`global/components/comment/deleted matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1598,7 +1598,7 @@ exports[`global/components/comment/deleted matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/global/components/comment/detail/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/global/components/comment/detail/__tests__/__snapshots__/Detail-test.js.snap
@@ -693,7 +693,7 @@ exports[`global/components/comment/detail/Detail matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1602,7 +1602,7 @@ exports[`global/components/comment/detail/Detail matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/global/components/comment/meta/__tests__/__snapshots__/Meta-test.js.snap
+++ b/client/src/global/components/comment/meta/__tests__/__snapshots__/Meta-test.js.snap
@@ -785,7 +785,7 @@ exports[`global/components/comment/meta matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1694,7 +1694,7 @@ exports[`global/components/comment/meta matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/global/components/dialog/__tests__/__snapshots__/Confirm-test.js.snap
+++ b/client/src/global/components/dialog/__tests__/__snapshots__/Confirm-test.js.snap
@@ -559,7 +559,7 @@ exports[`backend/components/dialog/Confirm matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1468,7 +1468,7 @@ exports[`backend/components/dialog/Confirm matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/global/components/drawer/__tests__/__snapshots__/Wrapper-test.js.snap
+++ b/client/src/global/components/drawer/__tests__/__snapshots__/Wrapper-test.js.snap
@@ -563,7 +563,7 @@ exports[`global/components/drawer/Wrapper matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1472,7 +1472,7 @@ exports[`global/components/drawer/Wrapper matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/reader/components/Header/__tests__/__snapshots__/Header-test.js.snap
+++ b/client/src/reader/components/Header/__tests__/__snapshots__/Header-test.js.snap
@@ -608,7 +608,7 @@ exports[`Reader.Header Component matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1517,7 +1517,7 @@ exports[`Reader.Header Component matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/reader/components/control-menu/__tests__/__snapshots__/AppearanceMenuBody-test.js.snap
+++ b/client/src/reader/components/control-menu/__tests__/__snapshots__/AppearanceMenuBody-test.js.snap
@@ -567,7 +567,7 @@ exports[`reader/components/control-menu/AppearanceMenuBody matches the snapshot 
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1476,7 +1476,7 @@ exports[`reader/components/control-menu/AppearanceMenuBody matches the snapshot 
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/reader/components/notation/resource/__tests__/__snapshots__/Detail-test.js.snap
+++ b/client/src/reader/components/notation/resource/__tests__/__snapshots__/Detail-test.js.snap
@@ -559,7 +559,7 @@ exports[`reader/components/notation/resource/Detail matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1468,7 +1468,7 @@ exports[`reader/components/notation/resource/Detail matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/reader/components/notes/partial/__tests__/__snapshots__/Filters-test.js.snap
+++ b/client/src/reader/components/notes/partial/__tests__/__snapshots__/Filters-test.js.snap
@@ -568,7 +568,7 @@ exports[`reader/components/notes/partial/Filters matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1477,7 +1477,7 @@ exports[`reader/components/notes/partial/Filters matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/reader/components/section/__tests__/__snapshots__/NextSection-test.js.snap
+++ b/client/src/reader/components/section/__tests__/__snapshots__/NextSection-test.js.snap
@@ -558,7 +558,7 @@ exports[`reader/components/section/NextSection matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1467,7 +1467,7 @@ exports[`reader/components/section/NextSection matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",

--- a/client/src/reader/components/section/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/client/src/reader/components/section/__tests__/__snapshots__/Pagination-test.js.snap
@@ -558,7 +558,7 @@ exports[`reader/components/section/Pagination matches the snapshot 1`] = `
                 "annotation_summary": Object {
                   "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                   "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                  "source": "\\"{{section}}\\" in <0></0>",
+                  "source": "\\"{{section}}\\" in <text></text>",
                 },
                 "cannot_move_down": "Cannot move down. Item is already in the last category.",
                 "cannot_move_up": "Cannot move up. Item is already in the first category.",
@@ -1467,7 +1467,7 @@ exports[`reader/components/section/Pagination matches the snapshot 1`] = `
               "annotation_summary": Object {
                 "annotation": "{{creator}} annotated \\"{{section}}\\" in <text></text> on <date></date>.",
                 "highlight": "{{creator}} highlighted \\"{{section}}\\" in <text></text> on <date></date>.",
-                "source": "\\"{{section}}\\" in <0></0>",
+                "source": "\\"{{section}}\\" in <text></text>",
               },
               "cannot_move_down": "Cannot move down. Item is already in the last category.",
               "cannot_move_up": "Cannot move up. Item is already in the first category.",


### PR DESCRIPTION
Adds a wrapper component `TextTitle` because elements that use `dangerouslySetInnerHTML` can't be passed as components directly to `Trans`.