### PR TITLE
[F] Implement PG search filtering

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -91,6 +91,7 @@ gem "paper_trail", "~> 14.0"
 gem "paper_trail-association_tracking", "~> 2.2.1"
 gem "paper_trail-globalid", "~> 0.2"
 gem "pg", "~> 1.2"
+gem 'pg_search'
 gem "premailer-rails", "~> 1.0"
 gem "pry-rails", "~> 0.3.9"
 gem "puma", "~> 6.4"

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -91,7 +91,7 @@ gem "paper_trail", "~> 14.0"
 gem "paper_trail-association_tracking", "~> 2.2.1"
 gem "paper_trail-globalid", "~> 0.2"
 gem "pg", "~> 1.2"
-gem 'pg_search'
+gem "pg_search"
 gem "premailer-rails", "~> 1.0"
 gem "pry-rails", "~> 0.3.9"
 gem "puma", "~> 6.4"

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -528,6 +528,9 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    pg_search (2.3.6)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     premailer (1.21.0)
       addressable
       css_parser (>= 1.12.0)
@@ -900,6 +903,7 @@ DEPENDENCIES
   paper_trail-globalid (~> 0.2)
   parallel_tests (~> 2.29.2)
   pg (~> 1.2)
+  pg_search
   premailer-rails (~> 1.0)
   pry-rails (~> 0.3.9)
   puma (~> 6.4)

--- a/api/README.md
+++ b/api/README.md
@@ -57,3 +57,12 @@ bin/pspec-failures
 You can still use regular rspec commands for specific tags or individual spec files if you should need to. Parallelization is intended mainly for speeding up global test runs when necessary.
 
 `SimpleCov` transparently detects the presence of `parallel_tests`, and handles the merging the coverage information without any intervention on our part.
+
+## Setting up Dev Database
+
+We have an `import.tar` file that contains a number of sample projects and texts you can use for development. Ask around and someone can provide it to you. Once you get it, extract it and run the `import:projects` rake task on it:
+
+```bash
+tar -xf import.tar
+docker compose exec web bin/rake 'manifold:import:projects[import]'
+```

--- a/api/app/models/annotation.rb
+++ b/api/app/models/annotation.rb
@@ -94,6 +94,7 @@ class Annotation < ApplicationRecord
   delegate :text_nodes, to: :text_section, prefix: true
 
   # Search
+  pg_search_scope :keyword_search, against: [:title, :body]
   searchkick(callbacks: :async,
              batch_size: 500,
              highlight: [:title, :body])

--- a/api/app/models/annotation.rb
+++ b/api/app/models/annotation.rb
@@ -94,7 +94,6 @@ class Annotation < ApplicationRecord
   delegate :text_nodes, to: :text_section, prefix: true
 
   # Search
-  pg_search_scope :keyword_search, against: [:title, :body]
   searchkick(callbacks: :async,
              batch_size: 500,
              highlight: [:title, :body])

--- a/api/app/models/concerns/filterable.rb
+++ b/api/app/models/concerns/filterable.rb
@@ -10,6 +10,7 @@ module Filterable
   extend ActiveSupport::Concern
 
   include LazyOrdering
+  include PgSearch::Model
 
   included do
     extend Dry::Core::ClassAttributes

--- a/api/app/models/concerns/filterable.rb
+++ b/api/app/models/concerns/filterable.rb
@@ -10,7 +10,6 @@ module Filterable
   extend ActiveSupport::Concern
 
   include LazyOrdering
-  include PgSearch::Model
 
   included do
     extend Dry::Core::ClassAttributes

--- a/api/app/models/concerns/has_keyword_search.rb
+++ b/api/app/models/concerns/has_keyword_search.rb
@@ -12,11 +12,13 @@ module HasKeywordSearch
 
   module ClassMethods
     # @return [void]
+    # rubocop:disable Naming/PredicateName
     def has_keyword_search!(**options)
       keyword_search_options options.freeze
 
       pg_search_scope :keyword_search, **options
     end
+    # rubocop:enable Naming/PredicateName
 
     def has_keyword_search?
       keyword_search_options.present?

--- a/api/app/models/concerns/has_keyword_search.rb
+++ b/api/app/models/concerns/has_keyword_search.rb
@@ -1,0 +1,25 @@
+module HasKeywordSearch
+  extend ActiveSupport::Concern
+  include PgSearch::Model
+
+  included do
+    extend Dry::Core::ClassAttributes
+
+    defines :keyword_search_options, type: ::Types::Hash.map(::Types::Symbol, ::Types::Any)
+
+    keyword_search_options({}.freeze)
+  end
+
+  module ClassMethods
+    # @return [void]
+    def has_keyword_search!(**options)
+      keyword_search_options options.freeze
+
+      pg_search_scope :keyword_search, **options
+    end
+
+    def has_keyword_search?
+      keyword_search_options.present?
+    end
+  end
+end

--- a/api/app/models/event.rb
+++ b/api/app/models/event.rb
@@ -5,7 +5,6 @@ class Event < ApplicationRecord
   TYPEAHEAD_ATTRIBUTES = [:title].freeze
   KEYWORD_SEARCH_ATTRIBUTES = %i[subject_title subject_subtitle excerpt].freeze
 
-
   # ClassyEnum
   include ClassyEnum::ActiveRecord
   classy_enum_attr :event_type

--- a/api/app/models/event.rb
+++ b/api/app/models/event.rb
@@ -5,6 +5,7 @@ class Event < ApplicationRecord
   TYPEAHEAD_ATTRIBUTES = [:title].freeze
   KEYWORD_SEARCH_ATTRIBUTES = %i[subject_title subject_subtitle excerpt].freeze
 
+
   # ClassyEnum
   include ClassyEnum::ActiveRecord
   classy_enum_attr :event_type
@@ -18,6 +19,8 @@ class Event < ApplicationRecord
   include Filterable
   include HasFormattedAttributes
   include SearchIndexable
+  include HasKeywordSearch
+  has_keyword_search! against: KEYWORD_SEARCH_ATTRIBUTES
 
   has_formatted_attribute :subject_title
 
@@ -50,7 +53,6 @@ class Event < ApplicationRecord
   validates :event_type, presence: true
 
   # Search
-  pg_search_scope :keyword_search, against: KEYWORD_SEARCH_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/event.rb
+++ b/api/app/models/event.rb
@@ -3,6 +3,7 @@
 class Event < ApplicationRecord
 
   TYPEAHEAD_ATTRIBUTES = [:title].freeze
+  KEYWORD_SEARCH_ATTRIBUTES = %i[subject_title subject_subtitle excerpt].freeze
 
   # ClassyEnum
   include ClassyEnum::ActiveRecord
@@ -49,7 +50,7 @@ class Event < ApplicationRecord
   validates :event_type, presence: true
 
   # Search
-  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
+  pg_search_scope :keyword_search, against: KEYWORD_SEARCH_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/event.rb
+++ b/api/app/models/event.rb
@@ -49,6 +49,7 @@ class Event < ApplicationRecord
   validates :event_type, presence: true
 
   # Search
+  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/ingestion_source.rb
+++ b/api/app/models/ingestion_source.rb
@@ -11,6 +11,7 @@ class IngestionSource < ApplicationRecord
   include SerializedAbilitiesFor
   include SearchIndexable
   include Attachments
+  include HasKeywordSearch
   self.authorizer_name = "ProjectChildAuthorizer"
 
   classy_enum_attr :kind, enum: "IngestionSourceKind", allow_blank: false
@@ -53,6 +54,7 @@ class IngestionSource < ApplicationRecord
   end
 
   # Search
+  has_keyword_search! against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500)

--- a/api/app/models/ingestion_source.rb
+++ b/api/app/models/ingestion_source.rb
@@ -53,7 +53,6 @@ class IngestionSource < ApplicationRecord
   end
 
   # Search
-  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500)

--- a/api/app/models/ingestion_source.rb
+++ b/api/app/models/ingestion_source.rb
@@ -53,6 +53,7 @@ class IngestionSource < ApplicationRecord
   end
 
   # Search
+  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500)

--- a/api/app/models/journal.rb
+++ b/api/app/models/journal.rb
@@ -24,6 +24,7 @@ class Journal < ApplicationRecord
   include WithPermittedUsers
   include WithProjectCollectionLayout
   include WithConfigurableAvatar
+  include HasKeywordSearch
 
   has_formatted_attributes :description, :subtitle, :image_credits
   has_formatted_attributes :title, include_wrap: false
@@ -84,6 +85,13 @@ class Journal < ApplicationRecord
 
   scope :search_import, -> { includes(:collaborators, :makers) }
 
+  has_keyword_search!(
+    against: %i[title subtitle description],
+    associated_against: {
+      creator: %i[first_name last_name nickname],
+      makers: %i[first_name last_name display_name]
+    }
+  )
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/journal.rb
+++ b/api/app/models/journal.rb
@@ -84,7 +84,6 @@ class Journal < ApplicationRecord
 
   scope :search_import, -> { includes(:collaborators, :makers) }
 
-  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/journal.rb
+++ b/api/app/models/journal.rb
@@ -84,6 +84,7 @@ class Journal < ApplicationRecord
 
   scope :search_import, -> { includes(:collaborators, :makers) }
 
+  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/journal_issue.rb
+++ b/api/app/models/journal_issue.rb
@@ -101,6 +101,7 @@ class JournalIssue < ApplicationRecord
     )
   }
 
+  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/journal_issue.rb
+++ b/api/app/models/journal_issue.rb
@@ -14,6 +14,13 @@ class JournalIssue < ApplicationRecord
   include HasFormattedAttributes
   include SearchIndexable
   include HasSortTitle
+  include HasKeywordSearch
+
+  has_keyword_search! associated_against: {
+    journal: [:title],
+    journal_volume: [:number],
+    project: [:description]
+  }
 
   belongs_to :journal, counter_cache: true
   belongs_to :journal_volume, optional: true, counter_cache: true
@@ -101,11 +108,6 @@ class JournalIssue < ApplicationRecord
     )
   }
 
-  pg_search_scope :keyword_search, associated_against: {
-    journal: [:title],
-    journal_volume: [:number],
-    project: [:description]
-  }
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/journal_issue.rb
+++ b/api/app/models/journal_issue.rb
@@ -101,7 +101,11 @@ class JournalIssue < ApplicationRecord
     )
   }
 
-  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
+  pg_search_scope :keyword_search, associated_against: {
+    journal: [:title],
+    journal_volume: [:number],
+    project: [:description]
+  }
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/maker.rb
+++ b/api/app/models/maker.rb
@@ -15,6 +15,7 @@ class Maker < ApplicationRecord
   include SerializedAbilitiesFor
   include WithParsedName
   include SearchIndexable
+  include HasKeywordSearch
 
   # Associations
   has_many :collaborators, dependent: :destroy
@@ -35,7 +36,7 @@ class Maker < ApplicationRecord
   validate :name_is_present!
 
   # Search
-  pg_search_scope :keyword_search, against: KEYWORD_SEARCH_ATTRIBUTES
+  has_keyword_search! against: KEYWORD_SEARCH_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500)

--- a/api/app/models/maker.rb
+++ b/api/app/models/maker.rb
@@ -2,6 +2,7 @@
 class Maker < ApplicationRecord
   # Constants
   TYPEAHEAD_ATTRIBUTES = [:first_name, :last_name].freeze
+  KEYWORD_SEARCH_ATTRIBUTES = %i[name first_name middle_name last_name display_name].freeze
 
   PACKAGING_ATTRIBUTES = %i[id name first_name middle_name last_name display_name suffix prefix].freeze
 
@@ -34,6 +35,7 @@ class Maker < ApplicationRecord
   validate :name_is_present!
 
   # Search
+  pg_search_scope :keyword_search, against: KEYWORD_SEARCH_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500)

--- a/api/app/models/maker.rb
+++ b/api/app/models/maker.rb
@@ -2,7 +2,7 @@
 class Maker < ApplicationRecord
   # Constants
   TYPEAHEAD_ATTRIBUTES = [:first_name, :last_name].freeze
-  KEYWORD_SEARCH_ATTRIBUTES = %i[name first_name middle_name last_name display_name].freeze
+  KEYWORD_SEARCH_ATTRIBUTES = %i[first_name middle_name last_name display_name].freeze
 
   PACKAGING_ATTRIBUTES = %i[id name first_name middle_name last_name display_name suffix prefix].freeze
 

--- a/api/app/models/project.rb
+++ b/api/app/models/project.rb
@@ -27,6 +27,7 @@ class Project < ApplicationRecord
   include SoftDeletable
   include TimestampScopes
   include WithConfigurableAvatar
+  include HasKeywordSearch
 
   has_formatted_attributes :description, :subtitle, :image_credits
   has_formatted_attributes :restricted_access_body, include_wrap: false
@@ -239,6 +240,16 @@ class Project < ApplicationRecord
     )
   }
 
+  has_keyword_search!(
+    against: %i[title subtitle description],
+    associated_against: {
+      creator: %i[first_name last_name],
+      makers: %i[first_name last_name display_name],
+      texts: %i[social_title],
+      subjects: %i[name],
+      tags: %i[name]
+    }
+  )
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/project.rb
+++ b/api/app/models/project.rb
@@ -239,7 +239,6 @@ class Project < ApplicationRecord
     )
   }
 
-  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/project.rb
+++ b/api/app/models/project.rb
@@ -239,6 +239,7 @@ class Project < ApplicationRecord
     )
   }
 
+  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/resource.rb
+++ b/api/app/models/resource.rb
@@ -116,7 +116,6 @@ class Resource < ApplicationRecord
   after_commit :queue_fetch_thumbnail, on: [:create, :update]
   after_commit :trigger_event_creation, on: [:create]
 
-  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/resource.rb
+++ b/api/app/models/resource.rb
@@ -18,6 +18,7 @@ class Resource < ApplicationRecord
   include Sluggable
   include Metadata
   include SearchIndexable
+  include HasKeywordSearch
 
   TYPEAHEAD_ATTRIBUTES = [:title].freeze
   ALLOWED_KINDS = %w(image video audio link pdf document file spreadsheet presentation
@@ -116,6 +117,7 @@ class Resource < ApplicationRecord
   after_commit :queue_fetch_thumbnail, on: [:create, :update]
   after_commit :trigger_event_creation, on: [:create]
 
+  has_keyword_search! against:%i[title description]
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/resource.rb
+++ b/api/app/models/resource.rb
@@ -117,7 +117,7 @@ class Resource < ApplicationRecord
   after_commit :queue_fetch_thumbnail, on: [:create, :update]
   after_commit :trigger_event_creation, on: [:create]
 
-  has_keyword_search! against:%i[title description]
+  has_keyword_search! against: %i[title description]
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/resource.rb
+++ b/api/app/models/resource.rb
@@ -116,6 +116,7 @@ class Resource < ApplicationRecord
   after_commit :queue_fetch_thumbnail, on: [:create, :update]
   after_commit :trigger_event_creation, on: [:create]
 
+  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/resource_collection.rb
+++ b/api/app/models/resource_collection.rb
@@ -44,6 +44,7 @@ class ResourceCollection < ApplicationRecord
     order(by)
   }
 
+  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(callbacks: :async,
              batch_size: 500,
              word_start: TYPEAHEAD_ATTRIBUTES,

--- a/api/app/models/resource_collection.rb
+++ b/api/app/models/resource_collection.rb
@@ -10,6 +10,7 @@ class ResourceCollection < ApplicationRecord
   include Sluggable
   include SerializedAbilitiesFor
   include SearchIndexable
+  include HasKeywordSearch
 
   TYPEAHEAD_ATTRIBUTES = [:title].freeze
 
@@ -44,6 +45,12 @@ class ResourceCollection < ApplicationRecord
     order(by)
   }
 
+  has_keyword_search!(
+    against: %i[title description],
+    associated_against: {
+      project: %i[title]
+    }
+  )
   searchkick(callbacks: :async,
              batch_size: 500,
              word_start: TYPEAHEAD_ATTRIBUTES,

--- a/api/app/models/resource_collection.rb
+++ b/api/app/models/resource_collection.rb
@@ -44,7 +44,6 @@ class ResourceCollection < ApplicationRecord
     order(by)
   }
 
-  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(callbacks: :async,
              batch_size: 500,
              word_start: TYPEAHEAD_ATTRIBUTES,

--- a/api/app/models/subject.rb
+++ b/api/app/models/subject.rb
@@ -9,6 +9,7 @@ class Subject < ApplicationRecord
   include SerializedAbilitiesFor
   include Filterable
   include SearchIndexable
+  include HasKeywordSearch
 
   # Associations
   has_many :text_subjects, dependent: :destroy
@@ -40,6 +41,7 @@ class Subject < ApplicationRecord
   alias_attribute :title, :name
 
   # Search
+  has_keyword_search! against: %i[name]
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500)

--- a/api/app/models/subject.rb
+++ b/api/app/models/subject.rb
@@ -40,7 +40,6 @@ class Subject < ApplicationRecord
   alias_attribute :title, :name
 
   # Search
-  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500)

--- a/api/app/models/subject.rb
+++ b/api/app/models/subject.rb
@@ -40,6 +40,7 @@ class Subject < ApplicationRecord
   alias_attribute :title, :name
 
   # Search
+  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500)

--- a/api/app/models/tag.rb
+++ b/api/app/models/tag.rb
@@ -6,6 +6,7 @@ class Tag < ActsAsTaggableOn::Tag
   include SerializedAbilitiesFor
   include Filterable
   include SearchIndexable
+  include HasKeywordSearch
 
   scope :by_kind, lambda { |kind|
     joins(:taggings).where(taggings: { taggable_type: kind }) if kind.present?
@@ -14,6 +15,7 @@ class Tag < ActsAsTaggableOn::Tag
   alias_attribute :title, :name
 
   # Search
+  has_keyword_search! against: %i[name]
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500)

--- a/api/app/models/tag.rb
+++ b/api/app/models/tag.rb
@@ -14,7 +14,6 @@ class Tag < ActsAsTaggableOn::Tag
   alias_attribute :title, :name
 
   # Search
-  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500)

--- a/api/app/models/tag.rb
+++ b/api/app/models/tag.rb
@@ -14,6 +14,7 @@ class Tag < ActsAsTaggableOn::Tag
   alias_attribute :title, :name
 
   # Search
+  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500)

--- a/api/app/models/text.rb
+++ b/api/app/models/text.rb
@@ -129,6 +129,7 @@ class Text < ApplicationRecord
   after_commit :trigger_text_added_event, on: [:create, :update]
   after_commit :inject_global_stylesheet, on: :create
 
+  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/text.rb
+++ b/api/app/models/text.rb
@@ -20,6 +20,7 @@ class Text < ApplicationRecord
   include SoftDeletable
   include TableOfContentsWithCollected
   include TimestampScopes
+  include HasKeywordSearch
 
   TYPEAHEAD_ATTRIBUTES = %i[title makers].freeze
 
@@ -130,7 +131,7 @@ class Text < ApplicationRecord
   after_commit :trigger_text_added_event, on: [:create, :update]
   after_commit :inject_global_stylesheet, on: :create
 
-  pg_search_scope :keyword_search, associated_against: {titles: [:value]}, against: [:description]
+  has_keyword_search! associated_against: {titles: [:value]}, against: [:description]
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/text.rb
+++ b/api/app/models/text.rb
@@ -21,7 +21,8 @@ class Text < ApplicationRecord
   include TableOfContentsWithCollected
   include TimestampScopes
 
-  TYPEAHEAD_ATTRIBUTES = [:title, :makers].freeze
+  TYPEAHEAD_ATTRIBUTES = %i[title makers].freeze
+
 
   has_paper_trail meta: {
     parent_item_id: :project_id,
@@ -129,7 +130,7 @@ class Text < ApplicationRecord
   after_commit :trigger_text_added_event, on: [:create, :update]
   after_commit :inject_global_stylesheet, on: :create
 
-  pg_search_scope :keyword_search, against: TYPEAHEAD_ATTRIBUTES
+  pg_search_scope :keyword_search, associated_against: {titles: [:value]}, against: [:description]
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/text.rb
+++ b/api/app/models/text.rb
@@ -24,7 +24,6 @@ class Text < ApplicationRecord
 
   TYPEAHEAD_ATTRIBUTES = %i[title makers].freeze
 
-
   has_paper_trail meta: {
     parent_item_id: :project_id,
     parent_item_type: "Project",
@@ -131,7 +130,7 @@ class Text < ApplicationRecord
   after_commit :trigger_text_added_event, on: [:create, :update]
   after_commit :inject_global_stylesheet, on: :create
 
-  has_keyword_search! associated_against: {titles: [:value]}, against: [:description]
+  has_keyword_search! associated_against: { titles: [:value] }, against: [:description]
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,
              batch_size: 500,

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ApplicationRecord
   include WithParsedName
   include SearchIndexable
   include SoftDeletable
+  include HasKeywordSearch
 
   TYPEAHEAD_ATTRIBUTES = [:title, :first_name, :last_name, :email].freeze
 
@@ -103,6 +104,7 @@ class User < ApplicationRecord
   scope :untrusted, -> { where(trusted: false) }
 
   # Search
+  has_keyword_search! against: %i[first_name last_name email]
   searchkick word_start: TYPEAHEAD_ATTRIBUTES, callbacks: :async
 
   delegate *RoleName.global_predicates, to: :role

--- a/api/app/operations/filtering/apply.rb
+++ b/api/app/operations/filtering/apply.rb
@@ -11,7 +11,7 @@ module Filtering
     # @param [Boolean] use_pg_search
     # @return [Searchkick::Relation]
     # @return [ActiveRecord::Relation] with kaminari data from {.by_pagination}.
-    def call(raw_params, scope:, user:, model: scope.model, skip_pagination: false, use_pg_search: false)
+    def call(raw_params, scope:, user:, model: scope.model, skip_pagination: false, use_pg_search: ENV["USE_PG_SEARCH"])
       if use_pg_search
         Filtering::Postgres::Applicator.new(raw_params, model: model, scope: scope, user: user, skip_pagination: skip_pagination).call
       else

--- a/api/app/operations/filtering/apply.rb
+++ b/api/app/operations/filtering/apply.rb
@@ -8,10 +8,15 @@ module Filtering
     # @param [ActiveRecord::Relation] scope
     # @param [User, nil] user
     # @param [Boolean] skip_pagination
+    # @param [Boolean] use_pg_search
     # @return [Searchkick::Relation]
     # @return [ActiveRecord::Relation] with kaminari data from {.by_pagination}.
-    def call(raw_params, scope:, user:, model: scope.model, skip_pagination: false)
-      Filtering::Applicator.new(raw_params, model: model, scope: scope, user: user, skip_pagination: skip_pagination).call
+    def call(raw_params, scope:, user:, model: scope.model, skip_pagination: false, use_pg_search: false)
+      if use_pg_search
+        Filtering::Postgres::Applicator.new(raw_params, model: model, scope: scope, user: user, skip_pagination: skip_pagination).call
+      else
+        Filtering::Applicator.new(raw_params, model: model, scope: scope, user: user, skip_pagination: skip_pagination).call
+      end
     end
   end
 end

--- a/api/app/operations/filtering/apply.rb
+++ b/api/app/operations/filtering/apply.rb
@@ -11,6 +11,7 @@ module Filtering
     # @param [Boolean] use_pg_search
     # @return [Searchkick::Relation]
     # @return [ActiveRecord::Relation] with kaminari data from {.by_pagination}.
+    # rubocop:disable Metrics/ParameterLists - this extra pg toggle should be temporary
     def call(raw_params, scope:, user:, model: scope.model, skip_pagination: false, use_pg_search: ENV["USE_PG_SEARCH"])
       if use_pg_search
         Filtering::Postgres::Applicator.new(raw_params, model: model, scope: scope, user: user, skip_pagination: skip_pagination).call
@@ -18,5 +19,6 @@ module Filtering
         Filtering::Applicator.new(raw_params, model: model, scope: scope, user: user, skip_pagination: skip_pagination).call
       end
     end
+    # rubocop:enable Metrics/ParameterLists - this extra pg toggle should be temporary
   end
 end

--- a/api/app/services/filtering/postgres/applicator.rb
+++ b/api/app/services/filtering/postgres/applicator.rb
@@ -1,0 +1,194 @@
+module Filtering
+  module Postgres
+    class Applicator
+    include Dry::Initializer[undefined: false].define -> do
+      param :raw_params, Filtering::Types::Params
+
+      option :scope, Filtering::Types::Scope
+
+      option :user, Filtering::Types::User.optional, optional: true
+
+      option :skip_pagination, Filtering::Types::Bool.optional, default: proc { false }, as: :skip_pagination_option
+
+      option :model, Filtering::Types::ModelKlass, default: proc { scope.model }
+    end
+
+    include ManifoldApi::Deps[
+      maybe_scope_by_param: "filtering.maybe_scope_by_param",
+    ]
+
+    # @return [Filtering::Config]
+    attr_reader :config
+
+    # @return [ActiveSupport::HashWithIndifferentAccess]
+    attr_reader :params
+
+    # @return [Searchkick::Relation]
+    # @return [ActiveRecord::Relation] with kaminari data from {.by_pagination}.
+    attr_reader :results
+
+    # @return [Boolean]
+    attr_reader :skip_pagination
+
+    # @return [Searchkick::Relation]
+    # @return [ActiveRecord::Relation] with kaminari data from {.by_pagination}.
+    def call
+      set_up!
+
+      filter_with_database!
+
+      if should_apply_keyword_search?
+        @ids = @filtered_scope.distinct.reorder(nil).pluck(:id)
+
+        apply_keyword_search!
+      elsif should_apply_pagination?
+        @results = @filtered_scope.page(params[:page]).per(params[:per_page])
+      else
+        @results = @filtered_scope.all
+      end
+
+      return results
+    end
+
+    private
+
+    def apply_keyword_search!
+      @results = model.keyword_search(params[:keyword])
+
+      return unless exceeds_total_pages?(@results)
+
+      params[:page] = results.total_pages
+
+      @results = model.keyword_search
+    end
+
+    # @!group Steps
+
+    # @return [void]
+    def set_up!
+      @config = model.filtering_config
+
+      @params = normalize_params
+
+      @skip_pagination = @params[:skip_pagination] || RequestStore[:skip_pagination] || skip_pagination_option
+    end
+
+    # This will filter the given scope by the provided hash of params,
+    # and either prepare the
+    # @return [void]
+    def filter_with_database!
+      @filtered_scope = filter_with_database.apply_filtering_loads
+    end
+
+    # @!endgroup
+
+    # @!group Filtering Actions
+
+    # @return [ActiveRecord::Relation]
+    def filter_with_database
+      maybe_apply_default_order do
+        params.reduce scope do |query, (key, value)|
+          apply_database_filter query, key, value
+        end
+      end
+    end
+
+    # @!endgroup
+
+    # @!group Database Filtering
+
+    # Try to filter by a single param.
+    #
+    # @see Filtering::MaybeScopeByParam
+    # @param [ActiveRecord::Relation] query
+    # @param [String] key
+    # @param [Object] value
+    # @return [ActiveRecord::Relation]
+    def apply_database_filter(query, key, value)
+      return query if config.blacklisted_param?(key)
+
+      unless param_requires_user?(key)
+        maybe_scope_by_param.(query, key, value)
+      else
+        if query.respond_to?(key)
+          query.public_send(key, user)
+        else
+          query.all
+        end
+      end
+    end
+
+    # Match a certain pattern of param keys that conform to a scope on the
+    # model that take the provided user as their argument.
+    #
+    # @param [String] key
+    def param_requires_user?(key)
+      key.start_with?("with_") && key.end_with?("_ability", "_role")
+    end
+
+    # @!endgroup
+
+    # @!group Searchkick Filtering
+
+    # @return [ActiveRecord::Relation]
+    def maybe_apply_default_order
+      return yield unless should_apply_default_order?
+
+      initial_order_values = scope.order_values
+
+      final_scope = yield
+
+      final_order_values = final_scope.order_values
+
+      return final_scope unless initial_order_values == final_order_values
+
+      config.apply_default_order!(final_scope)
+    end
+
+    def search_query
+      params[:keyword].presence || "*"
+    end
+
+    def should_apply_keyword_search?
+      return false unless params.key?(:keyword)
+      return false if has_keyword_scope?
+      return false unless @filtered_scope.exists?
+
+      return true
+    end
+
+    def has_keyword_scope?
+      scope.respond_to?(:by_keyword)
+    end
+
+    # @param [Searchkick::Relation] results
+    def exceeds_total_pages?(results)
+      return false unless paginated? results
+
+      # No sense in re-running the ES query if we're already asking for the first page.
+      return false if results.current_page == 1
+
+      results.current_page > results.total_pages
+    end
+
+    def paginated?(results)
+      results.respond_to?(:current_page) && results.total_pages.present?
+    end
+
+    def should_apply_default_order?
+      config.should_apply_default_order?(params)
+    end
+
+    def should_apply_pagination?
+      !skip_pagination && params[:page].present?
+    end
+
+    # @!endgroup
+
+    def normalize_params
+      raw_params.with_indifferent_access.reverse_merge(page: 1, per_page: model.default_per_page)
+    end
+
+    end
+  end
+end

--- a/api/db/migrate/20250312204629_create_pg_search_documents.rb
+++ b/api/db/migrate/20250312204629_create_pg_search_documents.rb
@@ -1,0 +1,17 @@
+class CreatePgSearchDocuments < ActiveRecord::Migration[6.1]
+  def up
+    say_with_time("Creating table for pg_search multisearch") do
+      create_table :pg_search_documents do |t|
+        t.text :content
+        t.belongs_to :searchable, polymorphic: true, index: true
+        t.timestamps null: false
+      end
+    end
+  end
+
+  def down
+    say_with_time("Dropping table for pg_search multisearch") do
+      drop_table :pg_search_documents
+    end
+  end
+end

--- a/api/db/structure.sql
+++ b/api/db/structure.sql
@@ -1790,6 +1790,39 @@ CREATE VIEW public.permissions AS
 
 
 --
+-- Name: pg_search_documents; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.pg_search_documents (
+    id bigint NOT NULL,
+    content text,
+    searchable_type character varying,
+    searchable_id bigint,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: pg_search_documents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.pg_search_documents_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: pg_search_documents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.pg_search_documents_id_seq OWNED BY public.pg_search_documents.id;
+
+
+--
 -- Name: project_collection_subjects; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3149,6 +3182,13 @@ ALTER TABLE ONLY public.pages ALTER COLUMN id SET DEFAULT nextval('public.pages_
 
 
 --
+-- Name: pg_search_documents id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pg_search_documents ALTER COLUMN id SET DEFAULT nextval('public.pg_search_documents_id_seq'::regclass);
+
+
+--
 -- Name: project_collection_subjects id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3553,6 +3593,14 @@ ALTER TABLE ONLY public.pending_entitlement_transitions
 
 ALTER TABLE ONLY public.pending_entitlements
     ADD CONSTRAINT pending_entitlements_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pg_search_documents pg_search_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pg_search_documents
+    ADD CONSTRAINT pg_search_documents_pkey PRIMARY KEY (id);
 
 
 --
@@ -4908,6 +4956,13 @@ CREATE INDEX index_pending_entitlements_on_subject_type_and_subject_id ON public
 --
 
 CREATE INDEX index_pending_entitlements_on_user_id ON public.pending_entitlements USING btree (user_id);
+
+
+--
+-- Name: index_pg_search_documents_on_searchable; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pg_search_documents_on_searchable ON public.pg_search_documents USING btree (searchable_type, searchable_id);
 
 
 --
@@ -7379,4 +7434,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250129200019'),
 ('20250210192150'),
 ('20250210230256'),
-('20250306230246');
+('20250306230246'),
+('20250312204629');
+
+

--- a/api/spec/factories/journal_issue.rb
+++ b/api/spec/factories/journal_issue.rb
@@ -13,4 +13,16 @@ FactoryBot.define do
   factory :draft_journal_issue, parent: :journal_issue do
     association :project, factory: :draft_project
   end
+
+  factory :journal_issue_with_title, parent: :journal_issue do
+    transient do
+      journal_attributes {{title: "new"}}
+      journal_volume_attributes {{number: 1}}
+      project_attributes {{description: "tomorrow"}}
+    end
+    journal { association :journal, **journal_attributes }
+    project { association :project, **project_attributes }
+    association :creator, factory: :user
+    journal_volume { association :journal_volume, **journal_volume_attributes }
+  end
 end

--- a/api/spec/operations/filtering/apply_spec.rb
+++ b/api/spec/operations/filtering/apply_spec.rb
@@ -137,5 +137,17 @@ RSpec.describe Filtering::Apply, type: :operation do
         expect(operation.call({keyword: "Luke"}, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
+
+    it "performs keyword search on Journal model" do
+      FactoryBot.create_list(:journal, 5, title: "hello", description: "foo")
+      FactoryBot.create_list(:journal, 4, title: "goodbye", description: "bar")
+      aggregate_failures("multiple filters") do
+        expect(operation.call({keyword: "hello"}, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({keyword: "goodbye"}, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({keyword: "foo"}, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({keyword: "bar"}, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({keyword: "Luke"}, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(0)
+      end
+    end
   end
 end

--- a/api/spec/operations/filtering/apply_spec.rb
+++ b/api/spec/operations/filtering/apply_spec.rb
@@ -149,5 +149,29 @@ RSpec.describe Filtering::Apply, type: :operation do
         expect(operation.call({keyword: "Luke"}, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
+
+    it "performs keyword search on Project model" do
+      FactoryBot.create_list(:project, 5, title: "hello", description: "foo")
+      FactoryBot.create_list(:project, 4, title: "goodbye", description: "bar")
+      aggregate_failures("multiple filters") do
+        expect(operation.call({keyword: "hello"}, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({keyword: "goodbye"}, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({keyword: "foo"}, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({keyword: "bar"}, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({keyword: "Luke"}, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(0)
+      end
+    end
+
+    it "performs keyword search on Resource Collection model" do
+      FactoryBot.create_list(:resource_collection, 5, title: "hello", description: "foo")
+      FactoryBot.create_list(:resource_collection, 4, title: "goodbye", description: "bar")
+      aggregate_failures("multiple filters") do
+        expect(operation.call({keyword: "hello"}, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({keyword: "goodbye"}, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({keyword: "foo"}, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({keyword: "bar"}, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({keyword: "Luke"}, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(0)
+      end
+    end
   end
 end

--- a/api/spec/operations/filtering/apply_spec.rb
+++ b/api/spec/operations/filtering/apply_spec.rb
@@ -91,5 +91,51 @@ RSpec.describe Filtering::Apply, type: :operation do
         expect(operation.call({keyword: "Luke"}, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
+
+    it "performs keyword search on User model" do
+      FactoryBot.create_list(:user, 10, first_name: "hello", last_name: "foo")
+      FactoryBot.create_list(:user, 9, first_name: "goodbye", last_name: "bar")
+      aggregate_failures("multiple filters") do
+        expect(operation.call({keyword: "hello"}, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({keyword: "goodbye"}, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(9)
+        expect(operation.call({keyword: "foo"}, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({keyword: "bar"}, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(9)
+        expect(operation.call({keyword: "Luke"}, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(0)
+      end
+    end
+
+    it "performs keyword search on Tag model" do
+      FactoryBot.create(:tag, name: "hello")
+      FactoryBot.create(:tag, name: "goodbye")
+      aggregate_failures("multiple filters") do
+        expect(operation.call({keyword: "hello"}, model: Tag, scope: Tag.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({keyword: "goodbye"}, model: Tag, scope: Tag.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({keyword: "Luke"}, model: Tag, scope: Tag.all, user: admin_user, use_pg_search: true).length).to eq(0)
+      end
+    end
+
+    it "performs keyword search on Ingestion Source model" do
+      FactoryBot.create(:ingestion_source, display_name: "hello", source_identifier: "foo")
+      FactoryBot.create(:ingestion_source, display_name: "goodbye", source_identifier: "bar")
+      aggregate_failures("multiple filters") do
+        expect(operation.call({keyword: "hello"}, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({keyword: "goodbye"}, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({keyword: "foo"}, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({keyword: "bar"}, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({keyword: "Luke"}, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(0)
+      end
+    end
+
+    it "performs keyword search on Resource model" do
+      FactoryBot.create_list(:resource, 5, title: "hello", description: "foo")
+      FactoryBot.create_list(:resource, 4, title: "goodbye", description: "bar")
+      aggregate_failures("multiple filters") do
+        expect(operation.call({keyword: "hello"}, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({keyword: "goodbye"}, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({keyword: "foo"}, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({keyword: "bar"}, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({keyword: "Luke"}, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(0)
+      end
+    end
   end
 end

--- a/api/spec/operations/filtering/apply_spec.rb
+++ b/api/spec/operations/filtering/apply_spec.rb
@@ -3,29 +3,28 @@
 require "rails_helper"
 
 RSpec.shared_examples "common filtering examples" do |use_pg_search|
-    let(:admin_user) { FactoryBot.create :user, :admin }
+  let(:admin_user) { FactoryBot.create :user, :admin }
 
-    it "smoke test" do
-      FactoryBot.create_list(:project, 5)
-      expect(operation.call({}, model: Project, scope: Project.all, user: nil, use_pg_search: use_pg_search).length).to eq(5)
-    end
+  it "smoke test" do
+    FactoryBot.create_list(:project, 5)
+    expect(operation.call({}, model: Project, scope: Project.all, user: nil, use_pg_search: use_pg_search).length).to eq(5)
+  end
 
-    it "with filter param" do
-      FactoryBot.create_list(:project, 5)
-      FactoryBot.create_list(:project, 5, :as_draft)
-      expect(operation.call({draft: true}, model: Project, scope: Project.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(5)
-    end
+  it "with filter param" do
+    FactoryBot.create_list(:project, 5)
+    FactoryBot.create_list(:project, 5, :as_draft)
+    expect(operation.call({ draft: true }, model: Project, scope: Project.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(5)
+  end
 
-    it "paginates" do
-      FactoryBot.create_list(:project, 30)
-      expect(operation.call({per_page: 3}, model: Project, scope: Project.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(3)
-    end
+  it "paginates" do
+    FactoryBot.create_list(:project, 30)
+    expect(operation.call({ per_page: 3 }, model: Project, scope: Project.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(3)
+  end
 
-    it "with skip pagination param" do
-      FactoryBot.create_list(:project, 30)
-      expect(operation.call({per_page: 3}, model: Project, scope: Project.all, skip_pagination: true, user: admin_user, use_pg_search: use_pg_search).length).to eq(30)
-    end
-
+  it "with skip pagination param" do
+    FactoryBot.create_list(:project, 30)
+    expect(operation.call({ per_page: 3 }, model: Project, scope: Project.all, skip_pagination: true, user: admin_user, use_pg_search: use_pg_search).length).to eq(30)
+  end
 end
 
 RSpec.describe Filtering::Apply, type: :operation do
@@ -46,11 +45,11 @@ RSpec.describe Filtering::Apply, type: :operation do
       FactoryBot.create_list(:maker, 10)
       FactoryBot.create_list(:maker, 10, first_name: "Rocky", last_name: "Balboa", name: "Rocky Balboa")
       aggregate_failures("multiple filters") do
-        expect(operation.call({keyword: "Rocky"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(10)
-        expect(operation.call({keyword: "Balboa"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(10)
-        expect(operation.call({keyword: "Rocky Balboa"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(10)
-        expect(operation.call({keyword: "Rambo"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(10)
-        expect(operation.call({keyword: "Luke"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(0)
+        expect(operation.call({ keyword: "Rocky" }, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({ keyword: "Balboa" }, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({ keyword: "Rocky Balboa" }, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({ keyword: "Rambo" }, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({ keyword: "Luke" }, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
 
@@ -58,23 +57,23 @@ RSpec.describe Filtering::Apply, type: :operation do
       FactoryBot.create_list(:event, 10, subject_title: "hello")
       FactoryBot.create_list(:event, 9, subject_title: "goodbye")
       aggregate_failures("multiple filters") do
-        expect(operation.call({keyword: "hello"}, model: Event, scope: Event.all, user: admin_user, use_pg_search: true).length).to eq(10)
-        expect(operation.call({keyword: "goodbye"}, model: Event, scope: Event.all, user: admin_user, use_pg_search: true).length).to eq(9)
-        expect(operation.call({keyword: "Luke"}, model: Event, scope: Event.all, user: admin_user, use_pg_search: true).length).to eq(0)
+        expect(operation.call({ keyword: "hello" }, model: Event, scope: Event.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({ keyword: "goodbye" }, model: Event, scope: Event.all, user: admin_user, use_pg_search: true).length).to eq(9)
+        expect(operation.call({ keyword: "Luke" }, model: Event, scope: Event.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
 
     it "performs keyword search on Journal Issue model" do
-      FactoryBot.create_list(:journal_issue_with_title, 10, journal_attributes: {title: "hello"}, journal_volume_attributes: {number: 1}, project_attributes: {description: "foo"})
-      FactoryBot.create_list(:journal_issue_with_title, 9, journal_attributes: {title: "goodbye"}, journal_volume_attributes: {number: 3}, project_attributes: {description: "bar"})
+      FactoryBot.create_list(:journal_issue_with_title, 10, journal_attributes: { title: "hello" }, journal_volume_attributes: { number: 1 }, project_attributes: { description: "foo" })
+      FactoryBot.create_list(:journal_issue_with_title, 9, journal_attributes: { title: "goodbye" }, journal_volume_attributes: { number: 3 }, project_attributes: { description: "bar" })
       aggregate_failures("multiple filters") do
-        expect(operation.call({keyword: "hello"}, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(10)
-        expect(operation.call({keyword: "goodbye"}, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(9)
-        expect(operation.call({keyword: "1"}, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(10)
-        expect(operation.call({keyword: "3"}, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(9)
-        expect(operation.call({keyword: "foo"}, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(10)
-        expect(operation.call({keyword: "bar"}, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(9)
-        expect(operation.call({keyword: "Luke"}, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(0)
+        expect(operation.call({ keyword: "hello" }, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({ keyword: "goodbye" }, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(9)
+        expect(operation.call({ keyword: "1" }, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({ keyword: "3" }, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(9)
+        expect(operation.call({ keyword: "foo" }, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({ keyword: "bar" }, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(9)
+        expect(operation.call({ keyword: "Luke" }, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
 
@@ -84,11 +83,11 @@ RSpec.describe Filtering::Apply, type: :operation do
       FactoryBot.create(:text_title, text: first_text, value: "hello")
       FactoryBot.create(:text_title, text: second_text, value: "goodbye")
       aggregate_failures("multiple filters") do
-        expect(operation.call({keyword: "hello"}, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(1)
-        expect(operation.call({keyword: "goodbye"}, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(1)
-        expect(operation.call({keyword: "foo"}, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(1)
-        expect(operation.call({keyword: "bar"}, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(1)
-        expect(operation.call({keyword: "Luke"}, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(0)
+        expect(operation.call({ keyword: "hello" }, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({ keyword: "goodbye" }, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({ keyword: "foo" }, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({ keyword: "bar" }, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({ keyword: "Luke" }, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
 
@@ -96,11 +95,11 @@ RSpec.describe Filtering::Apply, type: :operation do
       FactoryBot.create_list(:user, 10, first_name: "hello", last_name: "foo")
       FactoryBot.create_list(:user, 9, first_name: "goodbye", last_name: "bar")
       aggregate_failures("multiple filters") do
-        expect(operation.call({keyword: "hello"}, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(10)
-        expect(operation.call({keyword: "goodbye"}, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(9)
-        expect(operation.call({keyword: "foo"}, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(10)
-        expect(operation.call({keyword: "bar"}, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(9)
-        expect(operation.call({keyword: "Luke"}, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(0)
+        expect(operation.call({ keyword: "hello" }, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({ keyword: "goodbye" }, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(9)
+        expect(operation.call({ keyword: "foo" }, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({ keyword: "bar" }, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(9)
+        expect(operation.call({ keyword: "Luke" }, model: User, scope: User.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
 
@@ -108,9 +107,9 @@ RSpec.describe Filtering::Apply, type: :operation do
       FactoryBot.create(:tag, name: "hello")
       FactoryBot.create(:tag, name: "goodbye")
       aggregate_failures("multiple filters") do
-        expect(operation.call({keyword: "hello"}, model: Tag, scope: Tag.all, user: admin_user, use_pg_search: true).length).to eq(1)
-        expect(operation.call({keyword: "goodbye"}, model: Tag, scope: Tag.all, user: admin_user, use_pg_search: true).length).to eq(1)
-        expect(operation.call({keyword: "Luke"}, model: Tag, scope: Tag.all, user: admin_user, use_pg_search: true).length).to eq(0)
+        expect(operation.call({ keyword: "hello" }, model: Tag, scope: Tag.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({ keyword: "goodbye" }, model: Tag, scope: Tag.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({ keyword: "Luke" }, model: Tag, scope: Tag.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
 
@@ -118,11 +117,11 @@ RSpec.describe Filtering::Apply, type: :operation do
       FactoryBot.create(:ingestion_source, display_name: "hello", source_identifier: "foo")
       FactoryBot.create(:ingestion_source, display_name: "goodbye", source_identifier: "bar")
       aggregate_failures("multiple filters") do
-        expect(operation.call({keyword: "hello"}, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(1)
-        expect(operation.call({keyword: "goodbye"}, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(1)
-        expect(operation.call({keyword: "foo"}, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(1)
-        expect(operation.call({keyword: "bar"}, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(1)
-        expect(operation.call({keyword: "Luke"}, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(0)
+        expect(operation.call({ keyword: "hello" }, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({ keyword: "goodbye" }, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({ keyword: "foo" }, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({ keyword: "bar" }, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({ keyword: "Luke" }, model: IngestionSource, scope: IngestionSource.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
 
@@ -130,11 +129,11 @@ RSpec.describe Filtering::Apply, type: :operation do
       FactoryBot.create_list(:resource, 5, title: "hello", description: "foo")
       FactoryBot.create_list(:resource, 4, title: "goodbye", description: "bar")
       aggregate_failures("multiple filters") do
-        expect(operation.call({keyword: "hello"}, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(5)
-        expect(operation.call({keyword: "goodbye"}, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(4)
-        expect(operation.call({keyword: "foo"}, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(5)
-        expect(operation.call({keyword: "bar"}, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(4)
-        expect(operation.call({keyword: "Luke"}, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(0)
+        expect(operation.call({ keyword: "hello" }, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({ keyword: "goodbye" }, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({ keyword: "foo" }, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({ keyword: "bar" }, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({ keyword: "Luke" }, model: Resource, scope: Resource.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
 
@@ -142,11 +141,11 @@ RSpec.describe Filtering::Apply, type: :operation do
       FactoryBot.create_list(:journal, 5, title: "hello", description: "foo")
       FactoryBot.create_list(:journal, 4, title: "goodbye", description: "bar")
       aggregate_failures("multiple filters") do
-        expect(operation.call({keyword: "hello"}, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(5)
-        expect(operation.call({keyword: "goodbye"}, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(4)
-        expect(operation.call({keyword: "foo"}, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(5)
-        expect(operation.call({keyword: "bar"}, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(4)
-        expect(operation.call({keyword: "Luke"}, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(0)
+        expect(operation.call({ keyword: "hello" }, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({ keyword: "goodbye" }, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({ keyword: "foo" }, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({ keyword: "bar" }, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({ keyword: "Luke" }, model: Journal, scope: Journal.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
 
@@ -154,11 +153,11 @@ RSpec.describe Filtering::Apply, type: :operation do
       FactoryBot.create_list(:project, 5, title: "hello", description: "foo")
       FactoryBot.create_list(:project, 4, title: "goodbye", description: "bar")
       aggregate_failures("multiple filters") do
-        expect(operation.call({keyword: "hello"}, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(5)
-        expect(operation.call({keyword: "goodbye"}, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(4)
-        expect(operation.call({keyword: "foo"}, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(5)
-        expect(operation.call({keyword: "bar"}, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(4)
-        expect(operation.call({keyword: "Luke"}, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(0)
+        expect(operation.call({ keyword: "hello" }, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({ keyword: "goodbye" }, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({ keyword: "foo" }, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({ keyword: "bar" }, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({ keyword: "Luke" }, model: Project, scope: Project.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
 
@@ -166,11 +165,21 @@ RSpec.describe Filtering::Apply, type: :operation do
       FactoryBot.create_list(:resource_collection, 5, title: "hello", description: "foo")
       FactoryBot.create_list(:resource_collection, 4, title: "goodbye", description: "bar")
       aggregate_failures("multiple filters") do
-        expect(operation.call({keyword: "hello"}, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(5)
-        expect(operation.call({keyword: "goodbye"}, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(4)
-        expect(operation.call({keyword: "foo"}, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(5)
-        expect(operation.call({keyword: "bar"}, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(4)
-        expect(operation.call({keyword: "Luke"}, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(0)
+        expect(operation.call({ keyword: "hello" }, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({ keyword: "goodbye" }, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({ keyword: "foo" }, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(5)
+        expect(operation.call({ keyword: "bar" }, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(4)
+        expect(operation.call({ keyword: "Luke" }, model: ResourceCollection, scope: ResourceCollection.all, user: admin_user, use_pg_search: true).length).to eq(0)
+      end
+    end
+
+    it "performs keyword search on Subject model" do
+      FactoryBot.create(:subject, name: "hello")
+      FactoryBot.create(:subject, name: "goodbye")
+      aggregate_failures("multiple filters") do
+        expect(operation.call({ keyword: "hello" }, model: Subject, scope: Subject.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({ keyword: "goodbye" }, model: Subject, scope: Subject.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({ keyword: "Luke" }, model: Subject, scope: Subject.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
   end

--- a/api/spec/operations/filtering/apply_spec.rb
+++ b/api/spec/operations/filtering/apply_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples "common filtering examples" do |use_pg_search|
+    let(:admin_user) { FactoryBot.create :user, :admin }
+
+    it "smoke test" do
+      FactoryBot.create_list(:project, 5)
+      expect(operation.call({}, model: Project, scope: Project.all, user: nil, use_pg_search: use_pg_search).length).to eq(5)
+    end
+
+    it "with filter param" do
+      FactoryBot.create_list(:project, 5)
+      FactoryBot.create_list(:project, 5, :as_draft)
+      expect(operation.call({draft: true}, model: Project, scope: Project.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(5)
+    end
+
+    it "paginates" do
+      FactoryBot.create_list(:project, 30)
+      expect(operation.call({per_page: 3}, model: Project, scope: Project.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(3)
+    end
+
+    it "with skip pagination param" do
+      FactoryBot.create_list(:project, 30)
+      expect(operation.call({per_page: 3}, model: Project, scope: Project.all, skip_pagination: true, user: admin_user, use_pg_search: use_pg_search).length).to eq(30)
+    end
+
+    it "performs keyword search" do
+      stub_request(:get, /elasticsearch/).to_return(status: 200, body: "", headers: {})
+      FactoryBot.create_list(:project, 20)
+      params = {keyword: "body"}
+      expect(operation.call(params, model: Project, scope: Project.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(20)
+    end
+end
+
+RSpec.describe Filtering::Apply, type: :operation do
+  let(:operation) { described_class.new }
+
+  context "Searchkick Search" do
+    include_examples "common filtering examples", false do
+      let(:operation) { described_class.new }
+    end
+  end
+
+  context "PG Search" do
+    include_examples "common filtering examples", true do
+      let(:operation) { described_class.new }
+    end
+  end
+end

--- a/api/spec/operations/filtering/apply_spec.rb
+++ b/api/spec/operations/filtering/apply_spec.rb
@@ -26,18 +26,6 @@ RSpec.shared_examples "common filtering examples" do |use_pg_search|
       expect(operation.call({per_page: 3}, model: Project, scope: Project.all, skip_pagination: true, user: admin_user, use_pg_search: use_pg_search).length).to eq(30)
     end
 
-    it "performs keyword search on Maker model" do
-      stub_request(:get, /elasticsearch/).to_return(status: 200, body: "", headers: {})
-      FactoryBot.create_list(:maker, 10)
-      FactoryBot.create_list(:maker, 10, first_name: "Rocky", last_name: "Balboa", name: "Rocky Balboa")
-      aggregate_failures("multiple filters") do
-        expect(operation.call({keyword: "Rocky"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(10)
-        expect(operation.call({keyword: "Balboa"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(10)
-        expect(operation.call({keyword: "Rocky Balboa"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(10)
-        expect(operation.call({keyword: "Rambo"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(10)
-        expect(operation.call({keyword: "Luke"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(0)
-      end
-    end
 end
 
 RSpec.describe Filtering::Apply, type: :operation do
@@ -52,6 +40,30 @@ RSpec.describe Filtering::Apply, type: :operation do
   context "PG Search" do
     include_examples "common filtering examples", true do
       let(:operation) { described_class.new }
+    end
+
+    it "performs keyword search on Maker model" do
+      stub_request(:get, /elasticsearch/).to_return(status: 200, body: "", headers: {})
+      FactoryBot.create_list(:maker, 10)
+      FactoryBot.create_list(:maker, 10, first_name: "Rocky", last_name: "Balboa", name: "Rocky Balboa")
+      aggregate_failures("multiple filters") do
+        expect(operation.call({keyword: "Rocky"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({keyword: "Balboa"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({keyword: "Rocky Balboa"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({keyword: "Rambo"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({keyword: "Luke"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: true).length).to eq(0)
+      end
+    end
+
+    it "performs keyword search on Event model" do
+      stub_request(:get, /elasticsearch/).to_return(status: 200, body: "", headers: {})
+      FactoryBot.create_list(:event, 10, subject_title: "hello")
+      FactoryBot.create_list(:event, 9, subject_title: "goodbye")
+      aggregate_failures("multiple filters") do
+        expect(operation.call({keyword: "hello"}, model: Event, scope: Event.all, user: admin_user, use_pg_search: true).length).to eq(10)
+        expect(operation.call({keyword: "goodbye"}, model: Event, scope: Event.all, user: admin_user, use_pg_search: true).length).to eq(9)
+        expect(operation.call({keyword: "Luke"}, model: Event, scope: Event.all, user: admin_user, use_pg_search: true).length).to eq(0)
+      end
     end
   end
 end

--- a/api/spec/operations/filtering/apply_spec.rb
+++ b/api/spec/operations/filtering/apply_spec.rb
@@ -26,11 +26,17 @@ RSpec.shared_examples "common filtering examples" do |use_pg_search|
       expect(operation.call({per_page: 3}, model: Project, scope: Project.all, skip_pagination: true, user: admin_user, use_pg_search: use_pg_search).length).to eq(30)
     end
 
-    it "performs keyword search" do
+    it "performs keyword search on Maker model" do
       stub_request(:get, /elasticsearch/).to_return(status: 200, body: "", headers: {})
-      FactoryBot.create_list(:project, 20)
-      params = {keyword: "body"}
-      expect(operation.call(params, model: Project, scope: Project.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(20)
+      FactoryBot.create_list(:maker, 10)
+      FactoryBot.create_list(:maker, 10, first_name: "Rocky", last_name: "Balboa", name: "Rocky Balboa")
+      aggregate_failures("multiple filters") do
+        expect(operation.call({keyword: "Rocky"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(10)
+        expect(operation.call({keyword: "Balboa"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(10)
+        expect(operation.call({keyword: "Rocky Balboa"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(10)
+        expect(operation.call({keyword: "Rambo"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(10)
+        expect(operation.call({keyword: "Luke"}, model: Maker, scope: Maker.all, user: admin_user, use_pg_search: use_pg_search).length).to eq(0)
+      end
     end
 end
 

--- a/api/spec/operations/filtering/apply_spec.rb
+++ b/api/spec/operations/filtering/apply_spec.rb
@@ -77,5 +77,19 @@ RSpec.describe Filtering::Apply, type: :operation do
         expect(operation.call({keyword: "Luke"}, model: JournalIssue, scope: JournalIssue.all, user: admin_user, use_pg_search: true).length).to eq(0)
       end
     end
+
+    it "performs keyword search on Text model" do
+      first_text = FactoryBot.create(:text, description: "foo")
+      second_text = FactoryBot.create(:text, description: "bar")
+      FactoryBot.create(:text_title, text: first_text, value: "hello")
+      FactoryBot.create(:text_title, text: second_text, value: "goodbye")
+      aggregate_failures("multiple filters") do
+        expect(operation.call({keyword: "hello"}, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({keyword: "goodbye"}, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({keyword: "foo"}, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({keyword: "bar"}, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(1)
+        expect(operation.call({keyword: "Luke"}, model: Text, scope: Text.all, user: admin_user, use_pg_search: true).length).to eq(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
This implements a separate Filtering applicator that supports using the `pg_search` gem rather than `searchkick`. It also modifies several models to support `pg_search` based filtering. Currently `pg_search` can be activated in an environment by setting an environment variable 'USE_PG_SEARCH' to true.

See the [apply_spec.rb](https://github.com/ManifoldScholar/manifold/pull/3826/files#diff-b30e9927ac51020b121370585eedf262f974a082a2467e8e348beeff4b58b298) for a list of currently supported models

#### Models that do not need to support `pg_search` because they already implement custom `by_keyword`:
- entitlement
- annotation
- reading group
- comment

#### Some Notes / Important differences from Searchkick:
- pg_search [can search through associations](https://github.com/Casecommons/pg_search?tab=readme-ov-file#searching-through-associations), but it's somewhat limited. It can't search more than one association deep, and it doesn't index the association. So we'll want to keep an eye on performance for some association-heavy searches.
- Since pg_search calls into Postgres, not Ruby, all field names passed to it need to be the postgres name for the corresponding column, not the ruby method name. So if we have a column `name` that we alias in rails with `alias name title`, we need to pass pg_search `name`, not `title`. This also means that fields like `title_plaintext` are unavailable. They could be implemented as a PG function, however.

#### Possible Improvements:
- I haven't tried to implement highlighting here, mostly because I haven't seen it in the front end in areas that seemed to be calling into keyword search. pg_search supports it though, so we can add it in another PR.
- I haven't intensely tested around typos, incomplete words, etc