### PR TITLE
[B] Fix crash when trying to access roles with an anonymous user

### DIFF
--- a/api/app/controllers/concerns/json_api.rb
+++ b/api/app/controllers/concerns/json_api.rb
@@ -49,8 +49,6 @@ module JSONAPI
   def serializable_errors(to_serialize)
     raise_not_errors unless to_serialize.respond_to?(:errors)
     V1::Helpers::Errors.new(to_serialize.errors).for_serialization
-
-    # errors.map { |attribute, message| ::V1::Helpers::Error.new(attribute, message) }
   end
 
   def set_content_type

--- a/api/app/models/anonymous_user.rb
+++ b/api/app/models/anonymous_user.rb
@@ -15,6 +15,10 @@ AnonymousUser = Naught.build do |config|
     RUBY
   end
 
+  def roles
+    []
+  end
+
   def role
     nil
   end


### PR DESCRIPTION
This fixes a crash when trying to access records in the local env as an anonymous user. The crash happened when calling `roles` on an `AnonymousUser` class, a method the class doesn't have. Adding a mock for it fixes the issue.

It's unclear to me why this isn't happening in edge, or why the issue was only noticed recently. The relevant files haven't been changed in several months. A possible culprit is this commit: https://github.com/ManifoldScholar/manifold/commit/9a9421748026819faac8f88cee0d2543104a4ea8#diff-25f7b21a047b52c4068e2ef9030192afb4ad52f16d63c3acd7f949a1c6eb42d1R7

However, reverting my branch to before that commit breaks my local env for a variety of different reasons, making it difficult to test.