### PR TITLE
[C] Ensure settings always have up-to-date FA cache

### DIFF
--- a/api/config/initializers/15_update_settings_from_env.rb
+++ b/api/config/initializers/15_update_settings_from_env.rb
@@ -1,6 +1,8 @@
 Rails.application.configure do
   config.after_initialize do
     Settings.potentially_update_from_environment!
+
+    Settings.instance.refresh_formatted_attributes_cache! if Settings.table_exists?
   rescue NoMethodError
     Rails.logger.warn <<~TEXT
         Unable to update settings from environment due to NoMethodError. This could be due


### PR DESCRIPTION
During initialization, we should check to make sure that the settings are refreshed to the latest version of the cache in order to pick up any new defaults that may have been added.