### PR TITLE
[B] Receive form control clicks directly on input

### DIFF
--- a/client/src/global/components/sign-in-up/UpdateForm.js
+++ b/client/src/global/components/sign-in-up/UpdateForm.js
@@ -238,7 +238,7 @@ export class UpdateFormContainer extends Component {
                       })}
                     />
                     <div
-                      style={{ position: "relative" }}
+                      style={{ position: "relative", pointerEvents: "none" }}
                       className="dropzone-button dropzone-button-dotted"
                     >
                       <div

--- a/client/src/theme/styles/components/backend/project/avatarBuilder.js
+++ b/client/src/theme/styles/components/backend/project/avatarBuilder.js
@@ -158,6 +158,9 @@ export default `
 
           .contents-image-preview {
             flex-grow: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
             justify-content: space-between;
             padding: 0 0 15px;
 

--- a/client/src/theme/styles/components/global/checkboxes.js
+++ b/client/src/theme/styles/components/global/checkboxes.js
@@ -5,7 +5,6 @@ export default `
     ${setHoverStyle()}
     position: relative;
     display: block;
-    cursor: pointer;
 
     &--white {
       &:hover {
@@ -62,8 +61,12 @@ export default `
 
     input {
       position: absolute;
-      z-index: -1;
+      inset-inline-start: 0;
+      inset-block-start: 0;
+      inline-size: 100%;
+      block-size: 100%;
       opacity: 0;
+      cursor: pointer;
     }
 
     input:checked ~ .checkbox__indicator {

--- a/client/src/theme/styles/components/global/forms/formInputsPrimary.js
+++ b/client/src/theme/styles/components/global/forms/formInputsPrimary.js
@@ -324,7 +324,6 @@ export default `
     padding-left: 33px;
     margin-bottom: 0;
     font-size: 13px;
-    cursor: pointer;
 
     ${respond(`font-size: 16px;`, 60)}
 
@@ -349,8 +348,14 @@ export default `
 
     input {
       position: absolute;
-      z-index: -1;
+      inset-inline-start: 0;
+      inset-block-start: 0;
+      inline-size: 100%;
+      block-size: 100%;
+      margin: 0;
       opacity: 0;
+      z-index: 1;
+      cursor: pointer;
 
       &.focus-visible ~ .toggle-indicator {
         background-color: var(--color-accent-primary-light);

--- a/client/src/theme/styles/components/global/forms/formInputsSecondary.js
+++ b/client/src/theme/styles/components/global/forms/formInputsSecondary.js
@@ -317,7 +317,6 @@ export default `
     }
 
     .form-dropzone {
-      position: relative;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -363,8 +362,10 @@ export default `
         align-items: center;
         justify-content: center;
         width: 100%;
+        pointer-events: none;
 
         .message {
+          position: relative;
           width: 100%;
           padding: 20px;
           word-wrap: break-word;
@@ -378,31 +379,33 @@ export default `
       }
 
       .contents-image-preview {
-        display: flex;
-        flex-direction: column;
+        display: grid;
+        grid-template-columns: 1fr;
+        grid-template-rows: auto;
         align-items: center;
-        justify-content: center;
         width: 100%;
         padding: 10px;
+        pointer-events: none;
 
         .preview {
+          grid-column: 1 / -1;
+          grid-row: 1 / -1;
+          justify-self: center;
           max-width: 100%;
           max-height: 200px;
           background: var(--color-base-neutral20);
         }
 
         .message {
-          position: absolute;
-          top: 50%;
-          left: 50%;
-          z-index: 1;
+          grid-column: 1 / -1;
+          grid-row: 1 / -1;
+          justify-self: center;
           width: 75%;
           padding: 5px 20px 15px;
           margin-bottom: 20px;
           text-align: center;
           background: var(--color-base-neutral95);
           opacity: 0.9;
-          transform: translate(-50%, -50%);
         }
       }
 

--- a/client/src/theme/styles/components/global/forms/shared.js
+++ b/client/src/theme/styles/components/global/forms/shared.js
@@ -6,8 +6,6 @@ import {
   outlineOnFocus,
   defaultFocusStyle,
   defaultTransitionProps,
-  setHoverStyle,
-  screenReaderText,
   formLabelPrimary,
   selectPrimary,
   utilityPrimary
@@ -50,6 +48,7 @@ export default `
   }
 
   .form-dropzone {
+    position: relative;
     cursor: pointer;
 
     &__inline-button {
@@ -58,11 +57,12 @@ export default `
       text-decoration: underline;
       text-transform: inherit;
       letter-spacing: inherit;
+      pointer-events: auto;
     }
 
     &__upload-prompt {
-      ${setHoverStyle()}
       text-decoration: underline;
+      transition: color var(--transition-duration-default) var(--transition-timing-function);
     }
 
     .dropzone-button {
@@ -98,8 +98,21 @@ export default `
     }
 
     input {
-      ${screenReaderText}
       display: block !important;
+      position: absolute;
+      inset-inline-start: 0;
+      inset-block-start: 0;
+      inline-size: 100%;
+      block-size: 100%;
+      opacity: 0;
+      cursor: pointer;
+
+      &:hover {
+        + [class^='contents-'] .form-dropzone__upload-prompt,
+        + .dropzone-button .form-dropzone__upload-prompt {
+          color: var(--hover-color);
+        }
+      }
 
       &.focus-visible {
         outline: 0;


### PR DESCRIPTION
This lightly refactors radios, checkboxes, and file-type inputs so that
the input itself fills the clickable area and receives the click. This
builds on 5cdedb and solves an issue where form controls in drawers
were failing to respond to pointer clicks.

Resolves MNFLD-409
Resolves #3399
