### PR TITLE
Add journal editor role to backend

### DIFF
--- a/api/app/authorizers/journal_authorizer.rb
+++ b/api/app/authorizers/journal_authorizer.rb
@@ -19,7 +19,7 @@ class JournalAuthorizer < ApplicationAuthorizer
   # @param [User] user
   # @param [Hash] _options
   def updatable_by?(user, _options = {})
-    has_any_role? user, :admin, :editor, :marketeer, :project_editor
+    has_any_role? user, :admin, :editor, :marketeer, :project_editor, :journal_editor
   end
 
   def journal_administered_by?(user, _options = {})

--- a/api/app/enums/role_name.rb
+++ b/api/app/enums/role_name.rb
@@ -262,6 +262,17 @@ class RoleName::ProjectEditor < RoleName
   provides_full_read_access!
 end
 
+class RoleName::JournalEditor < RoleName
+  any_editor!
+
+  scoped!
+
+  can_update_projects!
+  can_update_journals!
+  provides_draft_access!
+  provides_full_read_access!
+end
+
 class RoleName::ProjectPropertyManager < RoleName
   scoped!
 

--- a/api/app/models/journal_issue.rb
+++ b/api/app/models/journal_issue.rb
@@ -52,7 +52,7 @@ class JournalIssue < ApplicationRecord
   end
 
   scope :with_read_ability, ->(user = nil) do
-    where(project: Project.with_read_ability(user)).or(where(journal: Journal.with_update_ability(user)))
+    where(project: Project.with_read_ability(user)).or(where(journal: Journal.with_read_ability(user)))
   end
 
   scope :for_nav, ->(user = nil) do

--- a/api/spec/authorizers/journal_authorizer_spec.rb
+++ b/api/spec/authorizers/journal_authorizer_spec.rb
@@ -1,0 +1,168 @@
+require "rails_helper"
+
+RSpec.describe "Journal Abilities", :authorizer do
+  include TestHelpers::AuthorizationHelpers
+
+  let(:journal_traits) do
+    []
+  end
+  let(:user_traits) do
+    []
+  end
+
+  let!(:user) { FactoryBot.create :user, *user_traits }
+  let!(:journal) { FactoryBot.create :journal, *journal_traits}
+  let!(:journal_issue) { FactoryBot.create :journal_issue, journal: journal }
+
+  subject { user }
+
+  shared_examples_for "no access" do
+    it { is_expected.to be_unable_to(:read, :create, :update, :destroy).on(journal) }
+
+    include_examples "unauthorized to manage journal permissions"
+    include_examples "unauthorized to manage journal entitlements"
+    include_examples "unauthorized to manage journal issues"
+  end
+
+  shared_examples_for "full access" do
+    it("can perform all CRUD actions") { is_expected.to be_able_to(:create, :read, :update, :destroy).on(journal) }
+
+    include_examples "authorized to manage journal permissions"
+    include_examples "authorized to manage journal entitlements"
+    include_examples "authorized to manage journal issues"
+  end
+
+  shared_examples_for "not admin" do
+    include_examples "unauthorized to manage journal permissions"
+    include_examples "unauthorized to manage journal entitlements"
+  end
+
+  shared_examples_for "read only" do
+    it { is_expected.to be_able_to(:read).on(journal).and be_unable_to(:create, :update, :destroy).on(journal)}
+
+    include_examples "unauthorized to manage journal permissions"
+    include_examples "unauthorized to manage journal entitlements"
+    include_examples "unauthorized to manage journal issues"
+  end
+
+  shared_examples_for "read access" do
+    it { is_expected.to be_able_to(:read).on(journal)}
+  end
+
+  shared_examples_for "edit access" do
+    it { is_expected.to be_able_to(:update).on(journal)}
+  end
+
+  shared_examples_for "delete access" do
+    it { is_expected.to be_able_to(:delete).on(journal)}
+  end
+
+  shared_examples_for "authorized to manage journal entitlements" do
+    it "can manage journal entitlements" do
+      is_expected.to be_able_to(:manage_entitlements, :create_entitlements).on(journal)
+    end
+  end
+
+  shared_examples_for "authorized to manage journal permissions" do
+    it "is able to manage journal permissions" do
+      is_expected.to be_able_to(:manage_permissions, :create_permissions).on(journal)
+    end
+  end
+
+  shared_examples_for "authorized to manage journal issues" do
+    it "is able to manage journal issues in full" do
+      is_expected.to be_able_to(
+        :manage_permissions,
+        :create_permissions,
+        :create,
+        :read,
+        :update,
+        :destroy
+      ).on(journal_issue)
+
+    end
+  end
+
+  shared_examples_for "unauthorized to manage journal issues" do
+   it "is unable to manage journal issues" do
+      is_expected.to be_unable_to(
+        :manage_permissions,
+        :create_permissions,
+        :create,
+        :read,
+        :update,
+        :destroy
+      ).on(journal_issue)
+    end
+  end
+
+  shared_examples_for "unauthorized to create new journals" do
+    it { is_expected.to be_unable_to(:create).on(journal)}
+  end
+
+  shared_examples_for "unauthorized to delete journals" do
+    it { is_expected.to be_unable_to(:delete).on(journal)}
+  end
+
+  shared_examples_for "unauthorized to manage journal entitlements" do
+    it "cannot manage journal entitlements" do
+      is_expected.to be_unable_to(:manage_entitlements, :create_entitlements).on(journal)
+    end
+  end
+
+  shared_examples_for "unauthorized to manage journal permissions" do
+    it "cannot manage journal permissions" do
+      is_expected.not_to be_able_to(:manage_permissions, :create_permissions).on(journal)
+    end
+  end
+
+  context "when unauthenticated" do
+    let(:user) { anonymous_user }
+
+    include_examples "no access"
+  end
+
+  context "when the user is a regular reader" do
+    include_examples "read only"
+  end
+
+  context "when the user is an editor" do
+    let(:user_traits) { [:editor] }
+
+    include_examples "full access"
+  end
+
+  context "when the user is an admin" do
+    let(:user_traits) { [:admin] }
+
+    include_examples "full access"
+  end
+
+  context "when the user is a project editor" do
+    before do
+      user.add_role :project_editor, journal
+    end
+
+    include_examples "authorized to manage journal issues"
+    include_examples "unauthorized to create new journals"
+    include_examples "not admin"
+    include_examples "read access"
+    include_examples "edit access"
+    include_examples "delete access"
+  end
+
+  context "when the user is a journal editor" do
+    before do
+      user.add_role :journal_editor, journal
+    end
+
+    include_examples "authorized to manage journal issues"
+
+    include_examples "unauthorized to create new journals"
+    include_examples "unauthorized to delete journals"
+    include_examples "not admin"
+    include_examples "read access"
+    include_examples "edit access"
+  end
+
+end


### PR DESCRIPTION
This PR adds a new user role, `JournalEditor`, designed to allow users to better control permissions granted to journals and journal issues as a whole. Any user with the role journal editor can read and edit an existing journal, as well as create, read, edit, delete, and control permissions to any issue within that journal.

Journal Editor is a scoped role, like Project Editor. So a user who is a Journal Editor on one journal may not be a journal editor on another journal. This also means that when assigning a journal editor role, front end must include the id of the record to scope the role to.

Some points for discussion:
- How many permissions should a journal editor have over journal issues? Currently they have full control (the same as other relevant roles like ProjectEditor), however we can assign different permissions as we see fit.
- Should we do anything with the existing journal issue permissions? This PR does not touch them, as some may already exist in production, and they allow more fine grain control over the journal issue than a journal editor role can.