### PR TITLE
[C] Lower attachment processing concurrency

### DIFF
--- a/api/app/jobs/attachments/process_attachment_job.rb
+++ b/api/app/jobs/attachments/process_attachment_job.rb
@@ -1,10 +1,11 @@
-require "image_processing/mini_magick"
+# frozen_string_literal: true
 
 module Attachments
   class ProcessAttachmentJob < ApplicationJob
     include ExclusiveJob
 
-    concurrency 3, drop: false unless Rails.env.test?
+    concurrency 1, drop: false unless Rails.env.test?
+
     retry_on ::MiniMagick::Error, wait: 10.seconds, attempts: 3
 
     queue_as :default
@@ -57,6 +58,5 @@ module Attachments
       }
     end
     # rubocop:enable Metrics/MethodLength
-
   end
 end

--- a/api/config/initializers/00_libraries.rb
+++ b/api/config/initializers/00_libraries.rb
@@ -1,4 +1,5 @@
 require "redcarpet/compat"
+require "image_processing/mini_magick"
 require "uber/inheritable_attr"
 require "to_week_range"
 require "auth_token"


### PR DESCRIPTION
Processing multiple large GIFs at once seems to cause problems with certain installations and Imagemagick. We will now process attachments serially instead of three at a time.