### PR TITLE
[F] Improve Flags API

### DIFF
--- a/api/app/authorizers/application_authorizer.rb
+++ b/api/app/authorizers/application_authorizer.rb
@@ -27,6 +27,11 @@ class ApplicationAuthorizer < Authority::Authorizer
     self.class.bulk_deletable_by?(user, options)
   end
 
+  # @note Defer to class option by default.
+  def flags_resolvable_by?(user, options = {})
+    self.class.flags_resolvable_by?(user, options)
+  end
+
   def has_any_role?(user, *roles, on: resource)
     roles.flatten.any? do |role|
       has_role?(user, role, on: on)
@@ -99,7 +104,7 @@ class ApplicationAuthorizer < Authority::Authorizer
     # @param [User, AnonymousUser, nil] user
     # @param [Hash] options
     def bulk_deletable_by?(user, _options = {})
-      has_any_role? user, :admin
+      admin_permissions?(user)
     end
 
     # Any class method from Authority::Authorizer that isn't overridden
@@ -113,6 +118,12 @@ class ApplicationAuthorizer < Authority::Authorizer
       # 'Whitelist' strategy for security: anything not explicitly allowed is
       # considered forbidden.
       config.allowed_by_default
+    end
+
+    # @param [User, AnonymousUser, nil] user
+    # @param [Hash] options
+    def flags_resolvable_by?(user, _options = {})
+      admin_permissions?(user)
     end
 
     def reading_groups_disabled?

--- a/api/app/authorizers/flag_authorizer.rb
+++ b/api/app/authorizers/flag_authorizer.rb
@@ -1,17 +1,6 @@
+# frozen_string_literal: true
+
 class FlagAuthorizer < ApplicationAuthorizer
-
-  def self.default(_able, _user, _options = {})
-    false
-  end
-
-  def self.creatable_by?(_user, _options = {})
-    true
-  end
-
-  def self.deletable_by?(_user, _options = {})
-    true
-  end
-
   def creatable_by?(user, _options = {})
     known_user?(user)
   end
@@ -20,4 +9,17 @@ class FlagAuthorizer < ApplicationAuthorizer
     creator_or_has_editor_permissions?(user, resource)
   end
 
+  class << self
+    def default(_able, _user, _options = {})
+      false
+    end
+
+    def creatable_by?(user, _options = {})
+      authenticated? user
+    end
+
+    def deletable_by?(user, _options = {})
+      authenticated? user
+    end
+  end
 end

--- a/api/app/controllers/api/v1/annotations_controller.rb
+++ b/api/app/controllers/api/v1/annotations_controller.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 module API
   module V1
     class AnnotationsController < ApplicationController
       config.pagination_enforced = true
 
       resourceful! Annotation do
-        Annotation.includes([:creator, :flags])
-          .filtered(with_pagination!(annotation_filter_params))
+        Annotation.filtered(with_pagination!(annotation_filter_params))
       end
 
       def index

--- a/api/app/controllers/api/v1/bulk_deletions_controller.rb
+++ b/api/app/controllers/api/v1/bulk_deletions_controller.rb
@@ -9,8 +9,6 @@ module API
 
       authority_actions annotations: "bulk_delete", reading_groups: "bulk_delete", users: "bulk_delete"
 
-      rescue_from StandardError, with: :render_error_response
-
       def annotations
         bulk_delete! ::Annotation
       end

--- a/api/app/controllers/api/v1/comments_controller.rb
+++ b/api/app/controllers/api/v1/comments_controller.rb
@@ -1,13 +1,17 @@
+# frozen_string_literal: true
+
 module API
   module V1
     # Comments controller
     class CommentsController < ApplicationController
       before_action :set_subject
 
+      INCLUDES = %i[creator flags].freeze
+
       resourceful! Comment, authorize_options: { except: [:index, :show] } do
         Comment.filtered(
           with_pagination!(comment_filter_params),
-          scope: comment_scope.roots_and_descendants_preordered
+          scope: comment_scope.includes(*INCLUDES).roots_and_descendants_preordered
         )
       end
 
@@ -19,7 +23,7 @@ module API
         @comments = load_comments
         render_multiple_resources(
           @comments,
-          include: includes,
+          include: INCLUDES,
           location: index_location
         )
       end
@@ -36,8 +40,8 @@ module API
         @comment = authorize_and_create_comment(comment_params)
         render_single_resource(
           @comment,
-          location: comment_location(@comment),
-          include: includes
+          include: INCLUDES,
+          location: comment_location(@comment)
         )
       end
 
@@ -56,10 +60,6 @@ module API
       end
 
       private
-
-      def includes
-        [:creator]
-      end
 
       def comment_location(comment)
         case comment.subject_type
@@ -90,7 +90,6 @@ module API
           @subject = Resource.friendly.find(params[:resource_id])
         end
       end
-
     end
   end
 end

--- a/api/app/controllers/api/v1/flags_controller.rb
+++ b/api/app/controllers/api/v1/flags_controller.rb
@@ -1,44 +1,78 @@
+# frozen_string_literal: true
+
 module API
   module V1
-    # Flags controller
     class FlagsController < ApplicationController
-      before_action :set_subject
+      before_action :set_flaggable!
 
       resourceful! Flag do
         current_user.created_flags
       end
 
+      authorize_actions_for ::Flag
+
+      authority_actions resolve_all: "resolve_flags"
+
       def create
-        @flag = Flag.create(creator: current_user, flaggable: @subject, message: flag_params[:message])
+        @flag = current_user.created_flags.where(flaggable: @flaggable).first_or_initialize
+
         authorize_action_for @flag
+
+        @flag.assign_attributes(flag_params)
+
+        # Allow a user to flag and unflag something without
+        # triggering multiple notifications.
+        @flag.resolved_by_creator = false
+
+        @flag.save!
+
         render_single_resource(
-          @subject.reload,
-          serializer: ::V1::AnnotationSerializer,
+          @flaggable.reload,
+          serializer: @flaggable_serializer,
           location: nil
         )
       end
 
+      # @see Flag#resolve!
+      # @note "Destroying" a flag actually just resolves it to prevent duplicate flags.
       def destroy
-        @flag = current_user.created_flags.by_flaggable(@subject).first
+        @flag = current_user.created_flags.by_flaggable(@flaggable).first!
+
         authorize_action_for @flag
-        @flag.destroy
+
+        @flag.resolve!(resolver: current_user)
+
         render_single_resource(
-          @subject.reload,
-          serializer: ::V1::AnnotationSerializer,
+          @flaggable.reload,
+          serializer: @flaggable_serializer,
+          location: nil
+        )
+      end
+
+      def resolve_all
+        authorize_action_for @flaggable
+
+        @flaggable.resolve_flags!(resolver: current_user)
+
+        render_single_resource(
+          @flaggable.reload,
+          serializer: @flaggable_serializer,
           location: nil
         )
       end
 
       private
 
-      def set_subject
+      # @return [void]
+      def set_flaggable!
         if params[:annotation_id]
-          @subject = Annotation.find(params[:annotation_id])
+          @flaggable_serializer = ::V1::AnnotationSerializer
+          @flaggable = Annotation.find(params[:annotation_id])
         elsif params[:comment_id]
-          @subject = Comment.find(params[:comment_id])
+          @flaggable_serializer = ::V1::CommentSerializer
+          @flaggable = Comment.find(params[:comment_id])
         end
       end
-
     end
   end
 end

--- a/api/app/jobs/flags/refresh_all_status_data_job.rb
+++ b/api/app/jobs/flags/refresh_all_status_data_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Flags
+  # Scheduled job that runs on an interval to make sure that counter caches
+  # and other {FlagStatus} data is up to date on every {FlaggableResource}.
+  #
+  # @see Flags::RefreshAllStatusData
+  class RefreshAllStatusDataJob < ApplicationJob
+    queue_as :low_priority
+
+    # @return [void]
+    def perform
+      ManifoldApi::Container["flags.refresh_all_status_data"].()
+    end
+  end
+end

--- a/api/app/models/annotation.rb
+++ b/api/app/models/annotation.rb
@@ -357,7 +357,7 @@ class Annotation < ApplicationRecord
 
   class << self
     def apply_filtering_loads
-      super.includes(:annotation_node, :creator, :membership_comments, :project, text_section: { text: %i[titles] })
+      super.includes(:annotation_node, :creator, :flags, :membership_comments, :project, text_section: { text: %i[titles] })
     end
 
     # @param [ReadingGroupMembership, String] rgm

--- a/api/app/models/comment.rb
+++ b/api/app/models/comment.rb
@@ -67,10 +67,6 @@ class Comment < ApplicationRecord
     parent && parent.creator_id == creator_id
   end
 
-  def flagged_by?(user)
-    flags.where(creator: user).count.positive?
-  end
-
   def author_created
     creator.project_author_of? project
   end

--- a/api/app/models/concerns/flaggable_resource.rb
+++ b/api/app/models/concerns/flaggable_resource.rb
@@ -1,11 +1,55 @@
+# frozen_string_literal: true
+
+# A concern that makes a model able to receive {Flag}s.
+#
+# @see FlagStatus
 module FlaggableResource
   extend ActiveSupport::Concern
 
   included do
     has_many :flags, as: :flaggable, dependent: :destroy, inverse_of: :flaggable
+    has_one :flag_status, as: :flaggable, inverse_of: :flaggable
+
+    after_touch :refresh_flag_status_data!
   end
 
-  def flagged?
-    flags_count.positive?
+  # @param [User, AnonymousUser, nil] user
+  def flagged_by?(user)
+    return false unless user.kind_of?(User) && user.persisted?
+
+    user.id.in?(flagger_ids)
+  end
+
+  # @return [void]
+  def refresh_flag_status_data!
+    reload_flag_status
+
+    new_flag_data = flag_status&.to_data || FlagStatus::EMPTY_DATA
+
+    update_columns(**new_flag_data)
+  end
+
+  # @see Flags#resolve!
+  # @return [FlaggableResource]
+  def resolve_flags!(**options)
+    flags.sans_resolved.find_each do |flag|
+      flag.resolve!(**options)
+    end
+
+    reload
+
+    return self
+  end
+
+  module ClassMethods
+    # @api private
+    # @see Flags::RefreshStatusData
+    # @return [Hash]
+    def for_refresh_query
+      {
+        flaggable_type: connection.quote(model_name.name),
+        table_name: quoted_table_name,
+      }
+    end
   end
 end

--- a/api/app/models/concerns/view.rb
+++ b/api/app/models/concerns/view.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 module View
   extend ActiveSupport::Concern
 
   def readonly?
+    # :nocov:
     true
+    # :nocov:
   end
 end

--- a/api/app/models/flag.rb
+++ b/api/app/models/flag.rb
@@ -1,38 +1,50 @@
-# A flag that flags a flaggable for review.
-class Flag < ApplicationRecord
+# frozen_string_literal: true
 
-  # Authority
+# A flag that marks a {FlaggableResource} for review.
+class Flag < ApplicationRecord
   include Authority::Abilities
   include SerializedAbilitiesFor
 
-  # Concerns
   include TrackedCreator
 
-  # Scopes
-  scope :by_creator, lambda { |creator|
-    next all unless creator.present?
+  strip_attributes only: %i[message]
 
-    where(creator: creator)
-  }
-  scope :by_flaggable, lambda { |flaggable|
-    next all unless flaggable.present?
+  scope :by_creator, ->(creator) { where(creator: creator) if creator.present? }
+  scope :by_flaggable, ->(flaggable) { where(flaggable: flaggable) if flaggable.present? }
+  scope :sans_resolved, -> { with_resolved.where(resolved_at: nil) }
+  scope :only_resolved, -> { with_resolved.where.not(resolved_at: nil) }
+  scope :with_resolved, -> { unscope(where: :resolved_at) }
 
-    where(flaggable: flaggable)
-  }
+  belongs_to :flaggable, polymorphic: true, touch: true
 
-  # Associations
-  belongs_to :flaggable, polymorphic: true, counter_cache: :flags_count
+  validates :creator_id, uniqueness: { scope: %i[flaggable_type flaggable_id] }
 
-  # # Validations
-  # validates :flaggable, presence: true
+  after_commit :enqueue_flag_notifications!, on: :create
 
-  # Callbacks
-  after_commit :enqueue_flag_notifications, on: [:create]
+  # @param [User, nil] resolver
+  # @return [void]
+  def resolve!(resolver: nil)
+    self.resolved_at ||= Time.current
+
+    if creator == resolver
+      self.resolved_by_creator = true
+    end
+
+    save!
+  end
+
+  # @!attribute [r] resolved
+  # Boolean state of {#resolved_at}
+  # @return [Boolean]
+  def resolved
+    resolved_at?
+  end
+
+  alias resolved? resolved
 
   private
 
-  def enqueue_flag_notifications
+  def enqueue_flag_notifications!
     Notifications::EnqueueFlagNotificationsJob.perform_later id
   end
-
 end

--- a/api/app/models/flag_status.rb
+++ b/api/app/models/flag_status.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# A view that calculates counts and other metadata for a {FlaggableResource}
+# based on uniquely associated {Flag} records.
+class FlagStatus < ApplicationRecord
+  include View
+
+  self.primary_key = :flaggable_id
+
+  belongs_to :flaggable, inverse_of: :flag_status, polymorphic: true
+
+  COUNTS = %i[
+    flags_count
+    resolved_flags_count
+    unresolved_flags_count
+  ].freeze
+
+  EMPTY_DATA = {
+    flagger_ids: [].freeze,
+    flags_count: 0,
+    resolved_flags_count: 0,
+    unresolved_flags_count: 0,
+  }.freeze
+
+  # @return [Hash]
+  def to_data
+    slice(*EMPTY_DATA.keys).symbolize_keys
+  end
+end

--- a/api/app/operations/flags/refresh_all_status_data.rb
+++ b/api/app/operations/flags/refresh_all_status_data.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Flags
+  # @see Flag
+  # @see FlagStatus
+  # @see FlaggableResource
+  # @see Flags::RefreshAllStatusDataJob
+  # @see Flags::RefreshStatusData
+  class RefreshAllStatusData
+    include Dry::Monads[:result, :do]
+    include ManifoldApi::Deps[
+      refresh_status_data: "flags.refresh_status_data"
+    ]
+
+    FLAGGABLE = {
+      annotations: ::Annotation,
+      comments: ::Comment,
+    }.freeze
+
+    # @return [{ Symbol => Integer }]
+    def call
+      refreshed = FLAGGABLE.transform_values do |flaggable_klass|
+        yield refresh_status_data.(flaggable_klass)
+      end
+
+      Success refreshed
+    end
+  end
+end

--- a/api/app/operations/flags/refresh_status_data.rb
+++ b/api/app/operations/flags/refresh_status_data.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Flags
+  # @see Flag
+  # @see FlagStatus
+  # @see FlaggableResource
+  class RefreshStatusData
+    include Dry::Monads[:result, :do]
+    include QueryOperation
+
+    BASE_QUERY = <<~SQL
+    WITH flag_status_data AS (
+      SELECT
+        fl.id AS flaggable_id,
+        fd.flagger_ids,
+        fd.flags_count,
+        fd.resolved_flags_count,
+        fd.unresolved_flags_count
+      FROM %<table_name>s fl
+      LEFT OUTER JOIN flag_statuses fs ON fs.flaggable_type = %<flaggable_type>s AND fs.flaggable_id = fl.id
+      LEFT JOIN LATERAL (
+        SELECT
+          COALESCE(fs.flagger_ids, '{}'::uuid[]) AS flagger_ids,
+          COALESCE(fs.flags_count, 0) AS flags_count,
+          COALESCE(fs.resolved_flags_count, 0) AS resolved_flags_count,
+          COALESCE(fs.unresolved_flags_count, 0) AS unresolved_flags_count
+      ) fd ON true
+      WHERE
+      (
+        fl.flagger_ids IS DISTINCT FROM fd.flagger_ids
+        OR
+        fl.flags_count IS DISTINCT FROM fd.flags_count
+        OR
+        fl.resolved_flags_count IS DISTINCT FROM fd.resolved_flags_count
+        OR
+        fl.unresolved_flags_count IS DISTINCT FROM fd.unresolved_flags_count
+      )
+    )
+    UPDATE %<table_name>s fl SET
+      flagger_ids = fd.flagger_ids,
+      flags_count = fd.flags_count,
+      resolved_flags_count = fd.resolved_flags_count,
+      unresolved_flags_count = fd.unresolved_flags_count
+    FROM flag_status_data fd
+    WHERE fd.flaggable_id = fl.id
+    SQL
+
+    # @param [Class<FlaggableResource>] flaggable_klass
+    # @return [Dry::Monads::Success(Integer)]
+    def call(flaggable_klass)
+      query = with_sql_template BASE_QUERY, flaggable_klass.for_refresh_query
+
+      Success sql_update!(query)
+    end
+  end
+end

--- a/api/app/serializers/v1/comment_serializer.rb
+++ b/api/app/serializers/v1/comment_serializer.rb
@@ -1,28 +1,39 @@
+# frozen_string_literal: true
+
 module V1
   class CommentSerializer < ManifoldSerializer
-
     include ::V1::Concerns::ManifoldSerializer
+
+    FLAG_METADATA_VISIBLE = ->(object, params) { flag_metadata_visible?(object, params) }
 
     abilities
     typed_attribute :parent_id, Types::Serializer::ID.optional
     typed_attribute :created_at, Types::DateTime.meta(read_only: true)
-    typed_attribute :flags_count, Types::Integer.meta(read_only: true)
     typed_attribute :deleted, Types::Bool
     typed_attribute :children_count, Types::Integer.meta(read_only: true)
     typed_attribute :sort_order, Types::Integer.meta(read_only: true)
     typed_attribute :author_created, Types::Bool.meta(read_only: true)
-    typed_attribute :flagged, Types::Bool.meta(read_only: true) do |object, params|
-      next false unless authenticated?(params)
-
-      object.flagged_by?(params[:current_user])
-    end
     typed_attribute :body, Types::String do |object, params|
       object.deleted == true ? deleted_body(object, params) : object.body
+    end
+
+    typed_attribute(:flagged, Types::Bool.meta(read_only: true)) do |object, params|
+      object.flagged_by?(params[:current_user])
+    end
+
+    typed_has_many :flags, serializer: ::V1::FlagSerializer, record_type: "flag", if: FLAG_METADATA_VISIBLE
+
+    ::FlagStatus::COUNTS.each do |attr|
+      typed_attribute attr, Types::Integer.meta(read_only: true), if: FLAG_METADATA_VISIBLE
     end
 
     has_one_creator
 
     class << self
+      def flag_metadata_visible?(_object, params)
+        admin?(params)
+      end
+
       def include_abilities?(_object, _params)
         true
       end
@@ -33,6 +44,5 @@ module V1
         nil
       end
     end
-
   end
 end

--- a/api/app/serializers/v1/concerns/manifold_serializer.rb
+++ b/api/app/serializers/v1/concerns/manifold_serializer.rb
@@ -170,6 +170,10 @@ module V1
           hash.deep_transform_keys { |key| key.to_s.camelize(:lower) }.symbolize_keys!
         end
 
+        def admin?(params)
+          authenticated?(params) && params[:current_user].admin?
+        end
+
         def authenticated?(params)
           params[:current_user].present?
         end

--- a/api/app/serializers/v1/flag_serializer.rb
+++ b/api/app/serializers/v1/flag_serializer.rb
@@ -1,13 +1,17 @@
+# frozen_string_literal: true
+
 module V1
   class FlagSerializer < ManifoldSerializer
     include ::V1::Concerns::ManifoldSerializer
 
     typed_attribute :created_at, Types::DateTime.meta(read_only: true)
-    typed_attribute :message, Types::String
+    typed_attribute :resolved_at, Types::DateTime.meta(read_only: true)
+    typed_attribute :resolved, Types::Bool.meta(read_only: true)
+    typed_attribute :resolved_by_creator, Types::Bool.meta(read_only: true)
+    typed_attribute :message, Types::String.optional.meta(read_only: true)
 
     typed_belongs_to :creator,
                      record_type: :user,
                      serializer: ::V1::UserSerializer
-
   end
 end

--- a/api/config/initializers/authority.rb
+++ b/api/config/initializers/authority.rb
@@ -29,6 +29,7 @@ Authority.configure do |config|
     edit: "update",
     update: "update",
     destroy: "delete",
+    resolve_flags: "resolve_flags",
     lookup: "lookup"
   }
 
@@ -51,6 +52,7 @@ Authority.configure do |config|
     fully_read: "fully_readable",
     list: "listable",
     bulk_delete: "bulk_deletable",
+    resolve_flags: "flags_resolvable",
     manage: "manageable",
     manage_project_exportations: "project_exportations_manageable",
     create_project_exportations: "project_exportations_creatable",

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,7 +1,17 @@
+# frozen_string_literal: true
+
 require "sidekiq/web"
 require "zhong/web"
 
 Rails.application.routes.draw do
+  concern :flaggable do
+    resource :flags, controller: "/api/v1/flags", only: [:create, :destroy] do
+      member do
+        delete :resolve_all
+      end
+    end
+  end
+
   concern :permissible do
     resources :permissions,
               only: [:create, :index, :show, :update, :destroy],
@@ -127,13 +137,13 @@ Rails.application.routes.draw do
 
       resources :comments, only: [:show, :update, :destroy] do
         namespace :relationships do
-          resource :flags, controller: "/api/v1/flags", only: [:create, :destroy]
+          concerns :flaggable
         end
       end
 
       resources :annotations, only: [:update, :destroy], controller: "text_sections/relationships/annotations" do
         namespace :relationships do
-          resource :flags, controller: "/api/v1/flags", only: [:create, :destroy]
+          concerns :flaggable
           resources :comments, controller: "/api/v1/comments"
         end
       end

--- a/api/db/migrate/20241212183245_add_flag_resolution.rb
+++ b/api/db/migrate/20241212183245_add_flag_resolution.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+class AddFlagResolution < ActiveRecord::Migration[6.1]
+  FLAGGABLES = %i[annotations comments].freeze
+
+  def change
+    FLAGGABLES.each do |flaggable|
+      prepare_new_flag_counts_for! flaggable
+    end
+
+    prune_flags_table!
+
+    change_table :flags do |t|
+      t.boolean :resolved_by_creator, null: false, default: false
+
+      t.timestamp :resolved_at
+
+      t.index %i[creator_id flaggable_type flaggable_id], unique: true, name: "index_flags_uniqueness"
+      t.index :resolved_at
+
+      t.foreign_key :users, column: :creator_id, on_delete: :cascade
+    end
+
+    change_column_null :flags, :creator_id, false
+    change_column_null :flags, :flaggable_type, false
+    change_column_null :flags, :flaggable_id, false
+
+    reset_flag_status!
+  end
+
+  private
+
+  def prepare_new_flag_counts_for!(flaggable)
+    reversible do |dir|
+      dir.up do
+        say_with_time "Correcting any null flags_count for #{flaggable}" do
+          exec_update(<<~SQL.strip_heredoc.strip)
+          UPDATE #{flaggable} SET flags_count = 0 WHERE flags_count IS NULL;
+          SQL
+        end
+
+        say_with_time "Normalizing count type for #{flaggable}" do
+          execute(<<~SQL.strip_heredoc.strip)
+          ALTER TABLE #{flaggable} ALTER COLUMN flags_count SET DATA TYPE bigint USING flags_count::bigint;
+          SQL
+        end
+      end
+
+      dir.down do
+        say_with_time "Reverting count type for #{flaggable}" do
+          execute(<<~SQL.strip_heredoc.strip)
+          ALTER TABLE #{flaggable} ALTER COLUMN flags_count SET DATA TYPE integer USING flags_count::integer;
+          SQL
+        end
+      end
+    end
+
+    change_column_null flaggable, :flags_count, false
+
+    change_table flaggable do |t|
+      t.bigint :resolved_flags_count, null: false, default: 0
+      t.bigint :unresolved_flags_count, null: false, default: 0
+      t.uuid :flagger_ids, null: false, default: [], array: true
+    end
+  end
+
+  # This table may need some TLC to support stricter constraints on it with longer-running tenants.
+  #
+  # @return [void]
+  def prune_flags_table!
+    reversible do |dir|
+      dir.up do
+        say_with_time "Delete any flags that don't match existing users" do
+          exec_delete(<<~SQL.strip_heredoc)
+          DELETE FROM flags WHERE creator_id IS NULL OR creator_id NOT IN (SELECT id FROM users);
+          SQL
+        end
+
+        say_with_time "Delete any possible flags that have no flaggable associated" do
+          exec_delete(<<~SQL.strip_heredoc)
+          DELETE FROM flags WHERE
+            CASE flaggable_type
+            WHEN 'Annotation' THEN
+              flaggable_id NOT IN (SELECT id FROM annotations)
+            WHEN 'Comment' THEN
+              flaggable_id NOT IN (SELECT id FROM comments)
+            ELSE
+              TRUE
+            END
+          SQL
+        end
+
+        say_with_time "Pruning flags for unique creator constraint" do
+          exec_delete(<<~SQL.strip_heredoc)
+          WITH flags_to_keep AS (
+            SELECT DISTINCT ON (creator_id, flaggable_type, flaggable_id)
+              id
+              FROM flags
+              ORDER BY creator_id, flaggable_type, flaggable_id, created_at ASC
+          )
+          DELETE FROM flags
+          WHERE id NOT IN (SELECT id FROM flags_to_keep)
+          SQL
+        end
+      end
+    end
+  end
+
+  # @return [void]
+  def reset_flag_status!
+    reversible do |dir|
+      dir.up do
+        say_with_time "Resetting Annotation flag counts" do
+          exec_update(<<~SQL.strip_heredoc)
+          WITH flag_counts AS (
+            SELECT
+              flaggable_type AS flaggable_type,
+              flaggable_id AS flaggable_id,
+              array_agg(DISTINCT creator_id) FILTER (WHERE NOT resolved_by_creator) AS flagger_ids,
+              COUNT(DISTINCT id) AS flags_count,
+              COUNT(DISTINCT id) FILTER (WHERE resolved_at IS NOT NULL) AS resolved_flags_count,
+              COUNT(DISTINCT id) FILTER (WHERE resolved_at IS NULL) AS unresolved_flags_count
+            FROM flags
+            GROUP BY 1, 2
+          ), full_flag_counts AS (
+            SELECT
+              fl.id AS flaggable_id,
+              COALESCE(fc.flagger_ids, '{}'::uuid[]) AS flagger_ids,
+              COALESCE(fc.flags_count, 0) AS flags_count,
+              COALESCE(fc.resolved_flags_count, 0) AS resolved_flags_count,
+              COALESCE(fc.unresolved_flags_count, 0) AS unresolved_flags_count
+            FROM annotations fl
+            LEFT OUTER JOIN flag_counts fc ON fc.flaggable_type = 'Annotation' AND fc.flaggable_id = fl.id
+          )
+          UPDATE annotations fl SET
+            flagger_ids = fc.flagger_ids,
+            flags_count = fc.flags_count,
+            resolved_flags_count = fc.resolved_flags_count,
+            unresolved_flags_count = fc.unresolved_flags_count
+          FROM full_flag_counts fc
+          WHERE fc.flaggable_id = fl.id
+          SQL
+        end
+
+        say_with_time "Resetting Comment flag counts" do
+          exec_update(<<~SQL.strip_heredoc)
+          WITH flag_counts AS (
+            SELECT
+              flaggable_type AS flaggable_type,
+              flaggable_id AS flaggable_id,
+              array_agg(DISTINCT creator_id) AS flagger_ids,
+              COUNT(DISTINCT id) AS flags_count,
+              COUNT(DISTINCT id) FILTER (WHERE resolved_at IS NOT NULL) AS resolved_flags_count,
+              COUNT(DISTINCT id) FILTER (WHERE resolved_at IS NULL) AS unresolved_flags_count
+            FROM flags
+            GROUP BY 1, 2
+          ), full_flag_counts AS (
+            SELECT
+              fl.id AS flaggable_id,
+              COALESCE(fc.flagger_ids, '{}'::uuid[]) AS flagger_ids,
+              COALESCE(fc.flags_count, 0) AS flags_count,
+              COALESCE(fc.resolved_flags_count, 0) AS resolved_flags_count,
+              COALESCE(fc.unresolved_flags_count, 0) AS unresolved_flags_count
+            FROM comments fl
+            LEFT OUTER JOIN flag_counts fc ON fc.flaggable_type = 'Comment' AND fc.flaggable_id = fl.id
+          )
+          UPDATE comments fl SET
+            flagger_ids = fc.flagger_ids,
+            flags_count = fc.flags_count,
+            resolved_flags_count = fc.resolved_flags_count,
+            unresolved_flags_count = fc.unresolved_flags_count
+          FROM full_flag_counts fc
+          WHERE fc.flaggable_id = fl.id
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/api/db/migrate/20241212214525_create_flag_statuses.rb
+++ b/api/db/migrate/20241212214525_create_flag_statuses.rb
@@ -1,0 +1,5 @@
+class CreateFlagStatuses < ActiveRecord::Migration[6.1]
+  def change
+    create_view :flag_statuses
+  end
+end

--- a/api/db/structure.sql
+++ b/api/db/structure.sql
@@ -261,10 +261,13 @@ CREATE TABLE public.annotations (
     resource_collection_id uuid,
     events_count integer DEFAULT 0,
     orphaned boolean DEFAULT false NOT NULL,
-    flags_count integer DEFAULT 0,
+    flags_count bigint DEFAULT 0 NOT NULL,
     reading_group_id uuid,
     deleted_at timestamp without time zone,
-    marked_for_purge_at timestamp without time zone
+    marked_for_purge_at timestamp without time zone,
+    resolved_flags_count bigint DEFAULT 0 NOT NULL,
+    unresolved_flags_count bigint DEFAULT 0 NOT NULL,
+    flagger_ids uuid[] DEFAULT '{}'::uuid[] NOT NULL
 );
 
 
@@ -283,9 +286,12 @@ CREATE TABLE public.comments (
     updated_at timestamp without time zone NOT NULL,
     deleted boolean DEFAULT false,
     children_count integer DEFAULT 0,
-    flags_count integer DEFAULT 0,
+    flags_count bigint DEFAULT 0 NOT NULL,
     sort_order integer,
-    events_count integer DEFAULT 0
+    events_count integer DEFAULT 0,
+    resolved_flags_count bigint DEFAULT 0 NOT NULL,
+    unresolved_flags_count bigint DEFAULT 0 NOT NULL,
+    flagger_ids uuid[] DEFAULT '{}'::uuid[] NOT NULL
 );
 
 
@@ -1370,13 +1376,30 @@ CREATE TABLE public.features (
 
 CREATE TABLE public.flags (
     id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
-    creator_id uuid,
-    flaggable_id uuid,
-    flaggable_type character varying,
+    creator_id uuid NOT NULL,
+    flaggable_id uuid NOT NULL,
+    flaggable_type character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    message text
+    message text,
+    resolved_by_creator boolean DEFAULT false NOT NULL,
+    resolved_at timestamp without time zone
 );
+
+
+--
+-- Name: flag_statuses; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.flag_statuses AS
+ SELECT flags.flaggable_type,
+    flags.flaggable_id,
+    COALESCE(array_agg(DISTINCT flags.creator_id) FILTER (WHERE (NOT flags.resolved_by_creator)), '{}'::uuid[]) AS flagger_ids,
+    count(DISTINCT flags.id) AS flags_count,
+    count(DISTINCT flags.id) FILTER (WHERE (flags.resolved_at IS NOT NULL)) AS resolved_flags_count,
+    count(DISTINCT flags.id) FILTER (WHERE (flags.resolved_at IS NULL)) AS unresolved_flags_count
+   FROM public.flags
+  GROUP BY flags.flaggable_type, flags.flaggable_id;
 
 
 --
@@ -4510,6 +4533,20 @@ CREATE INDEX index_flags_on_flaggable_type_and_flaggable_id ON public.flags USIN
 
 
 --
+-- Name: index_flags_on_resolved_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_flags_on_resolved_at ON public.flags USING btree (resolved_at);
+
+
+--
+-- Name: index_flags_uniqueness; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_flags_uniqueness ON public.flags USING btree (creator_id, flaggable_type, flaggable_id);
+
+
+--
 -- Name: index_friendly_id_slugs_on_slug_and_sluggable_type; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6358,6 +6395,14 @@ ALTER TABLE ONLY public.resource_imports
 
 
 --
+-- Name: flags fk_rails_4a17c6b2e1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.flags
+    ADD CONSTRAINT fk_rails_4a17c6b2e1 FOREIGN KEY (creator_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
 -- Name: users_roles fk_rails_4a41696df6; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7265,6 +7310,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241001182627'),
 ('20241025000218'),
 ('20241206175512'),
-('20241210200353');
+('20241210200353'),
+('20241212183245'),
+('20241212214525');
 
 

--- a/api/db/views/flag_statuses_v01.sql
+++ b/api/db/views/flag_statuses_v01.sql
@@ -1,0 +1,12 @@
+SELECT
+  flaggable_type,
+  flaggable_id,
+  COALESCE(
+    array_agg(DISTINCT creator_id) FILTER (WHERE NOT resolved_by_creator),
+    '{}'::uuid[]
+  ) AS flagger_ids,
+  COUNT(DISTINCT id) AS flags_count,
+  COUNT(DISTINCT id) FILTER (WHERE resolved_at IS NOT NULL) AS resolved_flags_count,
+  COUNT(DISTINCT id) FILTER (WHERE resolved_at IS NULL) AS unresolved_flags_count
+  FROM flags
+  GROUP BY 1, 2

--- a/api/spec/factories/flag.rb
+++ b/api/spec/factories/flag.rb
@@ -1,6 +1,18 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :flag do
     association :creator, factory: :user
     association :flaggable, factory: :comment
+
+    trait :resolved do
+      resolved_at { Time.current }
+    end
+
+    trait :self_resolved do
+      resolved
+
+      resolved_by_creator { true }
+    end
   end
 end

--- a/api/spec/jobs/flags/refresh_all_status_data_job_spec.rb
+++ b/api/spec/jobs/flags/refresh_all_status_data_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe Flags::RefreshAllStatusDataJob, type: :job do
+  let_it_be(:annotation, refind: true) { FactoryBot.create :annotation }
+  let_it_be(:unresolved_flag, refind: true) { FactoryBot.create :flag, flaggable: annotation }
+  let_it_be(:resolved_flag, refind: true) { FactoryBot.create :flag, :resolved, flaggable: annotation }
+  let_it_be(:self_resolved_flag, refind: true) { FactoryBot.create :flag, :self_resolved, flaggable: annotation }
+
+  let_it_be(:flagger_ids) do
+    [unresolved_flag.creator_id, resolved_flag.creator_id].sort
+  end
+
+  before do
+    annotation.update_columns(FlagStatus::EMPTY_DATA)
+  end
+
+  it "runs as expected" do
+    expect do
+      described_class.perform_now
+    end.to change { annotation.reload.flags_count }.by(3)
+      .and change { annotation.reload.resolved_flags_count }.by(2)
+      .and change { annotation.reload.unresolved_flags_count }.by(1)
+      .and change { annotation.reload.flagger_ids.sort }.from([]).to(flagger_ids)
+  end
+end

--- a/api/spec/requests/flags_spec.rb
+++ b/api/spec/requests/flags_spec.rb
@@ -1,63 +1,178 @@
 # frozen_string_literal: true
 
 RSpec.describe "Flags API", type: :request do
-  let(:comment) { FactoryBot.create(:comment, creator: reader) }
+  shared_examples_for "a flaggable relationship" do |model_klass|
+    factory_name = model_klass.model_name.i18n_key
 
-  describe "flags a comment" do
-    let(:path) { api_v1_comment_relationships_flags_path(comment) }
+    url_base = "/api/v1/#{model_klass.model_name.plural}/:#{model_klass.model_name.singular}_id/flags"
 
-    context "when the user is a reader" do
-      let(:headers) { reader_headers }
+    let!(:flaggable) { raise "need to have set!" }
 
-      it("returns the flagged comment") do
-        post path, headers: headers
-        api_response = JSON.parse(response.body)
-        expect(api_response["data"]["id"]).to eq comment.id
+    let!(:path) do
+      url_for([:api, :v1, flaggable, :relationships, :flags])
+    end
+
+    describe "POST #{url_base}" do
+      context "when the user is anonymous" do
+        let(:headers) { anonymous_headers }
+
+        it "is forbidden", :aggregate_failures do
+          expect do
+            post path, headers: headers
+          end.to keep_the_same(Flag, :count)
+
+          expect(response).to have_http_status :unauthorized
+        end
       end
 
-      it("saves the flag on the comment") do
-        post path, headers: headers
-        api_response = JSON.parse(response.body)
-        reloaded_comment = Comment.find(comment.id)
-        expect(reloaded_comment.flags.count).to eq 1
+      context "when the user is a reader" do
+        let(:headers) { reader_headers }
+
+        it "flags the comment", :aggregate_failures do
+          expect do
+            post path, headers: headers
+          end.to change(Flag, :count).by(1)
+
+          expect(response).to have_http_status(:created)
+
+          expect(response.parsed_body).to include_json(data: { id: flaggable.id, attributes: { flagged: true } })
+        end
+
+        context "when the user has already flagged the comment" do
+          let!(:existing_flag) { FactoryBot.create(:flag, creator: reader, flaggable: flaggable) }
+
+          it "is idempotent", :aggregate_failures do
+            expect do
+              post path, headers: headers
+            end.to keep_the_same(Flag, :count)
+              .and keep_the_same { existing_flag.reload.updated_at }
+
+            expect(response).to have_http_status(:created)
+
+            expect(response.parsed_body).to include_json(data: { id: flaggable.id, attributes: { flagged: true } })
+          end
+        end
+      end
+    end
+
+    describe "DELETE #{url_base}" do
+      context "when the user is anonymous" do
+        let(:headers) { anonymous_headers }
+
+        it "is forbidden" do
+          expect do
+            post path, headers: headers
+          end.to keep_the_same(Flag, :count)
+
+          expect(response).to have_http_status :unauthorized
+        end
       end
 
-      it("increments the counter cache on the comment") do
-        post path, headers: headers
-        api_response = JSON.parse(response.body)
-        reloaded_comment = Comment.find(comment.id)
-        expect(reloaded_comment.flags_count).to eq 1
+      context "when the user is a reader" do
+        let(:headers) { reader_headers }
+
+        context "when the comment is unflagged" do
+          it "does nothing" do
+            expect do
+              delete path, headers: headers
+            end.to keep_the_same(Flag, :count)
+
+            expect(response).to have_http_status :not_found
+          end
+        end
+
+        context "when the user has flagged the comment" do
+          let!(:existing_flag) { FactoryBot.create(:flag, creator: reader, flaggable: flaggable) }
+
+          it "resolves the flag", :aggregate_failures do
+            expect do
+              delete path, headers: headers
+            end.to keep_the_same(Flag, :count)
+              .and change { existing_flag.reload.resolved? }.from(false).to(true)
+
+            expect(response).to have_http_status(:ok)
+
+            expect(response.parsed_body).to include_json(data: { id: flaggable.id, attributes: { flagged: false } })
+          end
+
+          context "when the flag has already been resolved by an admin" do
+            before do
+              existing_flag.resolve!
+            end
+
+            it "records that the user resolved it themselves as well", :aggregate_failures do
+              expect do
+                delete path, headers: headers
+              end.to keep_the_same(Flag, :count)
+                .and keep_the_same { existing_flag.reload.resolved? }
+                .and change { existing_flag.reload.resolved_by_creator }.from(false).to(true)
+
+              expect(response).to have_http_status(:ok)
+
+              expect(response.parsed_body).to include_json(data: { id: flaggable.id, attributes: { flagged: false } })
+            end
+          end
+        end
+      end
+    end
+
+    describe "DELETE #{url_base}/resolve_all" do
+      let!(:unresolved_flag) { FactoryBot.create(:flag, flaggable: flaggable) }
+      let!(:resolved_flag) { FactoryBot.create(:flag, :resolved, flaggable: flaggable) }
+
+      let(:path) do
+        url_for([:resolve_all, :api, :v1, flaggable, :relationships, :flags])
+      end
+
+      context "when the user is an admin" do
+        let(:headers) { admin_headers }
+
+        it "resolves all unresolved flags" do
+          expect do
+            delete path, headers: headers
+          end.to change(Flag.only_resolved, :count).by(1)
+            .and change { unresolved_flag.reload.resolved? }.from(false).to(true)
+            .and keep_the_same { resolved_flag.reload.resolved? }
+        end
+      end
+
+      context "when the user is a reader" do
+        let(:headers) { reader_headers }
+
+        it "is forbidden" do
+          expect do
+            delete path, headers: headers
+          end.to keep_the_same(Flag.only_resolved, :count)
+            .and keep_the_same { unresolved_flag.reload.resolved? }
+        end
+      end
+
+      context "when the user is a anonymous" do
+        let(:headers) { anonymous_headers }
+
+        it "is forbidden" do
+          expect do
+            delete path, headers: headers
+          end.to keep_the_same(Flag.only_resolved, :count)
+            .and keep_the_same { unresolved_flag.reload.resolved? }
+        end
       end
     end
   end
 
-  describe "unflags a comment" do
-    let(:path) { api_v1_comment_relationships_flags_path(comment) }
-    let(:flag) { FactoryBot.create(:flag, creator: reader, flaggable: comment) }
+  context "when working with annotations" do
+    let_it_be(:annotation, refind: true) { FactoryBot.create(:annotation, creator: reader) }
 
-    context "when the user is a reader" do
-      let(:headers) { reader_headers }
+    include_examples "a flaggable relationship", Annotation do
+      let(:flaggable) { annotation }
+    end
+  end
 
-      it("returns the unflagged comment") do
-        flag
-        delete path, headers: headers
-        api_response = JSON.parse(response.body)
-        expect(api_response["data"]["id"]).to eq comment.id
-      end
+  context "when working with comments" do
+    let_it_be(:comment, refind: true) { FactoryBot.create(:comment, creator: reader) }
 
-      it("removes the flag on the comment") do
-        flag
-        delete path, headers: headers
-        reloaded_comment = Comment.find(comment.id)
-        expect(reloaded_comment.flags.count).to eq 0
-      end
-
-      it("increments the counter cache on the comment") do
-        flag
-        delete path, headers: headers
-        reloaded_comment = Comment.find(comment.id)
-        expect(reloaded_comment.flags_count).to eq 0
-      end
+    include_examples "a flaggable relationship", Comment do
+      let(:flaggable) { comment }
     end
   end
 end

--- a/api/zhong.rb
+++ b/api/zhong.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "./config/boot"
 require "./config/environment"
 
@@ -5,6 +7,10 @@ Zhong.redis = Redis.new(url: ENV["RAILS_REDIS_URL"])
 
 Zhong.schedule do
   category "caches" do
+    every(10.minutes, "refresh_all_flag_status_data") do
+      ::Flags::RefreshAllStatusDataJob.perform_later
+    end
+
     every(15.minutes, "refresh_project_collections") do
       ::ProjectCollectionJobs::QueueCacheCollectionProjectsJob.perform_later
     end


### PR DESCRIPTION
* Add ability to mark flags as resolved individually or for all flags on a flaggable record
* Ensure a user can only create one flag per flaggable record
* Allow users to clear flags for themselves while maintaining the above constraint
* Ensure full coverage of flags API for both annotations and comments
* Delete flags when soft-deleting users—they should not be preserved
* Avoid N+1 querying for `flagged` attribute in flaggable serializers
* Add scheduled task for maintaining flag status on flaggables
* Improve exception handling for authority / not found / generic errors

Resolves MNFLD-947