### PR TITLE
[F] Finalize Safari/FF keyboard annotation support

### DIFF
--- a/client/src/config/app/locale/en/json/reader.json
+++ b/client/src/config/app/locale/en/json/reader.json
@@ -2,6 +2,7 @@
   "reader": {
     "actions": {
       "copy": "Copy",
+      "cite": "Cite",
       "select_reading_group": "Select $t(glossary.reading_group_one)",
       "annotate_passage": "$t(actions.annotate) this passage",
       "visit_resource_page": "$t(actions.visit) $t(glossary.resource_title_case_one) $t(common.page_title_case_one)",
@@ -48,6 +49,7 @@
         "log_in_annotate": "Log in to $t(actions.annotate)",
         "highlight": "Highlight",
         "highlight_selection": "$t(reader.menus.popup.highlight) $t(glossary.selection_one)",
+        "unhighlight_selection": "Remove highlight",
         "you_highlighted": "You Highlighted",
         "reader_highlighted": "A Reader Highlighted",
         "attach_resource": "Attach resource to $t(glossary.selection_one)",

--- a/client/src/reader/components/annotation/popup/menus/FollowLink.js
+++ b/client/src/reader/components/annotation/popup/menus/FollowLink.js
@@ -4,7 +4,14 @@ import PropTypes from "prop-types";
 import Menu from "../parts/Menu";
 import MenuItem from "../parts/MenuItem";
 
-function FollowLink({ menu, visible, direction, activeEvent, actions }) {
+function FollowLink({
+  menu,
+  visible,
+  direction,
+  activeEvent,
+  actions,
+  isKeyboardSelection
+}) {
   const { link, annotationIds } = activeEvent;
   const { openViewAnnotationsDrawer } = actions;
 
@@ -20,6 +27,7 @@ function FollowLink({ menu, visible, direction, activeEvent, actions }) {
       visible={visible}
       aria-label={t("reader.menus.popup.follow_link")}
       direction={direction}
+      isKeyboardSelection={isKeyboardSelection}
     >
       <MenuItem
         menu={{ ...menu, visible }}

--- a/client/src/reader/components/annotation/popup/menus/Login.js
+++ b/client/src/reader/components/annotation/popup/menus/Login.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import Menu from "../parts/Menu";
 import MenuItem from "../parts/MenuItem";
 
-function Login({ menu, visible, direction, actions }) {
+function Login({ menu, visible, direction, actions, isKeyboardSelection }) {
   const { t } = useTranslation();
 
   return (
@@ -13,6 +13,7 @@ function Login({ menu, visible, direction, actions }) {
       visible={visible}
       aria-label={t("reader.menus.popup.log_in_annotate")}
       direction={direction}
+      isKeyboardSelection={isKeyboardSelection}
     >
       <MenuItem
         menu={menu}
@@ -31,7 +32,8 @@ Login.propTypes = {
   menu: PropTypes.object.isRequired,
   actions: PropTypes.object.isRequired,
   direction: PropTypes.oneOf(["up", "down"]),
-  visible: PropTypes.bool
+  visible: PropTypes.bool,
+  isKeyboardSelection: PropTypes.bool
 };
 
 export default Login;

--- a/client/src/reader/components/annotation/popup/menus/Main/Items/CurrentReadingGroup.js
+++ b/client/src/reader/components/annotation/popup/menus/Main/Items/CurrentReadingGroup.js
@@ -44,13 +44,13 @@ function CurrentReadingGroup({
         <span className="screen-reader-text">
           {t("reader.actions.select_reading_group")}
         </span>
-        <span className="annotation-popup__button-text">
+        <span className="annotation-popup__button-text" aria-hidden>
           {canAccessReadingGroups
             ? t("reader.menus.popup.current_group")
             : t("reader.menus.popup.current_visibility")}
           :
         </span>
-        <div className="annotation-popup__button-inner-row">
+        <div className="annotation-popup__button-inner-row" aria-hidden>
           <span className="annotation-popup__button-text annotation-popup__button-text--small">
             {getCurrentGroupName()}
           </span>

--- a/client/src/reader/components/annotation/popup/menus/Main/Items/Highlight.js
+++ b/client/src/reader/components/annotation/popup/menus/Main/Items/Highlight.js
@@ -30,7 +30,11 @@ function Highlight({ menu, actions, activeAnnotation }) {
         })}
         kind="any"
         label={t("reader.menus.popup.highlight")}
-        srLabel={t("reader.menus.popup.highlight_selection")}
+        srLabel={
+          highlighted
+            ? t("reader.menus.popup.unhighlight_selection")
+            : t("reader.menus.popup.highlight_selection")
+        }
         icon="annotate24"
       />
       {highlighted && (

--- a/client/src/reader/components/annotation/popup/menus/Main/index.js
+++ b/client/src/reader/components/annotation/popup/menus/Main/index.js
@@ -12,6 +12,7 @@ function MainMenu({
   direction,
   onKeyDown,
   openSubmenu,
+  isKeyboardSelection,
   ...restProps
 }) {
   const itemProps = {
@@ -31,6 +32,7 @@ function MainMenu({
       lastActiveMenu={lastActiveMenu}
       direction={direction}
       onKeyDown={onKeyDown}
+      isKeyboardSelection={isKeyboardSelection}
     >
       <MenuItems.Share {...itemProps} onClick={() => openSubmenu("share")} />
       <MenuItems.Notate {...itemProps} />
@@ -55,7 +57,8 @@ MainMenu.propTypes = {
   lastActiveMenu: PropTypes.shape({
     current: PropTypes.string
   }),
-  direction: PropTypes.oneOf(["up", "down"])
+  direction: PropTypes.oneOf(["up", "down"]),
+  isKeyboardSelection: PropTypes.bool
 };
 
 export default MainMenu;

--- a/client/src/reader/components/annotation/popup/menus/ReadingGroup.js
+++ b/client/src/reader/components/annotation/popup/menus/ReadingGroup.js
@@ -20,7 +20,8 @@ function ReadingGroupMenu({
   readingGroups,
   currentReadingGroup,
   onSelect,
-  currentUser
+  currentUser,
+  isKeyboardSelection
 }) {
   const context = useReaderContext();
   const canEngagePublicly = context.attributes.abilities.engagePublicly;
@@ -39,6 +40,7 @@ function ReadingGroupMenu({
       aria-label={t("glossary.reading_group_one")}
       direction={direction}
       onKeyDown={onKeyDown}
+      isKeyboardSelection={isKeyboardSelection}
     >
       <div className="annotation-popup__header">
         <IconComposer icon="readingGroup24" size="default" />
@@ -115,7 +117,8 @@ ReadingGroupMenu.propTypes = {
   readingGroups: PropTypes.array,
   currentReadingGroup: PropTypes.string.isRequired,
   onSelect: PropTypes.func.isRequired,
-  currentUser: PropTypes.object
+  currentUser: PropTypes.object,
+  isKeyboardSelection: PropTypes.bool
 };
 
 export default withCurrentUser(ReadingGroupMenu);

--- a/client/src/reader/components/annotation/popup/menus/Share.js
+++ b/client/src/reader/components/annotation/popup/menus/Share.js
@@ -15,7 +15,8 @@ function ShareMenu({
   selectionState,
   actions,
   onBackClick,
-  onKeyDown
+  onKeyDown,
+  isKeyboardSelection
 }) {
   const {
     facebookAppId,
@@ -42,6 +43,7 @@ function ShareMenu({
       aria-label={t("actions.share")}
       direction={direction}
       onKeyDown={onKeyDown}
+      isKeyboardSelection={isKeyboardSelection}
     >
       {canCite && (
         <MenuItem
@@ -100,7 +102,8 @@ ShareMenu.propTypes = {
   direction: PropTypes.oneOf(["up", "down"]),
   visible: PropTypes.bool,
   text: PropTypes.object,
-  selectionState: PropTypes.object
+  selectionState: PropTypes.object,
+  isKeyboardSelection: PropTypes.bool
 };
 
 export default ShareMenu;

--- a/client/src/reader/components/annotation/popup/parts/Menu/index.js
+++ b/client/src/reader/components/annotation/popup/parts/Menu/index.js
@@ -9,13 +9,14 @@ function Menu({
   lastActiveMenu,
   onKeyDown,
   direction,
+  isKeyboardSelection = false,
   children,
   ...menuProps
 }) {
   // Focus on first interactive el when menu becomes visible.
   // Or on last interactive el if moving from RG menu to main menu.
   useEffect(() => {
-    if (!menuProps.visible) return;
+    if (!menuProps.visible || !isKeyboardSelection) return;
     const fromRGtoMain =
       activeMenu === "main" && lastActiveMenu?.current === "readingGroup";
     fromRGtoMain ? menu.last() : menu.first();
@@ -36,7 +37,7 @@ function Menu({
     <ReakitMenu
       {...menu}
       {...menuProps}
-      unstable_finalFocusRef={undefined} // we handle this on our own since there's no disclosure component
+      unstable_autoFocusOnHide={false} // we handle this on our own since there's no disclosure component
       className={menuClassName}
       onKeyDown={onKeyDown}
     >

--- a/client/src/reader/components/section/body-nodes/nodes/Link.js
+++ b/client/src/reader/components/section/body-nodes/nodes/Link.js
@@ -39,19 +39,31 @@ class LinkNode extends Component {
     return adjustedAttributes;
   }
 
+  renderChildren() {
+    return React.Children.map(this.props.children, child => {
+      if (React.isValidElement(child)) {
+        return React.cloneElement(child, {
+          hasInteractiveAncestor: true
+        });
+      }
+    });
+  }
+
   render() {
     if (!this.hasUri() || this.isAbsoluteUri()) {
-      return React.createElement(
-        this.props.tag,
-        { ...this.props.attributes, target: "_blank" },
-        this.props.children
+      const Tag = this.props.tag;
+      return (
+        <Tag
+          {...this.props.attributes}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {this.renderChildren()}
+        </Tag>
       );
     }
-    return React.createElement(
-      Link,
-      this.adjustedAttributes(),
-      this.props.children
-    );
+
+    return <Link {...this.adjustedAttributes()}>{this.renderChildren()}</Link>;
   }
 }
 

--- a/client/src/reader/components/section/body-nodes/nodes/Text.js
+++ b/client/src/reader/components/section/body-nodes/nodes/Text.js
@@ -17,7 +17,8 @@ class TextNode extends Component {
     scrollToView: PropTypes.bool,
     scrollKey: PropTypes.string,
     scrollAnnotation: PropTypes.string,
-    t: PropTypes.func
+    t: PropTypes.func,
+    hasInteractiveAncestor: PropTypes.bool
   };
 
   componentDidMount() {
@@ -196,8 +197,9 @@ class TextNode extends Component {
       const removableHighlightId = removableHighlight
         ? removableHighlight.id
         : "";
+      const isInteractive = !!textAnnotationIds.length || removableHighlight;
       const interactiveAttributes =
-        !!textAnnotationIds.length || removableHighlight
+        isInteractive && !this.props.hasInteractiveAncestor
           ? {
               tabIndex: 0,
               role: "button",

--- a/client/src/reader/containers/annotation/annotatable-components/CaptureClick.js
+++ b/client/src/reader/containers/annotation/annotatable-components/CaptureClick.js
@@ -42,21 +42,21 @@ export default class AnnotatableCaptureClick extends Component {
     }
   };
 
-  handleKeyDown = event => {
+  handleKeyUp = event => {
     if (!event || !event.target || (event.key !== "Enter" && event.key !== " "))
       return;
-    this.handleClick(event);
+    this.handleClick(event, true);
   };
 
-  handleClick = event => {
+  handleClick = (event, isKeyEvent = false) => {
     if (!event || !event.target) return;
     const el = event.target;
     if (this.doesElementContainAnnotationAndHighlight(el))
       this.handleDisambiguationClick(event, el);
     if (this.doesElementContainRemovableHighlight(el))
-      return this.handleRemovableHighlightClick(event, el);
+      return this.handleRemovableHighlightClick(event, el, isKeyEvent);
     if (this.doesElementContainAnnotation(el))
-      return this.handleAnnotationClick(event, el);
+      return this.handleAnnotationClick(event, el, isKeyEvent);
   };
 
   handleDisambiguationClick(eventIgnored, el) {
@@ -68,26 +68,28 @@ export default class AnnotatableCaptureClick extends Component {
     });
   }
 
-  handleRemovableHighlightClick(event, el) {
+  handleRemovableHighlightClick(event, el, isKeyEvent) {
     event.preventDefault();
     event.stopPropagation();
     const id = el.dataset.removableHighlightId;
-    this.props.updateActiveAnnotation(id, event);
+    this.props.updateActiveAnnotation(id, event, { isKeyEvent });
   }
 
-  handleAnnotationClick(event, el) {
+  handleAnnotationClick(event, el, isKeyEvent) {
     event.preventDefault();
     const link = selectionHelpers.closest(el, "a");
     const annotationIds = this.elementAnnotationIds(el);
-    if (link) return this.showLinkMenu(event, el, annotationIds, link);
+    if (link)
+      return this.showLinkMenu(event, el, annotationIds, link, isKeyEvent);
     this.props.actions.openViewAnnotationsDrawer(annotationIds);
   }
 
-  showLinkMenu(event, el, annotationIds, link) {
+  showLinkMenu(event, el, annotationIds, link, isKeyEvent) {
     event.stopPropagation();
     const eventInfo = {
       annotationIds,
-      link
+      link,
+      isKeyEvent
     };
     this.props.updateActiveAnnotation(annotationIds[0], event, eventInfo);
   }
@@ -105,7 +107,7 @@ export default class AnnotatableCaptureClick extends Component {
       <div
         className="no-focus-outline"
         onClick={this.handleClick}
-        onKeyDown={this.handleKeyDown}
+        onKeyUp={this.handleKeyUp}
         onMouseUp={this.handleMouseUp}
         tabIndex={-1}
       >

--- a/client/src/reader/containers/annotation/annotatable-components/CaptureClick.js
+++ b/client/src/reader/containers/annotation/annotatable-components/CaptureClick.js
@@ -89,7 +89,7 @@ export default class AnnotatableCaptureClick extends Component {
       annotationIds,
       link
     };
-    this.props.updateActiveAnnotation(annotationIds, event, eventInfo);
+    this.props.updateActiveAnnotation(annotationIds[0], event, eventInfo);
   }
 
   elementAnnotationIds(el, type = "textAnnotationIds") {

--- a/client/src/reader/containers/annotation/annotatable-components/CaptureSelection.js
+++ b/client/src/reader/containers/annotation/annotatable-components/CaptureSelection.js
@@ -112,7 +112,11 @@ export default class AnnotatableCaptureSelection extends Component {
     return event.type !== "selectionchange";
   }
 
-  updateSelectionState(event = null, selectionComplete = false) {
+  updateSelectionState(
+    event = null,
+    selectionComplete = false,
+    isKeyboardSelection = false
+  ) {
     try {
       const { selectionState } = this.props;
       const selection = this.mapNativeSelection(this.nativeSelection);
@@ -128,7 +132,8 @@ export default class AnnotatableCaptureSelection extends Component {
         ),
         selectionComplete: complete,
         popupTriggerX: selection && x ? x : selectionState.popupTriggerX,
-        popupTriggerY: selection && y ? y : selectionState.popupTriggerY
+        popupTriggerY: selection && y ? y : selectionState.popupTriggerY,
+        isKeyboardSelection
       });
       this.props.updateSelection(newState);
     } catch (error) {
@@ -248,7 +253,7 @@ export default class AnnotatableCaptureSelection extends Component {
   handleKeyUp = event => {
     const { key, shiftKey } = event;
     if (key === "Shift" && shiftKey === false)
-      this.updateSelectionState(event, true);
+      this.updateSelectionState(event, true, true);
   };
 
   get focusInPopup() {

--- a/client/src/reader/containers/annotation/annotatable-components/Popup/LinkMenu.js
+++ b/client/src/reader/containers/annotation/annotatable-components/Popup/LinkMenu.js
@@ -3,7 +3,13 @@ import PropTypes from "prop-types";
 import { Menus } from "reader/components/annotation/popup";
 import { useAnnotationMenu } from "reader/components/annotation/popup/hooks";
 
-function LinkMenu({ direction, visible, actions, activeEvent }) {
+function LinkMenu({
+  direction,
+  visible,
+  actions,
+  activeEvent,
+  isKeyboardSelection
+}) {
   const { menus, activeMenu } = useAnnotationMenu({
     menuArray: ["main"],
     defaultMenu: "main",
@@ -17,6 +23,7 @@ function LinkMenu({ direction, visible, actions, activeEvent }) {
       direction={direction}
       activeEvent={activeEvent}
       actions={actions}
+      isKeyboardSelection={isKeyboardSelection}
     />
   );
 }
@@ -27,7 +34,8 @@ LinkMenu.propTypes = {
   activeEvent: PropTypes.object.isRequired,
   actions: PropTypes.object.isRequired,
   direction: PropTypes.oneOf(["up", "down"]),
-  visible: PropTypes.bool
+  visible: PropTypes.bool,
+  isKeyboardSelection: PropTypes.bool
 };
 
 export default LinkMenu;

--- a/client/src/reader/containers/annotation/annotatable-components/Popup/LoginMenu.js
+++ b/client/src/reader/containers/annotation/annotatable-components/Popup/LoginMenu.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Menus } from "reader/components/annotation/popup";
 import { useAnnotationMenu } from "reader/components/annotation/popup/hooks";
 
-function LoginMenu({ direction, actions, visible }) {
+function LoginMenu({ direction, actions, visible, isKeyboardSelection }) {
   const { menus, activeMenu } = useAnnotationMenu({
     menuArray: ["main"],
     defaultMenu: "main",
@@ -16,6 +16,7 @@ function LoginMenu({ direction, actions, visible }) {
       visible={activeMenu === "main"}
       direction={direction}
       actions={actions}
+      isKeyboardSelection={isKeyboardSelection}
     />
   );
 }
@@ -25,7 +26,8 @@ LoginMenu.displayName = "Annotation.Popup.LoginMenu";
 LoginMenu.propTypes = {
   actions: PropTypes.object.isRequired,
   direction: PropTypes.oneOf(["up", "down"]),
-  visible: PropTypes.bool
+  visible: PropTypes.bool,
+  isKeyboardSelection: PropTypes.bool
 };
 
 export default LoginMenu;

--- a/client/src/reader/containers/annotation/annotatable-components/Popup/PrimaryMenu.js
+++ b/client/src/reader/containers/annotation/annotatable-components/Popup/PrimaryMenu.js
@@ -15,7 +15,8 @@ function PrimaryMenu({
   actions,
   activeAnnotation,
   direction,
-  visible
+  visible,
+  isKeyboardSelection
 }) {
   const {
     menus,
@@ -36,6 +37,7 @@ function PrimaryMenu({
 
   const submenuProps = {
     direction,
+    isKeyboardSelection,
     onBackClick: () => setActiveMenu("main"),
     onKeyDown: event => handleKeyDown(event)
   };
@@ -55,6 +57,7 @@ function PrimaryMenu({
         activeAnnotation={activeAnnotation}
         readingGroups={readingGroups}
         currentReadingGroup={currentAnnotatingReadingGroup}
+        isKeyboardSelection={isKeyboardSelection}
       />
       <Menus.Share
         menu={menus.share}
@@ -89,7 +92,8 @@ PrimaryMenu.propTypes = {
   readingGroups: PropTypes.array,
   setAnnotatingReadingGroup: PropTypes.func,
   direction: PropTypes.oneOf(["up", "down"]),
-  visible: PropTypes.bool
+  visible: PropTypes.bool,
+  isKeyboardSelection: PropTypes.bool
 };
 
 export default withReadingGroups(PrimaryMenu);

--- a/client/src/reader/containers/annotation/annotatable-components/Popup/index.js
+++ b/client/src/reader/containers/annotation/annotatable-components/Popup/index.js
@@ -29,6 +29,13 @@ export default class AnnotatablePopup extends PureComponent {
     return !!(selection && selectionComplete);
   }
 
+  get isKeyboardSelection() {
+    return (
+      this.props.selectionState?.isKeyboardSelection ||
+      this.props.activeEvent?.isKeyEvent
+    );
+  }
+
   render() {
     return (
       <Positioner
@@ -49,6 +56,7 @@ export default class AnnotatablePopup extends PureComponent {
                   {...this.props}
                   direction={direction}
                   visible={this.visible}
+                  isKeyboardSelection={this.isKeyboardSelection}
                 />
               </Authorize>
               <Authorize kind="any">
@@ -57,6 +65,7 @@ export default class AnnotatablePopup extends PureComponent {
                     {...this.props}
                     direction={direction}
                     visible={this.visible}
+                    isKeyboardSelection={this.isKeyboardSelection}
                   />
                 )}
                 {!this.showLinkMenu && (
@@ -64,6 +73,7 @@ export default class AnnotatablePopup extends PureComponent {
                     {...this.props}
                     direction={direction}
                     visible={this.visible}
+                    isKeyboardSelection={this.isKeyboardSelection}
                   />
                 )}
               </Authorize>


### PR DESCRIPTION
This PR addresses browser inconsistencies around using the annotation popup that were introduced by 39ae9d0. That commit refactored the menu using the WAI-ARIA menu design pattern and implemented keyboard functionality for the first time. However, due to the way Safari and Firefox interweave the document's focus and selection states (see https://github.com/ManifoldScholar/manifold/pull/3086#issuecomment-1030141362), when focus was moved around the menu it triggered a loss of selection highlighting in these browsers. Because it did this for both pointer and keyboard interactions, we felt that this was an unacceptable visual regression, even if it didn't impact how Manifold internally tracks a selection for annotating, highlighting, sharing, or attaching a resource to.

As a workaround, this PR tracks whether the user has opened the menu with a pointer or a keyboard. For pointer users, it now avoids managing focus, so that Safari and Firefox maintain the current selection. For keyboard users, focus is managed by the menu, which is necessary for interaction. This does cause loss of selection highlighting for keyboard users of these browsers, but this is ultimately unavoidable and beyond the responsibility of Manifold (see https://github.com/ManifoldScholar/manifold/issues/2326#issuecomment-523208990 for more on this). This is admittedly not an ideal solution, but it is the best we can do under the constraints of browser inconsistencies. Chromium-based browsers continue to work as desired.

Fortunately this is probably a temporary solution, as the CSS Custom Highlight API should create an alternative, standards-driven path to storing selection in the browser.

https://www.w3.org/TR/css-highlight-api-1/
https://css-tricks.com/css-custom-highlight-api-early-loo/