### PR TITLE
[B] Revise TOC content block header logic

### DIFF
--- a/client/src/frontend/components/content-block-list/List.js
+++ b/client/src/frontend/components/content-block-list/List.js
@@ -8,6 +8,7 @@ export default class ContentBlockList extends PureComponent {
   static propTypes = {
     entity: PropTypes.object,
     hideHeader: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
+    hideDefaultHeader: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
     hideLastBottomBorder: PropTypes.bool
   };
 
@@ -36,11 +37,10 @@ export default class ContentBlockList extends PureComponent {
     );
   }
 
-  getHeader(block) {
-    if (typeof this.props.hideHeader === "boolean")
-      return this.props.hideHeader;
-    if (Array.isArray(this.props.hideHeader))
-      return this.props.hideHeader.includes(block.type);
+  hideHeader(block, hideProp = "hideHeader") {
+    if (typeof this.props[hideProp] === "boolean") return this.props[hideProp];
+    if (Array.isArray(this.props[hideProp]))
+      return this.props[hideProp].includes(block.type);
     return false;
   }
 
@@ -53,7 +53,8 @@ export default class ContentBlockList extends PureComponent {
           key={block.id}
           block={block}
           {...restProps}
-          hideHeader={this.getHeader(block)}
+          hideHeader={this.hideHeader(block)}
+          hideDefaultHeader={this.hideHeader(block, "hideDefaultHeader")}
           hideBottomBorder={
             this.props.hideLastBottomBorder &&
             index === this.visibleContentBlocks.length - 1

--- a/client/src/frontend/components/content-block/Block/index.js
+++ b/client/src/frontend/components/content-block/Block/index.js
@@ -28,14 +28,13 @@ function showBlock(block, authorization) {
   return visible;
 }
 
-function getTitle(block, typeComponent) {
+function getTitle(block, typeComponent, hideDefaultHeader) {
   const {
     attributes: { title, renderable }
   } = block;
-
   if (!renderable) return typeComponent.placeholderTitle || typeComponent.title;
-
-  return title || typeComponent.title;
+  if (title) return title;
+  return hideDefaultHeader ? undefined : typeComponent.title;
 }
 
 function getIcon(block, typeComponent, isJournalIssue) {
@@ -52,11 +51,14 @@ function ContentBlock({
   block,
   entity,
   hideHeader,
+  hideDefaultHeader,
   hideBottomBorder,
   ...passThroughProps
 }) {
   const authorization = new Authorization();
   const typeComponent = typeToBlockComponent(block.attributes.type);
+  const entityIsJournalIssue =
+    entity.attributes.isJournalIssue || entity.type === "journalIssues";
 
   if (!showBlock(block, authorization)) return null;
 
@@ -67,8 +69,8 @@ function ContentBlock({
   const headerProps = hideHeader
     ? {}
     : {
-        title: getTitle(block, typeComponent),
-        icon: getIcon(block, typeComponent, entity.attributes.isJournalIssue),
+        title: getTitle(block, typeComponent, hideDefaultHeader),
+        icon: getIcon(block, typeComponent, entityIsJournalIssue),
         description: descriptionFormatted
       };
 
@@ -99,7 +101,10 @@ ContentBlock.displayName = "ContentBlock";
 
 ContentBlock.propTypes = {
   block: PropTypes.object.isRequired,
-  entity: PropTypes.object.isRequired
+  entity: PropTypes.object.isRequired,
+  hideHeader: PropTypes.bool,
+  hideDefaultHeader: PropTypes.bool,
+  hideBottomBorder: PropTypes.bool
 };
 
 export default ContentBlock;

--- a/client/src/frontend/components/content-block/types/TableOfContents.js
+++ b/client/src/frontend/components/content-block/types/TableOfContents.js
@@ -1,52 +1,35 @@
-import React, { PureComponent } from "react";
+import React from "react";
 import PropTypes from "prop-types";
-import { withTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import TOC from "frontend/components/toc";
 
-class ProjectContentBlockTableOfContentsBlock extends PureComponent {
-  static displayName = "Project.Content.Block.TableOfContents";
+function ProjectContentBlockTableOfContentsBlock({ block }) {
+  const { t } = useTranslation();
+  const {
+    relationships: { text },
+    attributes: { depth, showAuthors, showTextTitle }
+  } = block;
 
-  static propTypes = {
-    block: PropTypes.object.isRequired,
-    t: PropTypes.func
-  };
-
-  static get icon() {
-    return "toc64";
-  }
-
-  get blockAttributes() {
-    return this.props.block.attributes;
-  }
-
-  get text() {
-    return this.props.block.relationships.text;
-  }
-
-  get depth() {
-    return this.blockAttributes.depth;
-  }
-
-  get showAuthors() {
-    return this.blockAttributes.showAuthors;
-  }
-
-  get showTextTitle() {
-    return this.blockAttributes.showTextTitle;
-  }
-
-  render() {
-    return (
-      <nav aria-label={this.props.t("glossary.table_of_contents_title_case")}>
-        <TOC.List
-          showTextTitle={this.showTextTitle}
-          showAuthors={this.showAuthors}
-          text={this.text}
-          depth={this.depth}
-        />
-      </nav>
-    );
-  }
+  return (
+    <nav aria-label={t("glossary.table_of_contents_title_case")}>
+      <TOC.List
+        showTextTitle={showTextTitle}
+        showAuthors={showAuthors}
+        text={text}
+        depth={depth}
+      />
+    </nav>
+  );
 }
 
-export default withTranslation()(ProjectContentBlockTableOfContentsBlock);
+ProjectContentBlockTableOfContentsBlock.displayName =
+  "Project.Content.Block.TableOfContents";
+
+ProjectContentBlockTableOfContentsBlock.propTypes = {
+  block: PropTypes.object.isRequired
+};
+
+ProjectContentBlockTableOfContentsBlock.title = "Table of Contents";
+ProjectContentBlockTableOfContentsBlock.icon = "toc64";
+
+export default ProjectContentBlockTableOfContentsBlock;

--- a/client/src/frontend/components/journal/VolumeDetail/index.js
+++ b/client/src/frontend/components/journal/VolumeDetail/index.js
@@ -41,6 +41,7 @@ function VolumeDetail({ journal, volume }) {
                 entity={issue}
                 nested
                 hideHeader={["textsBlocks"]}
+                hideDefaultHeader={["tableOfContentsBlocks"]}
                 hideLastBottomBorder
               />
             </Styled.IssueWrapper>


### PR DESCRIPTION
* Refactors TOC block into function component to fix conflict between
withTranslation HOC and getting static icon/title properties of
component
* Adds option to ContentBlockList to hide default block title if one
isn't specified by user, and applies to TOC block in journal volume
detail view
