### PR TITLE
[B] Fix annotation popup on iOS

### DIFF
--- a/client/src/reader/components/annotation/popup/hooks/useAnnotationMenu/index.js
+++ b/client/src/reader/components/annotation/popup/hooks/useAnnotationMenu/index.js
@@ -25,7 +25,8 @@ export default function useAnnotationMenu({ menuArray, defaultMenu, visible }) {
         onMouseEnter: event => event.preventDefault(),
         onMouseMove: event => event.preventDefault(),
         onMouseLeave: event => event.preventDefault(),
-        onMouseDown: event => event.preventDefault()
+        onMouseDown: event => event.preventDefault(),
+        onTouchEnd: event => event.preventDefault()
       }
     ])
   );

--- a/client/src/reader/components/annotation/popup/menus/Main/Items/CurrentReadingGroup.js
+++ b/client/src/reader/components/annotation/popup/menus/Main/Items/CurrentReadingGroup.js
@@ -35,6 +35,7 @@ function CurrentReadingGroup({
       <ReakitMenuItem
         {...menu}
         onClick={onClick}
+        onTouchEnd={onClick}
         tabIndex={menu?.visible ? undefined : -1}
         aria-haspopup="menu"
         aria-expanded={activeMenu === "readingGroup"}

--- a/client/src/reader/components/annotation/popup/parts/MenuItem/index.js
+++ b/client/src/reader/components/annotation/popup/parts/MenuItem/index.js
@@ -26,6 +26,7 @@ function MenuItem({
           {...menu}
           {...menuProps}
           onClick={onClick}
+          onTouchEnd={onClick}
           tabIndex={menu.visible ? undefined : -1}
           className={classNames("annotation-popup__button", className)}
         >


### PR DESCRIPTION
This commit fixes problems with trying to use the reader annotation popup menu on iOS. Previously when a user tapped a menu item, nothing happening, as the interpreted mouse event `onClick` wasn't firing in response to a touch event as expected. I'm wondering whether this relates to the iOS text selection callout appearing simultaneously, but I'm not sure. (Also, I looked into hiding that callout, but it's not possible.) In any case, I've worked around this by attaching the same `onClick` callbacks in the popup menu to `onTouchEnd` events. I've also added `preventDefault()` for all `onTouchEnd` events so that focus isn't moved away from the current text selection, which causes the menu to become invisible.