### PR TITLE
[C] Allow duplicated stylesheets in exports

### DIFF
--- a/api/app/services/packaging/epub_v3/stylesheet_item.rb
+++ b/api/app/services/packaging/epub_v3/stylesheet_item.rb
@@ -35,7 +35,7 @@ module Packaging
       private
 
       def build_base_path
-        stylesheet.source_identifier.presence || "css/#{stylesheet_name}.css"
+        "css/#{stylesheet_name}.css"
       end
     end
   end


### PR DESCRIPTION
Just use the generated stylesheet name rather than the original source identifier when exporting stylesheets, since there are some legacy models that have duplicated stylesheets, and a fix for those will be more involved.