### PR TITLE
[B][F] Convert new project collection to route

### DIFF
--- a/client/src/backend/components/project-collection/List.js
+++ b/client/src/backend/components/project-collection/List.js
@@ -1,68 +1,78 @@
-import React, { PureComponent } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import ListItem from "./ListItem";
 import EntitiesList from "backend/components/list/EntitiesList";
 import IconComposer from "global/components/utility/IconComposer";
-import { withTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import lh from "helpers/linkHandler";
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
 
-class ProjectCollectionList extends PureComponent {
-  static displayName = "ProjectCollection.List";
+export default function ProjectCollectionList(props) {
+  const { t } = useTranslation();
 
-  static propTypes = {
-    projectCollection: PropTypes.object,
-    projectCollections: PropTypes.array,
-    onShowNew: PropTypes.func.isRequired,
-    onCollectionSelect: PropTypes.func.isRequired,
-    onToggleVisibility: PropTypes.func.isRequired,
-    onCollectionOrderChange: PropTypes.func.isRequired,
-    match: PropTypes.object,
-    t: PropTypes.func
-  };
+  const {
+    projectCollection,
+    projectCollections,
+    onCollectionSelect,
+    onToggleVisibility,
+    onCollectionOrderChange
+  } = props ?? {};
 
-  render() {
-    const { projectCollection } = this.props;
-    const active = projectCollection ? projectCollection.id : null;
-    const t = this.props.t;
+  const { id } = useParams();
 
-    return (
-      <aside className="aside-wide project-collection-list">
-        <EntitiesList
-          entities={this.props.projectCollections}
-          entityComponent={ListItem}
-          entityComponentProps={{
-            active,
-            clickHandler: this.props.onCollectionSelect,
-            visibilityToggleHandler: this.props.onToggleVisibility
-          }}
-          useDragHandle
-          listStyle="bare"
-          callbacks={{
-            onReorder: this.props.onCollectionOrderChange
-          }}
-        />
-        <div className="actions">
-          <button
-            className="button-icon-secondary button-icon-secondary--full"
-            onClick={this.props.onShowNew}
-          >
-            <IconComposer
-              icon="plus16"
-              size={20}
-              className={classNames(
-                "button-icon-secondary__icon",
-                "button-icon-secondary__icon--large"
-              )}
-            />
-            <span>{t("project_collections.create_collection")}</span>
-          </button>
-        </div>
-        <p className="instructional-copy">
-          {t("project_collections.create_collection_instructions")}
-        </p>
-      </aside>
-    );
-  }
+  const newPath =
+    id && id !== "new"
+      ? lh.link("backendProjectCollectionNew", projectCollection.id)
+      : lh.link("backendProjectCollectionsNew");
+
+  return (
+    <aside className="aside-wide project-collection-list">
+      <EntitiesList
+        entities={projectCollections}
+        entityComponent={ListItem}
+        entityComponentProps={{
+          active: id,
+          clickHandler: onCollectionSelect,
+          visibilityToggleHandler: onToggleVisibility
+        }}
+        useDragHandle
+        listStyle="bare"
+        callbacks={{
+          onReorder: onCollectionOrderChange
+        }}
+      />
+      <div className="actions">
+        <Link
+          className="button-icon-secondary button-icon-secondary--full"
+          to={newPath}
+        >
+          <IconComposer
+            icon="plus16"
+            size={20}
+            className={classNames(
+              "button-icon-secondary__icon",
+              "button-icon-secondary__icon--large"
+            )}
+          />
+          <span>{t("project_collections.create_collection")}</span>
+        </Link>
+      </div>
+      <p className="instructional-copy">
+        {t("project_collections.create_collection_instructions")}
+      </p>
+    </aside>
+  );
 }
 
-export default withTranslation()(ProjectCollectionList);
+ProjectCollectionList.displayName = "ProjectCollection.List";
+
+ProjectCollectionList.propTypes = {
+  projectCollection: PropTypes.object,
+  projectCollections: PropTypes.array,
+  onCollectionSelect: PropTypes.func.isRequired,
+  onToggleVisibility: PropTypes.func.isRequired,
+  onCollectionOrderChange: PropTypes.func.isRequired,
+  match: PropTypes.object
+};

--- a/client/src/backend/components/project-collection/List.js
+++ b/client/src/backend/components/project-collection/List.js
@@ -13,7 +13,6 @@ export default function ProjectCollectionList(props) {
   const { t } = useTranslation();
 
   const {
-    projectCollection,
     projectCollections,
     onCollectionSelect,
     onToggleVisibility,
@@ -24,7 +23,7 @@ export default function ProjectCollectionList(props) {
 
   const newPath =
     id && id !== "new"
-      ? lh.link("backendProjectCollectionNew", projectCollection.id)
+      ? lh.link("backendProjectCollectionNew", id)
       : lh.link("backendProjectCollectionsNew");
 
   return (

--- a/client/src/backend/containers/project-collection/Detail/index.js
+++ b/client/src/backend/containers/project-collection/Detail/index.js
@@ -45,6 +45,7 @@ export class ProjectCollectionDetail extends PureComponent {
 
   render() {
     const { collectionProjects, projectCollection, t } = this.props;
+
     if (!projectCollection || !collectionProjects) return null;
     const projects = collectionProjects.map(cp => cp.relationships.project);
 

--- a/client/src/backend/containers/project-collection/New.js
+++ b/client/src/backend/containers/project-collection/New.js
@@ -14,8 +14,7 @@ class ProjectCollectionNew extends PureComponent {
   static propTypes = {
     buildUpdateProjectCollection: PropTypes.func.isRequired,
     buildCreateProjectCollection: PropTypes.func.isRequired,
-    successHandler: PropTypes.func.isRequired,
-    setDirty: PropTypes.func.isRequired,
+    handleNewSuccess: PropTypes.func.isRequired,
     t: PropTypes.func
   };
 
@@ -35,12 +34,6 @@ class ProjectCollectionNew extends PureComponent {
     };
   }
 
-  onDirty = session => {
-    const dirtyAttrs = Object.keys(session.attributes).length;
-    const dirtyRels = Object.keys(session.relationships).length;
-    this.props.setDirty(dirtyAttrs || dirtyRels);
-  };
-
   render() {
     return (
       <Authorize
@@ -55,8 +48,7 @@ class ProjectCollectionNew extends PureComponent {
             name="backend-project-collection-create"
             update={this.props.buildUpdateProjectCollection}
             create={this.props.buildCreateProjectCollection}
-            onSuccess={this.props.successHandler}
-            onDirty={this.onDirty}
+            onSuccess={this.props.handleNewSuccess}
             className="form-secondary project-collection-form"
           >
             <ProjectCollection.Form.Fields {...this.props} />

--- a/client/src/backend/containers/route-containers.js
+++ b/client/src/backend/containers/route-containers.js
@@ -70,6 +70,7 @@ export default {
   ProjectCollectionDetail: ProjectCollection.Detail,
   ProjectCollectionManageProjects: ProjectCollection.ManageProjects,
   ProjectCollectionSettings: ProjectCollection.Settings,
+  ProjectCollectionNew: ProjectCollection.New,
   ProjectWrapper: Project.Wrapper,
   ProjectTexts: Project.Texts,
   ProjectTextIngestionNew: Project.Text.Ingestion.New,

--- a/client/src/backend/routes.js
+++ b/client/src/backend/routes.js
@@ -363,6 +363,14 @@ const routes = {
           helper: () => "/backend/projects/project-collections",
           routes: [
             {
+              name: "backendProjectCollectionsNew",
+              exact: true,
+              component: "ProjectCollectionNew",
+              path: "/backend/projects/project-collections/new",
+              helper: () => `/backend/projects/project-collections/new`,
+              modal: true
+            },
+            {
               name: "backendProjectCollection",
               exact: false,
               component: "ProjectCollectionDetail",
@@ -385,6 +393,14 @@ const routes = {
                   path: "/backend/projects/project-collections/:id/settings",
                   helper: pc =>
                     `/backend/projects/project-collections/${pc}/settings`
+                },
+                {
+                  name: "backendProjectCollectionNew",
+                  exact: true,
+                  component: "ProjectCollectionNew",
+                  path: "/backend/projects/project-collections/:id/new",
+                  helper: pc =>
+                    `/backend/projects/project-collections/${pc}/new`
                 }
               ]
             }

--- a/client/src/global/components/form/Switch/styles.js
+++ b/client/src/global/components/form/Switch/styles.js
@@ -15,6 +15,7 @@ const BOOLEAN_PADDING = 4;
 /* See note in renderSwitchIndicator, also checked and focus styles for InputCheckbox. */
 export const IndicatorSwitchOuter = styled.span`
   border-bottom: 1px solid var(--input-border-color);
+  pointer-events: none;
 `;
 
 export const IndicatorSwitchInner = styled.span`


### PR DESCRIPTION
This PR resolves a bug where the create new project collection drawer would get into an unusable state after successfully saving a new collection. The form would continue to be in a dirty state prompting a confirm unsaved changes modal to appear rather than closing the drawer. This PR adds a `/project-collections/new` route to create parity between this and other new routes in admin and also handle the form state using consistent routing mechanisms rather than a one-off handler.