### PR TITLE
[F] Improve filterable / ordering

### DIFF
--- a/api/app/models/application_record.rb
+++ b/api/app/models/application_record.rb
@@ -9,6 +9,7 @@ class ApplicationRecord < ActiveRecord::Base
   include ClassyEnum::ActiveRecord
   include ArelHelpers
   include DetectsSpam
+  include LazyOrdering
   include SliceWith
   include ValuesAt
   include WithAdvisoryLock::Concern

--- a/api/app/models/concerns/filterable.rb
+++ b/api/app/models/concerns/filterable.rb
@@ -5,10 +5,21 @@
 #
 # @see Filtering::Apply
 # @see Filtering::Applicator
+# @see Filtering::Config
 module Filterable
   extend ActiveSupport::Concern
 
-  class_methods do
+  include LazyOrdering
+
+  included do
+    extend Dry::Core::ClassAttributes
+
+    defines :filtering_config, type: Filtering::Types.Instance(Filtering::Config)
+
+    filtering_config Filtering::Config.new(self)
+  end
+
+  module ClassMethods
     # @param [Hash] params
     # @param [ActiveRecord::Relation] scope
     # @param [User, nil] user
@@ -22,6 +33,27 @@ module Filterable
     # @return [ActiveRecord::Relation<Filterable>]
     def apply_filtering_loads
       all
+    end
+
+    # @param [Hash] options (@see Filtering::Config for options)
+    # @return [void]
+    def configure_filtering!(**options)
+      filtering_config Filtering::Config.new(self, **options)
+    end
+
+    def filtering_recalculate_available_scopes!
+      filtering_config.recalculate_available_scopes!
+    rescue NameError
+      # :nocov:
+      # intentionally left blank, only occurs in CI
+      # :nocov:
+    end
+
+    # @api private
+    def singleton_method_added(name)
+      super
+
+      filtering_recalculate_available_scopes!
     end
   end
 end

--- a/api/app/models/concerns/lazy_ordering.rb
+++ b/api/app/models/concerns/lazy_ordering.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module LazyOrdering
+  extend ActiveSupport::Concern
+
+  SimpleSortDirection = Dry::Types["coercible.string"].default("asc").enum("asc", "desc").fallback("asc")
+
+  module ClassMethods
+    # @param [Symbol] column
+    # @return [ActiveRecord::Relation]
+    def lazily_order(column, raw_direction = :asc)
+      base = lazy_order_scope_for column
+
+      expr = lazy_order_expr_for(column, raw_direction: raw_direction)
+
+      base.order(expr)
+    end
+
+    def lazy_order_column_for(column)
+      method_name = :"#{column}_order_column"
+
+      if respond_to?(method_name)
+        public_send(method_name)
+      else
+        column
+      end.then { |expr| arel_attrify(expr) }
+    end
+
+    def lazy_order_expr_for(column, raw_direction: "asc")
+      direction = ::Filtering::Types::SortDirection[raw_direction]
+
+      method_name = :"#{column}_order_expression"
+
+      if respond_to?(method_name)
+        public_send(method_name, direction: direction)
+      else
+        attr = lazy_order_column_for column
+
+        attr.public_send(direction)
+      end
+    end
+
+    # @param [Symbol] column
+    # @return [ActiveRecord::Relation]
+    def lazy_order_scope_for(column)
+      scope_name = :"prepare_order_for_#{column}"
+
+      if respond_to?(scope_name)
+        all.public_send(scope_name)
+      else
+        all
+      end
+    end
+  end
+end

--- a/api/app/models/concerns/project_ordering.rb
+++ b/api/app/models/concerns/project_ordering.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Shared logic for
+module ProjectOrdering
+  extend ActiveSupport::Concern
+
+  ALLOWED_SORT_KEYS = %w(created_at updated_at publication_date title).freeze
+  ALLOWED_SORT_DIRECTIONS = %w(asc desc).freeze
+
+  ALLOWED_SORT_MAPPING = Filtering::SortMapping.from(*ALLOWED_SORT_KEYS)
+
+  ALLOWED_SORT_VALUES = ALLOWED_SORT_MAPPING.keys.freeze
+
+  DEFAULT_COLLECTION_SORT_VALUE = "created_at_desc"
+end

--- a/api/app/models/reading_group.rb
+++ b/api/app/models/reading_group.rb
@@ -57,7 +57,8 @@ class ReadingGroup < ApplicationRecord
 
   scope :by_keyword, ->(value) { build_keyword_scope(value) if value.present? }
   scope :with_sort_order, ->(value) { build_sort_order_scope(value) }
-  scope :with_order, ->(by = nil) { by.present? ? order(by) : order(created_at: :desc) }
+  scope :in_default_order, -> { order(created_at: :desc) }
+  scope :with_order, ->(by = nil) { by.present? ? order(by) : in_default_order }
   scope :non_public, -> { where.not(privacy: "public") }
   scope :visible_to_public, -> { where(privacy: "public") }
   scope :visible_to, ->(user) do

--- a/api/app/models/resource.rb
+++ b/api/app/models/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A resource is any asset our source document that is associated with a text.
 class Resource < ApplicationRecord
 
@@ -106,11 +108,9 @@ class Resource < ApplicationRecord
       .where("collection_resources.resource_collection_id = ?", id)
       .order("collection_resources.position ASC")
   }
-  scope :with_order, lambda { |by = nil|
-    return order(:sort_title, :created_at) unless by.present?
 
-    order(by)
-  }
+  scope :in_default_order, -> { order(sort_title: :asc, created_at: :asc) }
+  scope :with_order, ->(by = nil) { by.present? ? order(by) : in_default_order }
 
   # Callbacks
   before_validation :update_kind, :set_fingerprint!

--- a/api/app/models/settings.rb
+++ b/api/app/models/settings.rb
@@ -132,6 +132,10 @@ class Settings < ApplicationRecord
       end
     end
 
+    def default_project_sort
+      current.general.default_project_sort
+    end
+
     # Check if we {.update_from_environment? should update from the environment}
     # and {#update_from_environment! do so}.
     # @return [void]

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -83,13 +83,9 @@ class User < ApplicationRecord
   with_parsed_name :first_name, :last_name
   has_secure_password
 
-  # Scopes
   scope :by_email, ->(email) { where(arel_table[:email].matches("#{email}%")) if email.present? }
-  scope :with_order, ->(by) do
-    return order(:last_name, :first_name) unless by.present?
-
-    order(by)
-  end
+  scope :in_default_order, -> { order(:last_name, :first_name) }
+  scope :with_order, ->(by) { by.present? ? order(by) : in_default_order }
   scope :by_role, ->(role) { RoleName[role].then { |r| with_role(r.to_sym) if r.present? } }
   scope :by_cached_role, ->(*role) { where(role: role) }
   scope :email_confirmed, -> { where.not(email_confirmed_at: nil) }

--- a/api/app/operations/filtering/apply.rb
+++ b/api/app/operations/filtering/apply.rb
@@ -10,8 +10,8 @@ module Filtering
     # @param [Boolean] skip_pagination
     # @return [Searchkick::Relation]
     # @return [ActiveRecord::Relation] with kaminari data from {.by_pagination}.
-    def call(raw_params, scope:, user:, skip_pagination: false)
-      Filtering::Applicator.new(raw_params, scope: scope, user: user, skip_pagination: skip_pagination).call
+    def call(raw_params, scope:, user:, model: scope.model, skip_pagination: false)
+      Filtering::Applicator.new(raw_params, model: model, scope: scope, user: user, skip_pagination: skip_pagination).call
     end
   end
 end

--- a/api/app/serializers/v1/setting_serializer.rb
+++ b/api/app/serializers/v1/setting_serializer.rb
@@ -33,6 +33,7 @@ module V1
 
       contact_email: Types::Serializer::Email.optional,
       copyright: Types::String.optional,
+      default_project_sort: Types::String.optional,
       default_publisher: Types::String.optional,
       default_publisher_place: Types::String.optional,
       facebook: Types::String.optional,

--- a/api/app/services/filtering/config.rb
+++ b/api/app/services/filtering/config.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Filtering
+  # Per-model configuration for models that implement {Filterable}.
+  class Config
+    include Dry::Core::Memoizable
+    include Dry::Initializer[undefined: false].define -> do
+      param :model, Filtering::Types::ModelKlass
+
+      option :default_order_scope_name, Filtering::Types::Symbol, default: proc { :in_default_order }
+      option :order_param_name, Filtering::Types::Coercible::String, default: proc { "order" }
+      option :order_scope_name, Filtering::Types::Symbol, default: proc { :with_order }
+    end
+
+    SCOPE_PATTERN = /\A(?:by|with)_(?<param_name>.+)$/.freeze
+
+    EXCLUDED_SCOPES = %i[
+      by_cached_role
+      by_permitted_user
+      with_advisory_lock
+      with_advisory_lock_result
+      with_all_roles
+      with_any_roles
+      with_citable_children
+      with_citation
+      with_metadata
+      with_options
+      with_parsed_name
+      with_role
+      with_roles
+    ].freeze
+
+    PARAM_BLACKLIST = EXCLUDED_SCOPES.map { |scope| scope[SCOPE_PATTERN, :param_name] }.freeze
+
+    # @return [ActiveSupport::HashWithIndifferentAccess]
+    attr_reader :available_params
+
+    # @return [<Symbol>]
+    attr_reader :available_scopes
+
+    def initialize(...)
+      super
+
+      recalculate_available_scopes!
+    end
+
+    # @param [ActiveRecord::Relation] scope
+    # @return [ActiveRecord::Relation]
+    def apply_default_order!(scope)
+      scope.__send__(default_order_scope_name)
+    end
+
+    # @param [{ String => Object }] params
+    def applied_order?(params)
+      order_param_name.in?(params)
+    end
+
+    # @param [#to_s] param_name
+    def blacklisted_param?(param_name)
+      param_name.to_s.in?(PARAM_BLACKLIST)
+    end
+
+    def can_apply_default_order?
+      can_order? && has_default_order?
+    end
+
+    def can_order?
+      model.respond_to? order_scope_name
+    end
+
+    def has_default_order?
+      model.respond_to? default_order_scope_name
+    end
+
+    # @return [void]
+    def recalculate_available_scopes!
+      @available_scopes = calculate_available_scopes
+
+      @available_params = available_scopes.index_by do |scope|
+        scope[SCOPE_PATTERN, :param_name]
+      end.with_indifferent_access
+    end
+
+    def should_apply_default_order?(params)
+      can_apply_default_order? && !applied_order?(params)
+    end
+
+    private
+
+    # @return [<Symbol>]
+    def calculate_available_scopes
+      model.methods.grep(SCOPE_PATTERN) - EXCLUDED_SCOPES
+    end
+  end
+end

--- a/api/app/services/filtering/sort_mapping.rb
+++ b/api/app/services/filtering/sort_mapping.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Filtering
+  class SortMapping < ::Types::FlexibleStruct
+    DIRS = Filtering::Types::SortDirection.values.freeze
+
+    attribute :key, Filtering::Types::Coercible::String
+    attribute :property, Filtering::Types::Coercible::String
+    attribute :direction, Filtering::Types::SortDirection
+
+    alias dir direction
+
+    class << self
+      # @param [<String>] properties
+      # @return [ActiveSupport::HashWithIndifferentAccess{ String => Filtering::SortMapping }]
+      def from(*properties)
+        properties.flatten!
+
+        properties.product(DIRS).each_with_object({}.with_indifferent_access) do |(property, direction), h|
+          key = "#{property}_#{direction}"
+
+          mapping = Filtering::SortMapping.new(key: key, property: property, direction: direction)
+
+          h[key] = mapping
+        end.freeze
+      end
+    end
+  end
+end

--- a/api/app/services/filtering/types.rb
+++ b/api/app/services/filtering/types.rb
@@ -4,6 +4,8 @@ module Filtering
   module Types
     include Dry.Types
 
+    ModelKlass = Class.constrained(lt: ::Filterable)
+
     Params = Coercible::Hash.map(Coercible::String, Any).constructor do |value|
       case value
       when ActionController::Parameters
@@ -16,6 +18,8 @@ module Filtering
     end.fallback { {} }
 
     Scope = Instance(::ActiveRecord::Relation)
+
+    SortDirection = Dry::Types["coercible.string"].default("asc").enum("asc", "desc").fallback("asc")
 
     User = Instance(::AnonymousUser) | Instance(::User)
   end

--- a/api/app/services/project_collections/cache_collection_projects.rb
+++ b/api/app/services/project_collections/cache_collection_projects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ProjectCollections
   class CacheCollectionProjects < ActiveInteraction::Base
     record :project_collection
@@ -8,12 +10,12 @@ module ProjectCollections
     delegate :number_of_projects, to: :project_collection
     delegate :projects, to: :project_collection
     delegate :collection_projects, to: :project_collection
-    delegate :project_sorting, to: :project_collection
+    delegate :sort_order, to: :project_collection
 
     validate :must_be_smart!
 
     def execute
-      valid_projects = query.limit(number_of_projects).order(project_sorting)
+      valid_projects = query.limit(number_of_projects).in_specific_order(sort_order, mode: :collection)
 
       return project_collection if valid_projects.pluck(:id) == projects.pluck(:id)
 
@@ -62,6 +64,5 @@ module ProjectCollections
         array << Project.by_subject(subjects) if subjects.exists?
       end
     end
-
   end
 end

--- a/api/app/services/setting_sections/general.rb
+++ b/api/app/services/setting_sections/general.rb
@@ -27,6 +27,7 @@ module SettingSections
 
     attribute :contact_email, :string
     attribute :copyright, :string
+    attribute :default_project_sort, :string, default: "title_asc"
     attribute :default_publisher, :string
     attribute :default_publisher_place, :string
     attribute :facebook, :string

--- a/api/spec/models/project_collection_spec.rb
+++ b/api/spec/models/project_collection_spec.rb
@@ -47,12 +47,13 @@ RSpec.describe ProjectCollection, type: :model do
     let(:project_collection) { FactoryBot.create(:project_collection, sort_order: "updated_at_desc") }
 
     it "returns a string order argument joined to project" do
-      expect(project_collection.project_sorting).to eq "projects.updated_at desc, projects.title asc NULLS LAST"
+      expect(project_collection.project_sorting).to match_array [["updated_at", "desc"]]
     end
 
     it "defaults to created_at desc if invalid attribute" do
       project_collection.update sort_order: "bad_attribute"
-      expect(project_collection.project_sorting).to eq "projects.created_at desc, projects.title asc NULLS LAST"
+
+      expect(project_collection.project_sorting).to match_array [["created_at", "desc"]]
     end
   end
 

--- a/api/spec/models/project_spec.rb
+++ b/api/spec/models/project_spec.rb
@@ -188,6 +188,12 @@ RSpec.describe Project, type: :model do
         results = Project.filtered(featured: 1)
         expect(results.length).to be 1
       end
+
+      it "applies a default scope" do
+        scope = described_class.filtered({})
+
+        expect(scope.order_values).to have(2).items
+      end
     end
   end
 


### PR DESCRIPTION
* Add support for a default scope and auto-detecting based on whether or not the model is orderable, and has default scope method defined
* Detect whether the order param was applied, and if not, apply the default scope
* Expose the ability to set the default scope for projects in settings using the same values as ProjectCollections
* Clean up some of the project collection sorting logic not to be so dependent on raw strings and instead actual programmatic calls
* Use sort title for project collections and universally when sorting projects by title
* Blacklist some params that should not be included in filters ever for any reason

Resolves RET-1727