### PR TITLE
[F] Journal editor is allowed to create, read, update, delete projects within journal

### DIFF
--- a/api/app/authorizers/entitlement_authorizer.rb
+++ b/api/app/authorizers/entitlement_authorizer.rb
@@ -58,6 +58,7 @@ class EntitlementAuthorizer < ApplicationAuthorizer
     # @param [Hash] options
     # @option options [ApplicationRecord] :for
     def creatable_by?(user, options = {})
+      return false if user.marketeer?
       might_access? user, options
     end
 
@@ -65,6 +66,7 @@ class EntitlementAuthorizer < ApplicationAuthorizer
     # @param [Hash] options
     # @option options [ApplicationRecord] :for
     def manageable_by?(user, options = {})
+      return false if user.marketeer?
       might_access? user, options
     end
 

--- a/api/app/authorizers/permission_authorizer.rb
+++ b/api/app/authorizers/permission_authorizer.rb
@@ -1,13 +1,6 @@
+# frozen_string_literal: true
+
 class PermissionAuthorizer < ApplicationAuthorizer
-
-  def self.default(_able, user, options = {})
-    return true if editor_permissions?(user)
-    return false unless options[:for]
-    return false unless options[:for].respond_to? :permissions_manageable_by?
-
-    options[:for].permissions_manageable_by? user
-  end
-
   def default(_able, user, _options = {})
     return true if creator_or_has_editor_permissions?(user, resource)
     return false unless resource.resource
@@ -16,4 +9,13 @@ class PermissionAuthorizer < ApplicationAuthorizer
     resource.resource.permissions_manageable_by? user
   end
 
+  class << self
+    def default(_able, user, options = {})
+      return true if editor_permissions?(user)
+      return false unless options[:for]
+      return false unless options[:for].respond_to? :permissions_manageable_by?
+
+      options[:for].permissions_manageable_by? user
+    end
+  end
 end

--- a/api/app/authorizers/project_authorizer.rb
+++ b/api/app/authorizers/project_authorizer.rb
@@ -42,8 +42,8 @@ class ProjectAuthorizer < ApplicationAuthorizer
   #
   # @param [User] user
   # @param [Hash] _options
-  def updatable_by?(user, _options = {})
-    has_any_role? user, :admin, :editor, :marketeer, :project_editor
+  def updatable_by?(user, options = {})
+    has_any_role?(user, :admin, :editor, :marketeer, :project_editor) || with_journal { |j| j.updatable_by? user, options}
   end
 
   # @!group Project Property Access Control
@@ -113,15 +113,15 @@ class ProjectAuthorizer < ApplicationAuthorizer
   #
   # @param [User] user
   # @param [Hash] _options
-  def deletable_by?(user, _options = {})
-    has_any_role? user, :admin, :editor, :project_editor
+  def deletable_by?(user, options = {})
+    has_any_role?(user, :admin, :editor, :project_editor) || with_journal { |j| j.deletable_by? user, options }
   end
 
   # @see RoleName.draft_access
   # @param [User] user
   # @param [Hash] _options
-  def drafts_readable_by?(user, _options = {})
-    has_any_role? user, *RoleName.draft_access
+  def drafts_readable_by?(user, options = {})
+    has_any_role?(user, *RoleName.draft_access) || with_journal { |j| j.readable_by? user, options }
   end
 
   def publicly_engageable_by?(user, _options = {})
@@ -173,8 +173,8 @@ class ProjectAuthorizer < ApplicationAuthorizer
     #
     # @param [User] user
     # @param [Hash] _options
-    def creatable_by?(user, _options = {})
-      project_creator_permissions?(user)
+    def creatable_by?(user, options = {})
+      project_creator_permissions?(user) || user.journal_editor?
     end
 
     # {RoleName::Admin Admins} and {RoleName::Editor editors} can delete any project.
@@ -183,8 +183,8 @@ class ProjectAuthorizer < ApplicationAuthorizer
     #
     # @param [User] user
     # @param [Hash] _options
-    def deletable_by?(user, _options = {})
-      has_any_role? user, :admin, :editor, :project_editor
+    def deletable_by?(user, options = {})
+      has_any_role?(user, :admin, :editor, :project_editor)
     end
 
     # @see .marketeer_permissions?

--- a/api/app/authorizers/project_authorizer.rb
+++ b/api/app/authorizers/project_authorizer.rb
@@ -25,6 +25,23 @@ class ProjectAuthorizer < ApplicationAuthorizer
     ]
   end.freeze
 
+  # @note This should not actually be caught by any verbs for this model,
+  #   but we add it here to prevent the authorizer from short-circuiting
+  #   to the necessarily-permissive class-level {ProjectAuthorizer.default}.
+  def default(_adjective, user, _options = {})
+    # :nocov:
+    has_any_role?(user, :admin)
+    # :nocov:
+  end
+
+  # Admins, editors, marketeers, and project creators can create projects.
+  #
+  # @param [User] user
+  # @param [Hash] _options
+  def creatable_by?(user, _options = {})
+    has_any_role?(user, :admin, :editor, :marketeer, :project_creator)
+  end
+
   # First, we check to see if the project is a draft. If so, {#drafts_readable_by? it must be readable}.
   # Otherwise, we allow a project to be read.
   #
@@ -43,7 +60,7 @@ class ProjectAuthorizer < ApplicationAuthorizer
   # @param [User] user
   # @param [Hash] _options
   def updatable_by?(user, options = {})
-    has_any_role?(user, :admin, :editor, :marketeer, :project_editor) || with_journal { |j| j.updatable_by? user, options}
+    has_any_role?(user, :admin, :editor, :marketeer, :project_editor) || with_journal { |j| j.updatable_by? user, options }
   end
 
   # @!group Project Property Access Control
@@ -173,7 +190,7 @@ class ProjectAuthorizer < ApplicationAuthorizer
     #
     # @param [User] user
     # @param [Hash] _options
-    def creatable_by?(user, options = {})
+    def creatable_by?(user, _options = {})
       project_creator_permissions?(user) || user.journal_editor?
     end
 
@@ -183,7 +200,7 @@ class ProjectAuthorizer < ApplicationAuthorizer
     #
     # @param [User] user
     # @param [Hash] _options
-    def deletable_by?(user, options = {})
+    def deletable_by?(user, _options = {})
       has_any_role?(user, :admin, :editor, :project_editor)
     end
 

--- a/api/app/authorizers/project_authorizer.rb
+++ b/api/app/authorizers/project_authorizer.rb
@@ -106,9 +106,10 @@ class ProjectAuthorizer < ApplicationAuthorizer
   # @param [User] user
   # @param [Hash] options
   def entitlements_creatable_by?(user, options = {})
+    return false if resource.draft? && !has_any_role?(user, :admin, :editor)
     options ||= {}
 
-    options[:subject] = resource
+    options[:for] = resource
 
     user.can_create? Entitlement, options
   end
@@ -117,9 +118,10 @@ class ProjectAuthorizer < ApplicationAuthorizer
   # @param [User] user
   # @param [Hash] options
   def entitlements_manageable_by?(user, options = {})
+    return false if resource.draft? && !has_any_role?(user, :admin, :editor)
     options ||= {}
 
-    options[:subject] = resource
+    options[:for] = resource
 
     user.can_manage? Entitlement, options
   end

--- a/api/app/controllers/api/v1/journals/relationships/journal_issues_controller.rb
+++ b/api/app/controllers/api/v1/journals/relationships/journal_issues_controller.rb
@@ -1,14 +1,19 @@
+# frozen_string_literal: true
+
 module API
   module V1
     module Journals
       module Relationships
         class JournalIssuesController < AbstractJournalChildController
+          include AuthorizesJSONAPIRelationships
 
           resourceful! JournalIssue, authorize_options: { except: [:index] } do
             JournalIssue.filtered(
               with_pagination!(journal_issue_filter_params), scope: @journal.journal_issues.in_reverse_order, user: current_user
             )
           end
+
+          before_action :maybe_enforce_project_access!, only: :create
 
           def index
             @journal_issues = load_journal_issues
@@ -19,6 +24,7 @@ module API
 
           def create
             inputs = {}
+
             inputs[:params] = journal_issue_params.to_h
             inputs[:creator] = current_user
             inputs[:journal] = @journal
@@ -26,17 +32,23 @@ module API
             authorize_action_for JournalIssue.new(journal: @journal)
 
             outcome = JournalIssues::Create.run inputs
+
             render_single_resource outcome.result
           end
 
           private
+
+          # Check to make sure that the user is authorized to update the project, if present.
+          # @return [void]
+          def maybe_enforce_project_access!
+            authorize_jsonapi_relationship_in! journal_issue_params, Project
+          end
 
           def location
             return "" unless @journal_issue.persisted?
 
             api_v1_journal_issue_url(@journal_issue)
           end
-
         end
       end
     end

--- a/api/app/controllers/concerns/authorizes_json_api_relationships.rb
+++ b/api/app/controllers/concerns/authorizes_json_api_relationships.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module AuthorizesJSONAPIRelationships
+  extend ActiveSupport::Concern
+
+  # Occasionally we need to authorize based on attributes in a relationship.
+  #
+  # This provides a standardized way to do so based on params constructed in {Validation}.
+  #
+  # @param [ActionController::Parameters, #dig] params
+  # @param [Symbol] relationship_key
+  # @param [Class<ApplicationRecord>] model_klass
+  # @param [Symbol] action
+  # @return [void]
+  def authorize_jsonapi_relationship_in!(params, model_klass, action: :update, relationship_key: model_klass.model_name.i18n_key)
+    id = params.dig(:data, :relationships, relationship_key, :data, :id)
+
+    record = load_jsonapi_relationship_for model_klass, id
+
+    # :nocov:
+    return if record.blank?
+    # :nocov:
+
+    Authority.enforce action, record, authority_user
+  end
+
+  # @param [Class<ApplicationRecord>] model_klass
+  # @param [String] id
+  # @return [ApplicationRecord, nil]
+  def load_jsonapi_relationship_for(model_klass, id)
+    case id
+    when model_klass then id
+    when String then model_klass.find id
+    end
+  rescue ActiveRecord::RecordNotFound
+    # intentionally left blank, we don't try to authorize non-existing records
+    # and the failure should be caught elsewhere in the validation stack.
+  end
+end

--- a/api/app/services/journal_issues/create.rb
+++ b/api/app/services/journal_issues/create.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 module JournalIssues
   class Create < ActiveInteraction::Base
-
     isolatable!
 
     transactional!
 
     record :creator, class: "User"
     record :journal
+
     # Params are filtered in strong parameters with journal_issue_params
     hash :params, strip: false
 
@@ -14,12 +16,13 @@ module JournalIssues
 
     # @return [JournalIssue]
     def execute
-      @journal_issue =
-        ::Updaters::Default.new(params).update(journal.journal_issues.new(creator: creator))
+      @journal_issue = journal.journal_issues.new(creator: creator)
+
+      ::Updaters::Default.new(params).update(@journal_issue)
 
       create_and_assign_project unless @journal_issue.project.present?
 
-      journal_issue.save if journal_issue.valid?
+      journal_issue.save
 
       return journal_issue
     end
@@ -32,12 +35,12 @@ module JournalIssues
       title_parts.push "no. #{journal_issue.number}"
 
       project = Project.create(title: title_parts.join(", "), creator: creator)
-      Content::ScaffoldProjectContent.run project: project,
-                                          configuration: {
-                                            multiple_texts: true
-                                          }
+
+      inputs = { project: project, configuration: { multiple_texts: true } }
+
+      compose Content::ScaffoldProjectContent, inputs
+
       @journal_issue.project = project
     end
-
   end
 end

--- a/api/config/initializers/authority.rb
+++ b/api/config/initializers/authority.rb
@@ -46,7 +46,6 @@ Authority.configure do |config|
     read: "readable",
     update: "updatable",
     delete: "deletable",
-    destroy: "deleteable",
     read_deleted: "deleted_readable",
     read_drafts: "drafts_readable",
     fully_read: "fully_readable",

--- a/api/db/structure.sql
+++ b/api/db/structure.sql
@@ -7373,3 +7373,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250129200019'),
 ('20250210192150'),
 ('20250210230256');
+
+

--- a/api/spec/authorizers/comment_authorizer_spec.rb
+++ b/api/spec/authorizers/comment_authorizer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Comment Abilities", :authorizer do
 
     the_subject_behaves_like "instance abilities", Comment, create: false, read: true, update: false, delete: false
 
-    the_subject_behaves_like "class abilities", Comment, create: false, read: true, update: false, destroy: false
+    the_subject_behaves_like "class abilities", Comment, create: false, read: true, update: false, delete: false
   end
 
   context "when the subject is an admin" do
@@ -34,7 +34,7 @@ RSpec.describe "Comment Abilities", :authorizer do
 
       the_subject_behaves_like "instance abilities", Comment, create: true, read: true, update: false, delete: false
 
-      the_subject_behaves_like "class abilities", Comment, create: true, read: true, update: true, destroy: true
+      the_subject_behaves_like "class abilities", Comment, create: true, read: true, update: true, delete: true
 
     end
 
@@ -45,14 +45,14 @@ RSpec.describe "Comment Abilities", :authorizer do
 
       the_subject_behaves_like "instance abilities", Comment, create: false, read: true, update: false, delete: false
 
-      the_subject_behaves_like "class abilities", Comment, create: false, read: true, update: true, destroy: true
+      the_subject_behaves_like "class abilities", Comment, create: false, read: true, update: true, delete: true
     end
   end
 
   context "when the subject is the resource creator" do
     let_it_be(:subject, refind: true) { creator }
 
-    the_subject_behaves_like "instance abilities", Comment, read: true, update: true, destroy: true
+    the_subject_behaves_like "instance abilities", Comment, read: true, update: true, delete: true
   end
 
   context "when the comment is on an annotation in a closed project with disabled engagement" do
@@ -79,7 +79,7 @@ RSpec.describe "Comment Abilities", :authorizer do
         subject.clear_email_confirmation!
       end
 
-      the_subject_behaves_like "instance abilities", Comment, create: false, read: true, update: true, destroy: true
+      the_subject_behaves_like "instance abilities", Comment, create: false, read: true, update: true, delete: true
     end
   end
 

--- a/api/spec/authorizers/export_target_authorizer_spec.rb
+++ b/api/spec/authorizers/export_target_authorizer_spec.rb
@@ -21,6 +21,6 @@ RSpec.describe "Export Target Abilities", :authorizer do
     let(:user) { FactoryBot.create :user, :editor }
     let!(:export_target) { FactoryBot.create :export_target }
 
-    it { is_expected.to be_able_to(:read).on(export_target).and be_unable_to(:create, :update, :destroy).on(export_target) }
+    it { is_expected.to be_able_to(:read).on(export_target).and be_unable_to(:create, :update, :delete).on(export_target) }
   end
 end

--- a/api/spec/authorizers/journal_authorizer_spec.rb
+++ b/api/spec/authorizers/journal_authorizer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "Journal Abilities", :authorizer do
     include_examples "unauthorized to manage journal permissions"
     include_examples "unauthorized to manage journal entitlements"
     include_examples "unauthorized to manage journal issues"
+    include_examples "unauthorized to manage journal issue projects"
   end
 
   shared_examples_for "full access" do
@@ -30,6 +31,7 @@ RSpec.describe "Journal Abilities", :authorizer do
     include_examples "authorized to manage journal permissions"
     include_examples "authorized to manage journal entitlements"
     include_examples "authorized to manage journal issues"
+    include_examples "authorized to manage journal issue projects"
   end
 
   shared_examples_for "not admin" do
@@ -43,6 +45,7 @@ RSpec.describe "Journal Abilities", :authorizer do
     include_examples "unauthorized to manage journal permissions"
     include_examples "unauthorized to manage journal entitlements"
     include_examples "unauthorized to manage journal issues"
+    include_examples "unauthorized to manage journal issue projects"
   end
 
   shared_examples_for "read access" do
@@ -96,6 +99,41 @@ RSpec.describe "Journal Abilities", :authorizer do
     end
   end
 
+  shared_examples_for "authorized to manage journal issue projects" do
+    it "is able to create journal issue projects" do
+      is_expected.to be_able_to(
+        :create
+      ).on(journal_issue.project)
+    end
+    it "is able to read journal issue projects" do
+      is_expected.to be_able_to(
+        :read
+      ).on(journal_issue.project)
+    end
+    it "is able to update journal issue projects" do
+      is_expected.to be_able_to(
+        :update
+      ).on(journal_issue.project)
+    end
+    it "is able to destroy journal issue projects" do
+      is_expected.to be_able_to(
+        :destroy
+      ).on(journal_issue.project)
+    end
+  end
+
+  shared_examples_for "unauthorized to manage journal issue projects" do
+   it "is unable to manage journal issue projects" do
+      is_expected.to be_unable_to(
+        :manage_permissions,
+        :create_permissions,
+        :create,
+        :update,
+        :destroy
+      ).on(journal_issue.project)
+    end
+  end
+
   shared_examples_for "unauthorized to create new journals" do
     it { is_expected.to be_unable_to(:create).on(journal)}
   end
@@ -141,6 +179,7 @@ RSpec.describe "Journal Abilities", :authorizer do
   context "when the user is a project editor" do
     before do
       user.add_role :project_editor, journal
+      user.remove_role :reader
     end
 
     include_examples "authorized to manage journal issues"
@@ -154,15 +193,22 @@ RSpec.describe "Journal Abilities", :authorizer do
   context "when the user is a journal editor" do
     before do
       user.add_role :journal_editor, journal
+      user.remove_role :reader
     end
 
     include_examples "authorized to manage journal issues"
-
+    include_examples "authorized to manage journal issue projects"
     include_examples "unauthorized to create new journals"
     include_examples "unauthorized to delete journals"
     include_examples "not admin"
     include_examples "read access"
     include_examples "edit access"
-  end
 
+    context "when the journal issue is a draft" do
+      let!(:journal_issue) { FactoryBot.create :draft_journal_issue, journal: journal }
+
+      include_examples "authorized to manage journal issues"
+      include_examples "authorized to manage journal issue projects"
+    end
+  end
 end

--- a/api/spec/authorizers/journal_authorizer_spec.rb
+++ b/api/spec/authorizers/journal_authorizer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Journal Abilities", :authorizer do
   subject { user }
 
   shared_examples_for "no access" do
-    it { is_expected.to be_unable_to(:read, :create, :update, :destroy).on(journal) }
+    it { is_expected.to be_unable_to(:read, :create, :update, :delete).on(journal) }
 
     include_examples "unauthorized to manage journal permissions"
     include_examples "unauthorized to manage journal entitlements"
@@ -26,12 +26,11 @@ RSpec.describe "Journal Abilities", :authorizer do
   end
 
   shared_examples_for "full access" do
-    it("can perform all CRUD actions") { is_expected.to be_able_to(:create, :read, :update, :destroy).on(journal) }
+    it("can perform all CRUD actions") { is_expected.to be_able_to(:create, :read, :update, :delete).on(journal) }
 
     include_examples "authorized to manage journal permissions"
     include_examples "authorized to manage journal entitlements"
     include_examples "authorized to manage journal issues"
-    include_examples "authorized to manage journal issue projects"
   end
 
   shared_examples_for "not admin" do
@@ -40,7 +39,7 @@ RSpec.describe "Journal Abilities", :authorizer do
   end
 
   shared_examples_for "read only" do
-    it { is_expected.to be_able_to(:read).on(journal).and be_unable_to(:create, :update, :destroy).on(journal)}
+    it { is_expected.to be_able_to(:read).on(journal).and be_unable_to(:create, :update, :delete).on(journal)}
 
     include_examples "unauthorized to manage journal permissions"
     include_examples "unauthorized to manage journal entitlements"
@@ -80,7 +79,7 @@ RSpec.describe "Journal Abilities", :authorizer do
         :create,
         :read,
         :update,
-        :destroy
+        :delete
       ).on(journal_issue)
 
     end
@@ -94,31 +93,26 @@ RSpec.describe "Journal Abilities", :authorizer do
         :create,
         :read,
         :update,
-        :destroy
+        :delete
       ).on(journal_issue)
     end
   end
 
   shared_examples_for "authorized to manage journal issue projects" do
-    it "is able to create journal issue projects" do
-      is_expected.to be_able_to(
-        :create
-      ).on(journal_issue.project)
+    it "is not able to create journal issue projects directly" do
+      is_expected.not_to be_able_to(:create).on(journal_issue.project)
     end
+
     it "is able to read journal issue projects" do
-      is_expected.to be_able_to(
-        :read
-      ).on(journal_issue.project)
+      is_expected.to be_able_to(:read).on(journal_issue.project)
     end
+
     it "is able to update journal issue projects" do
-      is_expected.to be_able_to(
-        :update
-      ).on(journal_issue.project)
+      is_expected.to be_able_to(:update).on(journal_issue.project)
     end
-    it "is able to destroy journal issue projects" do
-      is_expected.to be_able_to(
-        :destroy
-      ).on(journal_issue.project)
+
+    it "cannot delete a journal issue's project directly (delete the journal issue itself)" do
+      is_expected.not_to be_able_to(:delete).on(journal_issue.project)
     end
   end
 
@@ -129,17 +123,17 @@ RSpec.describe "Journal Abilities", :authorizer do
         :create_permissions,
         :create,
         :update,
-        :destroy
+        :delete
       ).on(journal_issue.project)
     end
   end
 
   shared_examples_for "unauthorized to create new journals" do
-    it { is_expected.to be_unable_to(:create).on(journal)}
+    it { is_expected.to be_unable_to(:create).on(journal) }
   end
 
   shared_examples_for "unauthorized to delete journals" do
-    it { is_expected.to be_unable_to(:delete).on(journal)}
+    it { is_expected.to be_unable_to(:delete).on(journal) }
   end
 
   shared_examples_for "unauthorized to manage journal entitlements" do

--- a/api/spec/authorizers/journal_authorizer_spec.rb
+++ b/api/spec/authorizers/journal_authorizer_spec.rb
@@ -198,7 +198,6 @@ RSpec.describe "Journal Abilities", :authorizer do
 
     include_examples "authorized to manage journal issues"
     include_examples "authorized to manage journal issue projects"
-    include_examples "unauthorized to create new journals"
     include_examples "unauthorized to delete journals"
     include_examples "not admin"
     include_examples "read access"

--- a/api/spec/authorizers/permission_authorizer_spec.rb
+++ b/api/spec/authorizers/permission_authorizer_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe "Permission Abilities", :authorizer do
 
   context "when the subject is the creator of the permission's project" do
     let(:subject) { FactoryBot.create(:user, :project_creator) }
-    let(:object) { FactoryBot.create(:project, creator: subject) }
+    let(:project) { FactoryBot.create(:project, creator: subject) }
+    let(:object) { Permission.new(resource: project, role_names: %[project_editor]) }
+
     the_subject_behaves_like "instance abilities", Permission, all: true
   end
 end

--- a/api/spec/authorizers/project_authorizer_spec.rb
+++ b/api/spec/authorizers/project_authorizer_spec.rb
@@ -341,6 +341,8 @@ RSpec.describe "Project Abilities", :authorizer do
     it { is_expected.to be_able_to(:read).on(journal_issue.project) }
     it { is_expected.to be_able_to(:update).on(journal_issue.project) }
     it { is_expected.not_to be_able_to(:create).on(journal_issue.project) }
+    it { is_expected.to be_able_to(:manage_entitlements).on(journal_issue.project) }
+    it { is_expected.to be_able_to(:create_entitlements).on(journal_issue.project) }
 
     it "cannot delete a journal issue's project directly (delete the journal issue itself)" do
       is_expected.not_to be_able_to(:delete).on(journal_issue.project)

--- a/api/spec/authorizers/project_authorizer_spec.rb
+++ b/api/spec/authorizers/project_authorizer_spec.rb
@@ -328,4 +328,16 @@ RSpec.describe "Project Abilities", :authorizer do
       it { is_expected.not_to be_authorized_to :fully_read, project }
     end
   end
+
+  context "when the user is an editor of an associated journal" do
+    let!(:user) { FactoryBot.create :user }
+    let!(:journal) { FactoryBot.create :journal}
+    let!(:journal_issue) { FactoryBot.create :journal_issue, journal: journal }
+    before do
+      user.add_role :journal_editor, journal
+      user.remove_role :reader
+    end
+
+    include_examples "full access"
+  end
 end

--- a/api/spec/authorizers/project_authorizer_spec.rb
+++ b/api/spec/authorizers/project_authorizer_spec.rb
@@ -338,6 +338,12 @@ RSpec.describe "Project Abilities", :authorizer do
       user.remove_role :reader
     end
 
-    include_examples "full access"
+    it { is_expected.to be_able_to(:read).on(journal_issue.project) }
+    it { is_expected.to be_able_to(:update).on(journal_issue.project) }
+    it { is_expected.to be_able_to(:destroy).on(journal_issue.project) }
+    it { is_expected.to be_able_to(:create).on(journal_issue.project) }
+
+    it { is_expected.not_to be_able_to(:update).on(project) }
+    xit { is_expected.not_to be_able_to(:destroy).on(project) }
   end
 end

--- a/api/spec/factories/journal_issue.rb
+++ b/api/spec/factories/journal_issue.rb
@@ -8,6 +8,9 @@ FactoryBot.define do
     trait :with_volume do
       association :journal_volume, factory: :journal_volume
     end
+  end
 
+  factory :draft_journal_issue, parent: :journal_issue do
+    association :project, factory: :draft_project
   end
 end

--- a/api/spec/factories/project.rb
+++ b/api/spec/factories/project.rb
@@ -17,4 +17,8 @@ FactoryBot.define do
       restricted_access { true }
     end
   end
+
+  factory :draft_project, parent: :project do
+    draft { true }
+  end
 end

--- a/api/spec/requests/journals/relationships/journal_issues_controller_spec.rb
+++ b/api/spec/requests/journals/relationships/journal_issues_controller_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe "Journal JournalIssues API", type: :request do
   let_it_be(:journal, refind: true) { FactoryBot.create(:journal) }
+  let_it_be(:project, refind: true) { FactoryBot.create(:project) }
 
   describe "creates a journal issue" do
     let(:path) { api_v1_journal_relationships_journal_issues_path(journal) }
@@ -9,8 +10,7 @@ RSpec.describe "Journal JournalIssues API", type: :request do
     context "when the user is an admin" do
       let(:headers) { admin_headers }
 
-      context "when a project is provided" do
-        let(:project) { FactoryBot.create(:project) }
+      context "when a project is provided that the user can update" do
         let(:params) do
           {
             attributes: { number: 1 },
@@ -25,11 +25,13 @@ RSpec.describe "Journal JournalIssues API", type: :request do
           }
         end
 
-        describe "the response" do
-          it "has a 201 CREATED status code" do
+        it "creates an issue with the existing project" do
+          expect do
             post path, headers: headers, params: build_json_payload(params)
-            expect(response).to have_http_status(201)
-          end
+          end.to change(JournalIssue, :count).by(1)
+            .and keep_the_same(Project, :count)
+
+          expect(response).to have_http_status(201)
         end
       end
 
@@ -40,11 +42,65 @@ RSpec.describe "Journal JournalIssues API", type: :request do
           }
         end
 
-        describe "the response" do
-          it "has a 201 CREATED status code" do
+        it "creates an issue AND a project" do
+          expect do
             post path, headers: headers, params: build_json_payload(params)
-            expect(response).to have_http_status(201)
-          end
+          end.to change(JournalIssue, :count).by(1)
+            .and change(Project, :count).by(1)
+
+          expect(response).to have_http_status(201)
+        end
+      end
+    end
+
+    context "when the user is a journal editor" do
+      let_it_be(:journal_editor, refind: true) { FactoryBot.create :user }
+
+      let!(:headers) { build_headers_for journal_editor }
+
+      before do
+        journal_editor.add_role :journal_editor, journal
+      end
+
+      context "when a project is provided that the user can't update" do
+        let(:params) do
+          {
+            attributes: { number: 1 },
+            relationships: {
+              project: {
+                data: {
+                  id: project.id,
+                  type: "projects"
+                }
+              }
+            }
+          }
+        end
+
+        it "does not create an issue" do
+          expect do
+            post path, headers: headers, params: build_json_payload(params)
+          end.to keep_the_same(JournalIssue, :count)
+            .and keep_the_same(Project, :count)
+
+          expect(response).to have_http_status(403)
+        end
+      end
+
+      context "when no project is provided" do
+        let(:params) do
+          {
+            attributes: { number: "1", pendingSlug: "test" }
+          }
+        end
+
+        it "creates an issue and a project" do
+          expect do
+            post path, headers: headers, params: build_json_payload(params)
+          end.to change(JournalIssue, :count).by(1)
+            .and change(Project, :count).by(1)
+
+          expect(response).to have_http_status(201)
         end
       end
     end

--- a/api/spec/support/requests/authenticated_request.rb
+++ b/api/spec/support/requests/authenticated_request.rb
@@ -16,6 +16,12 @@ RSpec.shared_context "authenticated request" do
     }
   end
 
+  def build_headers_for(user)
+    token = AuthToken.encode_user(user)
+
+    build_headers token
+  end
+
   def get_user_token(user_type)
     public_send("#{user_type}_auth")
   end


### PR DESCRIPTION
This PR fixes some bugs where journal editors were able to view journal issues, but not the projects within the journal issues (which basically means they couldn't view the issues).