### PR TITLE
[B] Ensure spine + auto TOC are correctly calculated 

### DIFF
--- a/api/app/services/ingestions/strategies/epub.rb
+++ b/api/app/services/ingestions/strategies/epub.rb
@@ -56,7 +56,8 @@ module Ingestions
       end
 
       def text_sections
-        inspector.spine_item_nodes.map.with_index do |node, position|
+        inspector.spine_item_nodes.map.with_index do |node, index|
+          position = index + 1
           examiner = Strategy::Epub::TextSection.new self, node, position
           attributes = examiner.attributes
           build_path = context.write_build_file attributes[:source_identifier],

--- a/api/app/services/ingestions/strategies/manifest.rb
+++ b/api/app/services/ingestions/strategies/manifest.rb
@@ -109,7 +109,7 @@ module Ingestions
           examiner = Strategy::Manifest::TextSection.new self,
                                                          source,
                                                          ingestion_sources,
-                                                         index
+                                                         index + 1
           attributes = examiner.attributes
           build_path = context.write_build_file "#{examiner.source_identifier}.html",
                                                 examiner.raw_html

--- a/api/db/migrate/20231010184158_update_text_section_aggregation_to_version2.rb
+++ b/api/db/migrate/20231010184158_update_text_section_aggregation_to_version2.rb
@@ -1,0 +1,5 @@
+class UpdateTextSectionAggregationToVersion2 < ActiveRecord::Migration[6.1]
+  def change
+    update_view :text_section_aggregations, version: 2, revert_to_version: 1
+  end
+end

--- a/api/db/structure.sql
+++ b/api/db/structure.sql
@@ -2640,7 +2640,7 @@ CREATE VIEW public.text_export_statuses AS
 
 CREATE VIEW public.text_section_aggregations AS
  SELECT text_sections.text_id,
-    jsonb_agg(jsonb_build_object('label', text_sections.name, 'id', text_sections.id, 'source_path', text_sections.source_identifier) ORDER BY text_sections.legacy_position) AS auto_generated_toc
+    jsonb_agg(jsonb_build_object('label', text_sections.name, 'id', text_sections.id, 'source_path', text_sections.source_identifier, 'position', text_sections."position") ORDER BY text_sections."position") AS auto_generated_toc
    FROM public.text_sections
   GROUP BY text_sections.text_id;
 
@@ -7124,6 +7124,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230817212021'),
 ('20230823232509'),
 ('20230921024546'),
-('20231005175407');
+('20231005175407'),
+('20231010184158');
 
 

--- a/api/db/views/text_section_aggregations_v02.sql
+++ b/api/db/views/text_section_aggregations_v02.sql
@@ -1,0 +1,1 @@
+SELECT text_id, jsonb_agg(jsonb_build_object('label', name, 'id', id, 'source_path', source_identifier, 'position', position) ORDER BY position ASC NULLS LAST) AS auto_generated_toc FROM text_sections GROUP BY text_id;

--- a/api/spec/services/ingestions/strategies/epub_spec.rb
+++ b/api/spec/services/ingestions/strategies/epub_spec.rb
@@ -79,10 +79,10 @@ RSpec.describe Ingestions::Strategies::Epub do
 
     it "has one text section for every unique ingestion source referenced in TOC" do
       expected = [
-        { "source_identifier" => "section0001.xhtml", "name" => "Section 1", "kind" => "navigation", "position" => 0, "build" => "build/section0001.xhtml" },
-        { "source_identifier" => "section0002.xhtml", "name" => "Section 2", "kind" => "section", "position" => 1, "build" => "build/section0002.xhtml" },
-        { "source_identifier" => "section0002a.xhtml", "name" => "Section 2.a", "kind" => "section", "position" => 2, "build" => "build/section0002a.xhtml" },
-        { "source_identifier" => "section0003.xhtml", "name" => "Section 3", "kind" => "section", "position" => 3, "build" => "build/section0003.xhtml" }
+        { "source_identifier" => "section0001.xhtml", "name" => "Section 1", "kind" => "navigation", "position" => 1, "build" => "build/section0001.xhtml" },
+        { "source_identifier" => "section0002.xhtml", "name" => "Section 2", "kind" => "section", "position" => 2, "build" => "build/section0002.xhtml" },
+        { "source_identifier" => "section0002a.xhtml", "name" => "Section 2.a", "kind" => "section", "position" => 3, "build" => "build/section0002a.xhtml" },
+        { "source_identifier" => "section0003.xhtml", "name" => "Section 3", "kind" => "section", "position" => 4, "build" => "build/section0003.xhtml" }
       ]
       expect(manifest[:relationships][:text_sections]).to eq expected
     end
@@ -115,10 +115,10 @@ RSpec.describe Ingestions::Strategies::Epub do
 
     it "has one text section for every unique ingestion source referenced in TOC" do
       expected = [
-        { "source_identifier" => "section0001.xhtml",  "name" => "Section 1", "kind" => "navigation", "position" => 0, "build" => "build/section0001.xhtml" },
-        { "source_identifier" => "section0002.xhtml",  "name" => "Section 2", "kind" => "section", "position" => 1, "build" => "build/section0002.xhtml" },
-        { "source_identifier" => "section0002a.xhtml", "name" => "Section 2.a", "kind" => "section", "position" => 2, "build" => "build/section0002a.xhtml" },
-        { "source_identifier" => "section0003.xhtml", "name" => "Section 3", "kind" => "section", "position" => 3, "build" => "build/section0003.xhtml" }
+        { "source_identifier" => "section0001.xhtml",  "name" => "Section 1", "kind" => "navigation", "position" => 1, "build" => "build/section0001.xhtml" },
+        { "source_identifier" => "section0002.xhtml",  "name" => "Section 2", "kind" => "section", "position" => 2, "build" => "build/section0002.xhtml" },
+        { "source_identifier" => "section0002a.xhtml", "name" => "Section 2.a", "kind" => "section", "position" => 3, "build" => "build/section0002a.xhtml" },
+        { "source_identifier" => "section0003.xhtml", "name" => "Section 3", "kind" => "section", "position" => 4, "build" => "build/section0003.xhtml" }
       ]
       expect(manifest[:relationships][:text_sections]).to eq expected
     end
@@ -208,18 +208,18 @@ RSpec.describe Ingestions::Strategies::Epub do
 
       it "has one text section for every unique ingestion source referenced in TOC" do
         expected = [
-          { "source_identifier" => "titlepage.xhtml", "name" => "Titlepage", "kind" => "section", "position" => 0, "build" => "build/titlepage.xhtml" },
-          { "source_identifier" => "imprint.xhtml", "name" => "Imprint", "kind" => "section", "position" => 1, "build" => "build/imprint.xhtml" },
-          { "source_identifier" => "chapter-1.xhtml",  "name" => "I First Adventure", "kind" => "section", "position" => 2, "build" => "build/chapter-1.xhtml" },
-          { "source_identifier" => "chapter-2.xhtml",  "name" => "II Second Adventure", "kind" => "section", "position" => 3, "build" => "build/chapter-2.xhtml"  },
-          { "source_identifier" => "chapter-3.xhtml",  "name" => "III Third Adventure", "kind" => "section", "position" => 4, "build" => "build/chapter-3.xhtml"  },
-          { "source_identifier" => "chapter-4.xhtml",  "name" => "IV Fourth Adventure", "kind" => "section", "position" => 5, "build" => "build/chapter-4.xhtml"  },
-          { "source_identifier" => "chapter-5.xhtml",  "name" => "V Fifth Adventure", "kind" => "section", "position" => 6, "build" => "build/chapter-5.xhtml"  },
-          { "source_identifier" => "chapter-6.xhtml",  "name" => "VI Sixth Adventure", "kind" => "section", "position" => 7, "build" => "build/chapter-6.xhtml" },
-          { "source_identifier" => "chapter-7.xhtml",  "name" => "VII Seventh Adventure", "kind" => "section", "position" => 8, "build" => "build/chapter-7.xhtml" },
-          { "source_identifier" => "endnotes.xhtml",  "name" => "Endnotes", "kind" => "section", "position" => 9, "build" => "build/endnotes.xhtml" },
-          { "source_identifier" => "colophon.xhtml",  "name" => "Colophon", "kind" => "section", "position" => 10, "build" => "build/colophon.xhtml" },
-          { "source_identifier" => "uncopyright.xhtml", "name" => "Uncopyright", "kind" => "section", "position" => 11, "build" => "build/uncopyright.xhtml" }
+          { "source_identifier" => "titlepage.xhtml", "name" => "Titlepage", "kind" => "section", "position" => 1, "build" => "build/titlepage.xhtml" },
+          { "source_identifier" => "imprint.xhtml", "name" => "Imprint", "kind" => "section", "position" => 2, "build" => "build/imprint.xhtml" },
+          { "source_identifier" => "chapter-1.xhtml",  "name" => "I First Adventure", "kind" => "section", "position" => 3, "build" => "build/chapter-1.xhtml" },
+          { "source_identifier" => "chapter-2.xhtml",  "name" => "II Second Adventure", "kind" => "section", "position" => 4, "build" => "build/chapter-2.xhtml"  },
+          { "source_identifier" => "chapter-3.xhtml",  "name" => "III Third Adventure", "kind" => "section", "position" => 5, "build" => "build/chapter-3.xhtml"  },
+          { "source_identifier" => "chapter-4.xhtml",  "name" => "IV Fourth Adventure", "kind" => "section", "position" => 6, "build" => "build/chapter-4.xhtml"  },
+          { "source_identifier" => "chapter-5.xhtml",  "name" => "V Fifth Adventure", "kind" => "section", "position" => 7, "build" => "build/chapter-5.xhtml"  },
+          { "source_identifier" => "chapter-6.xhtml",  "name" => "VI Sixth Adventure", "kind" => "section", "position" => 8, "build" => "build/chapter-6.xhtml" },
+          { "source_identifier" => "chapter-7.xhtml",  "name" => "VII Seventh Adventure", "kind" => "section", "position" => 9, "build" => "build/chapter-7.xhtml" },
+          { "source_identifier" => "endnotes.xhtml",  "name" => "Endnotes", "kind" => "section", "position" => 10, "build" => "build/endnotes.xhtml" },
+          { "source_identifier" => "colophon.xhtml",  "name" => "Colophon", "kind" => "section", "position" => 11, "build" => "build/colophon.xhtml" },
+          { "source_identifier" => "uncopyright.xhtml", "name" => "Uncopyright", "kind" => "section", "position" => 12, "build" => "build/uncopyright.xhtml" }
         ]
 
         expect(manifest[:relationships][:text_sections]).to eq expected

--- a/api/spec/services/ingestions/strategies/manifest_spec.rb
+++ b/api/spec/services/ingestions/strategies/manifest_spec.rb
@@ -62,9 +62,9 @@ RSpec.describe Ingestions::Strategies::Manifest do
         end
 
         it "has one text section for every unique ingestion source referenced in TOC" do
-          expected = [{ "source_identifier" => "02e9b3b8b5268c3fe8bd4150fd546a55", "name" => "Title Set From TOC", "kind" => "section", "position" => 0, "build" => "build/02e9b3b8b5268c3fe8bd4150fd546a55.html" },
-                      { "source_identifier" => "9fef2b7e781641e6861d1aa79a597a57", "name" => "Section 1.1", "kind" => "section", "position" => 1, "build" => "build/9fef2b7e781641e6861d1aa79a597a57.html" },
-                      { "source_identifier" => "e2fe424ecf8e3c87da127ea617e57107", "name" => "Section 1.1a", "kind" => "section", "position" => 2, "build" => "build/e2fe424ecf8e3c87da127ea617e57107.html" }]
+          expected = [{ "source_identifier" => "02e9b3b8b5268c3fe8bd4150fd546a55", "name" => "Title Set From TOC", "kind" => "section", "position" => 1, "build" => "build/02e9b3b8b5268c3fe8bd4150fd546a55.html" },
+                      { "source_identifier" => "9fef2b7e781641e6861d1aa79a597a57", "name" => "Section 1.1", "kind" => "section", "position" => 2, "build" => "build/9fef2b7e781641e6861d1aa79a597a57.html" },
+                      { "source_identifier" => "e2fe424ecf8e3c87da127ea617e57107", "name" => "Section 1.1a", "kind" => "section", "position" => 3, "build" => "build/e2fe424ecf8e3c87da127ea617e57107.html" }]
           expect(manifest[:relationships][:text_sections]).to eq expected
         end
 


### PR DESCRIPTION
There are fixes here for two bugs related to text section order:
1.  When `spine` was [transitioned to a calculated field](https://github.com/ManifoldScholar/manifold/commit/88ec99fa2968db752d3ea3ca75f676496f1b79c8), `position` for a text section could no longer be 0, but array indices are still used in epub and manifest ingestion to set position. Hence, the section at index 0 is getting shifted to the end of the spine.
2. The `text_section_aggregations` view wasn't updated when [text section positions were migrated](https://github.com/ManifoldScholar/manifold/commit/6de0ef7228e29b956281ca824cded80c5c1744e1) in response to the change above, so autogenerated TOCs aren't reflecting section order.