### PR TITLE
[F] Improve project exportation / Bag-It packaging

### DIFF
--- a/api/app/models/text.rb
+++ b/api/app/models/text.rb
@@ -436,10 +436,8 @@ class Text < ApplicationRecord
   # @return [{ Symbol => Object }]
   def packaging_metadata
     metadata.with_indifferent_access
-      .merge(id: id)
-      .merge(slug: slug)
+      .merge(slice(:id, :slug, :publication_date, :created_at, :updated_at))
       .merge(titles: titles_packaging_metadata.compact)
-      .merge(slice(:publication_date))
       .merge(collaborators: collaborator_packaging_metadata)
   end
 

--- a/api/app/services/packaging/bag_it_spec/compilation.rb
+++ b/api/app/services/packaging/bag_it_spec/compilation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Packaging
   module BagItSpec
     # The BagIt spec compilation namespace
@@ -6,7 +8,7 @@ module Packaging
       TMP_ROOT = Rails.root.join("tmp", "bagit")
 
       # The compilation pipeline version.
-      VERSION = Gem::Version.new("1.1.0").freeze
+      VERSION = Gem::Version.new("1.2.0").freeze
     end
   end
 end

--- a/api/app/services/packaging/bag_it_spec/resources/attachment_proxy.rb
+++ b/api/app/services/packaging/bag_it_spec/resources/attachment_proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Packaging
   module BagItSpec
     module Resources
@@ -24,7 +26,6 @@ module Packaging
         def build_entries(builder)
           builder.attachment! :file, root.join(original_filename), uploaded_file
           builder.json! :metadata, root.join("metadata.json"), metadata
-          builder.simple! :mimetype, root.join("mimetype"), content_type
         end
 
         private

--- a/api/app/services/packaging/bag_it_spec/resources/proxy.rb
+++ b/api/app/services/packaging/bag_it_spec/resources/proxy.rb
@@ -8,15 +8,6 @@ module Packaging
 
         include Packaging::BagItSpec::BuildsEntries
 
-        # Attributes that should be copied to files
-        # of the same name in the top-level {#root}.
-        #
-        # @see #build_entries
-        ATTRIBUTE_ENTRIES = %i[
-          kind sub_kind
-          external_id external_type external_url
-        ].freeze
-
         param :resource, Types.Instance(::Resource)
 
         delegate :slug, to: :resource
@@ -61,12 +52,7 @@ module Packaging
         end
 
         def build_entries(builder)
-          ATTRIBUTE_ENTRIES.each do |attr|
-            builder.simple! attr, root.join(attr.to_s), resource[attr]
-          end
-
           builder.json! :metadata, root.join("metadata.json"), resource.packaging_metadata
-          builder.json! :tags, root.join("tags.json"), resource.tag_list
         end
 
         private

--- a/api/app/services/packaging/preservation/export_project_metadata.rb
+++ b/api/app/services/packaging/preservation/export_project_metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Packaging
   module Preservation
     class ExportProjectMetadata < ActiveInteraction::Base
@@ -16,8 +18,12 @@ module Packaging
         store :slug
         store :description
         store :publication_date
+        store :created_at
+        store :updated_at
         store :metadata
         store :collaborators, :collaborator_packaging_metadata
+        store :text_ids
+        store :resource_ids
       end
 
       private

--- a/api/app/services/utility/index_map.rb
+++ b/api/app/services/utility/index_map.rb
@@ -53,6 +53,11 @@ module Utility
       end
     end
 
+    # @param [#to_s] key
+    def include?(key)
+      cache.key? key.to_s
+    end
+
     # @return [<Object>]
     def to_a
       each_value.to_a

--- a/api/spec/services/packaging/bag_it_spec/resources/attachment_proxy_spec.rb
+++ b/api/spec/services/packaging/bag_it_spec/resources/attachment_proxy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Packaging::BagItSpec::Resources::AttachmentProxy do
@@ -8,5 +10,9 @@ RSpec.describe Packaging::BagItSpec::Resources::AttachmentProxy do
 
   subject { attachment_proxy }
 
-  it { is_expected.to have(3).entries }
+  it { is_expected.to have(2).entries }
+
+  its(:entries) { are_expected.to include :file }
+
+  its(:entries) { are_expected.to include :metadata }
 end

--- a/api/spec/services/packaging/bag_it_spec/resources/proxy_spec.rb
+++ b/api/spec/services/packaging/bag_it_spec/resources/proxy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Packaging::BagItSpec::Resources::Proxy do
@@ -7,17 +9,22 @@ RSpec.describe Packaging::BagItSpec::Resources::Proxy do
 
   let(:attachment_proxy_count) { 3 }
 
-  let(:attachment_entry_count) { 3 }
+  let(:attachment_entry_count) { 2 }
 
   # metadata.json
-  # tags.json
-  let(:arbitrary_entry_count) { 2 }
+  let(:arbitrary_entry_count) { 1 }
 
-  let(:proxy_entry_count) { described_class::ATTRIBUTE_ENTRIES.length + arbitrary_entry_count }
+  let(:proxy_entry_count) { arbitrary_entry_count }
   let(:expected_entry_count) { proxy_entry_count + (attachment_proxy_count * attachment_entry_count) }
 
   it "has the expected number of attachment proxies" do
-    expect(proxy).to have(3).attachments
+    expect(proxy).to have(attachment_proxy_count).attachments
+  end
+
+  it "has just a single specific entry for metadata" do
+    expect(proxy.entries).to have(1).entry
+
+    expect(proxy.entries).to include :metadata
   end
 
   it "has the expected count of entries" do


### PR DESCRIPTION
* Remove remaining simple text files, inline into respective metadata
* Add created_at / updated_at timestamps to various metadata
* Expose external video service url for vimeo / youtube in metadata
* Enumerate text and resource ids in top-level project metadata
* Bump manifold compilation version to 1.2.0 to signify changes