### PR TITLE
[B] Correct behavior when RGs are disabled

### DIFF
--- a/client/src/helpers/router/navigation.js
+++ b/client/src/helpers/router/navigation.js
@@ -38,11 +38,11 @@ class Navigation {
           }
         ]
       },
-      {
+      !settings.attributes.general.disableReadingGroups && {
         label: "Reading Groups",
         route: "frontendPublicReadingGroups"
       }
-    ];
+    ].filter(x => x);
   });
 
   static backend = memoize(() => {

--- a/client/src/store/middleware/currentUserMiddleware.js
+++ b/client/src/store/middleware/currentUserMiddleware.js
@@ -1,9 +1,6 @@
 import actions from "actions/currentUser";
-import { ApiClient, tokensAPI, meAPI, requests } from "api";
+import { ApiClient, tokensAPI, meAPI } from "api";
 import BrowserCookieHelper from "helpers/cookie/Browser";
-import { entityStoreActions } from "actions";
-
-const { request } = entityStoreActions;
 
 function generateErrorPayload(status = 401) {
   const heading = "Login Failed";
@@ -52,12 +49,9 @@ function handleAuthenticationSuccess(
 ) {
   dispatch(actions.setCurrentUser(options.user));
   dispatch(actions.setAuthToken(options.authToken));
-  const { promise } = dispatch(
-    request(meAPI.readingGroups(), requests.feMyReadingGroups)
-  );
   dispatch(actions.loginComplete());
   if (options.setCookie) setCookie(options.authToken, options.cookieHelper);
-  return promise;
+  return Promise.resolve();
 }
 
 function handleAuthenticationFailure(


### PR DESCRIPTION
The change in 9ccfcb8d811062f43bdcff480161e28c7b70e43c wasn’t a good
solution to the problem described in the commit because it’s difficult
to check settings in the current user middleware. This commit moves the
RG loading into the main Manifold app container and triggers it when a
user logs in, or when the app is mounted.