### PR TITLE
[B] Fix GHA apt packages

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -2,11 +2,11 @@ name: "Setup Ruby"
 runs:
   using: "composite"
   steps:
-    - name: "Install Dependencies"
-      uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: imagemagick libpq-dev
-        version: 1.0
+    - name: "Install Dependent libraries"
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get -yqq install imagemagick libpq-dev libvips libvips-dev
 
     - name: "Install Ruby 2.7.8"
       uses: ruby/setup-ruby@v1

--- a/api/spec/rails_helper.rb
+++ b/api/spec/rails_helper.rb
@@ -117,6 +117,16 @@ end
 
 Rails.application.eager_load!
 
+# Ensure imagemagick is loaded and accessible. If it's not, there is no sense
+# in running the test suite because dozens of tests are gonna fail.
+begin
+  MiniMagick.cli
+rescue MiniMagick::Error => e
+  # :nocov:
+  raise "Failed to load MiniMagick CLI, aborting tests: #{e.message}"
+  # :nocov:
+end
+
 RSpec.configure do |config|
   config.include TestHelpers
   config.extend WithModel


### PR DESCRIPTION
There is an underlying issue with the cache-apt-pkgs-action we are using that is yet unresolved, so we are switching to just installing packages manually with apt.

Additionally, rspec will now bail out early if imagemagick is not available instead of letting the whole suite run only to fail in 10m.