### PR TITLE
[B] Fix placeholder logic on frontend routes

### DIFF
--- a/client/src/frontend/containers/IssuesList/index.js
+++ b/client/src/frontend/containers/IssuesList/index.js
@@ -1,6 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
-import { useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   useFetch,
@@ -29,7 +27,6 @@ export default function IssuesListContainer() {
   });
 
   useSetLocation({ filters, page: pagination.number });
-  const location = useLocation();
 
   const filterProps = useListFilters({
     onFilterChange: param => setFilters({ newState: param }),
@@ -39,9 +36,9 @@ export default function IssuesListContainer() {
 
   const { t } = useTranslation();
 
-  if (!issues || !meta) return null;
+  const showPlaceholder = "keyword" in filters ? false : !issues?.length;
 
-  const showPlaceholder = location.search ? false : !issues.length;
+  if (!issues || !meta) return null;
 
   return (
     <>

--- a/client/src/frontend/containers/MyReadingGroups/List.js
+++ b/client/src/frontend/containers/MyReadingGroups/List.js
@@ -26,13 +26,16 @@ function MyReadingGroupsListContainer({ route }) {
     sort_order: DEFAULT_SORT_ORDER
   };
   const [filters, setFilters] = useFilterState(baseFilters);
-  useSetLocation({ filters, page: pagination.number });
 
   const [rgJoins, setRGJoins] = useState(0);
   const { data: readingGroups, meta } = useFetch({
     request: [meAPI.readingGroups, filters, pagination],
     dependencies: [rgJoins]
   });
+
+  useSetLocation({ filters, page: pagination.number });
+
+  const showPlaceholder = "keyword" in filters ? false : !readingGroups?.length;
 
   const currentUser = useCurrentUser();
   const history = useHistory();
@@ -63,7 +66,7 @@ function MyReadingGroupsListContainer({ route }) {
       <section>
         <div className="container groups-page-container">
           <GroupsHeading currentUser={currentUser} />
-          {!!readingGroups?.length && (
+          {!showPlaceholder && (
             <GroupsTable
               readingGroups={readingGroups}
               pagination={meta?.pagination}
@@ -75,11 +78,7 @@ function MyReadingGroupsListContainer({ route }) {
               }}
             />
           )}
-          {!readingGroups?.length && (
-            <EntityCollectionPlaceholder.ReadingGroups
-              currentUser={currentUser}
-            />
-          )}
+          {showPlaceholder && <EntityCollectionPlaceholder.ReadingGroups />}
           <JoinBox onJoin={() => setRGJoins(prev => prev + 1)} />
         </div>
       </section>

--- a/client/src/frontend/containers/ProjectCollections/index.js
+++ b/client/src/frontend/containers/ProjectCollections/index.js
@@ -94,18 +94,18 @@ export class ProjectsCollectionsContainer extends Component {
     return this.props.location;
   }
 
+  get pagination() {
+    return this.projectCollectionsMeta?.pagination;
+  }
+
   get showPlaceholder() {
-    if (this.location.search) return false; // There are search filters applied, skip the check
-    if (!this.projectCollections?.length) return true;
+    if (this.pagination?.currentPage > 1) return false;
+    return !this.projectCollections?.length;
   }
 
   get showPagination() {
-    if (
-      isEmpty(this.projectCollectionsMeta) ||
-      !this.projectCollectionsMeta.pagination
-    )
-      return false;
-    if (this.projectCollectionsMeta.pagination.totalPages === 1) return false;
+    if (isEmpty(this.pagination)) return false;
+    if (this.pagination.totalPages === 1) return false;
     return true;
   }
 

--- a/client/src/frontend/containers/Projects/index.js
+++ b/client/src/frontend/containers/Projects/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import CollectionNavigation from "frontend/components/composed/CollectionNavigation";
 import { projectsAPI } from "api";
@@ -27,11 +26,8 @@ export default function ProjectsContainer() {
   });
 
   useSetLocation({ filters, page: pagination.number });
-  const location = useLocation();
 
-  const showPlaceholder = location.search
-    ? false
-    : !projects || !projects.length;
+  const showPlaceholder = "keyword" in filters ? false : !projects?.length;
 
   const { t } = useTranslation();
 

--- a/client/src/frontend/containers/PublicReadingGroups/List.js
+++ b/client/src/frontend/containers/PublicReadingGroups/List.js
@@ -24,13 +24,16 @@ function PublicReadingGroupsListContainer({ route }) {
     sort_order: DEFAULT_SORT_ORDER
   };
   const [filters, setFilters] = useFilterState(baseFilters);
-  useSetLocation({ filters, page: pagination.number });
 
   const [rgJoins, setRGJoins] = useState(0);
   const { data: readingGroups, meta } = useFetch({
     request: [readingGroupsAPI.publicIndex, filters, pagination],
     dependencies: [rgJoins]
   });
+
+  useSetLocation({ filters, page: pagination.number });
+
+  const showPlaceholder = "keyword" in filters ? false : !readingGroups?.length;
 
   const currentUser = useCurrentUser();
   const { t } = useTranslation();
@@ -57,7 +60,7 @@ function PublicReadingGroupsListContainer({ route }) {
       <section>
         <div className="container groups-page-container">
           <GroupsHeading currentUser={currentUser} />
-          {!!readingGroups?.length && (
+          {!showPlaceholder && (
             <GroupsTable
               readingGroups={readingGroups}
               currentUser={currentUser}
@@ -72,11 +75,8 @@ function PublicReadingGroupsListContainer({ route }) {
               hideTags
             />
           )}
-          {!readingGroups?.length && (
-            <EntityCollectionPlaceholder.ReadingGroups
-              currentUser={currentUser}
-              isPublic
-            />
+          {showPlaceholder && (
+            <EntityCollectionPlaceholder.ReadingGroups isPublic />
           )}
           {currentUser && (
             <JoinBox onJoin={() => setRGJoins(prev => prev + 1)} />


### PR DESCRIPTION
* Consider filters when showing RG list placeholder
* Use presence of certain filter keys when showing placeholders for
other FE indexes, rather than `location.search`. Since we always show
URL params for pagination, `!!location.search` was always `true`,
meaning that the placeholder wouldn't appear under any circumstances.
