### PR TITLE
PG Multisearch

### DIFF
--- a/api/app/controllers/api/v1/search_results_controller.rb
+++ b/api/app/controllers/api/v1/search_results_controller.rb
@@ -13,7 +13,7 @@ module API
         if outcome.valid?
           render_jsonapi outcome.result,
                          include: [:model, :"model.creator", :"model.creators"],
-                         serializer: ::V1::SearchResultSerializer,
+                         serializer: select_serializer(outcome),
                          meta: {
                            keyword: search_options.dig(:keyword),
                            pagination: pagination_dict(outcome.result)
@@ -24,6 +24,14 @@ module API
       end
 
       private
+
+      def select_serializer(outcome)
+        if outcome.result.first.is_a?(PgSearch::Document)
+          ::V1::PgSearchSerializer
+        else
+          ::V1::SearchResultSerializer
+        end
+      end
 
       def render_error(outcome)
         options = {

--- a/api/app/models/annotation.rb
+++ b/api/app/models/annotation.rb
@@ -13,6 +13,7 @@ class Annotation < ApplicationRecord
   include TrackedCreator
   include Filterable
   include FlaggableResource
+  include HasKeywordSearch
   include SearchIndexable
   include SoftDeletable
 
@@ -94,6 +95,9 @@ class Annotation < ApplicationRecord
   delegate :text_nodes, to: :text_section, prefix: true
 
   # Search
+  has_multisearch! websearch: true,
+    against: [:subject, :body],
+    additional_attributes: ->(annotation) { { title: annotation.subject } }
   searchkick(callbacks: :async,
              batch_size: 500,
              highlight: [:title, :body])

--- a/api/app/models/concerns/has_keyword_search.rb
+++ b/api/app/models/concerns/has_keyword_search.rb
@@ -6,8 +6,10 @@ module HasKeywordSearch
     extend Dry::Core::ClassAttributes
 
     defines :keyword_search_options, type: ::Types::Hash.map(::Types::Symbol, ::Types::Any)
+    defines :multisearch_options, type: ::Types::Hash.map(::Types::Symbol, ::Types::Any)
 
     keyword_search_options({}.freeze)
+    multisearch_options({}.freeze)
   end
 
   module ClassMethods
@@ -17,6 +19,12 @@ module HasKeywordSearch
       keyword_search_options options.freeze
 
       pg_search_scope :keyword_search, **options
+    end
+
+    def has_multisearch!(**options)
+      multisearch_options options.freeze
+
+      multisearchable(**options)
     end
     # rubocop:enable Naming/PredicateName
 

--- a/api/app/models/journal.rb
+++ b/api/app/models/journal.rb
@@ -85,6 +85,10 @@ class Journal < ApplicationRecord
 
   scope :search_import, -> { includes(:collaborators, :makers) }
 
+  has_multisearch! websearch: true,
+    against: %i[title subtitle description],
+    additional_attributes: ->(journal) { { title: journal.title } }
+
   has_keyword_search!(
     against: %i[title subtitle description],
     associated_against: {

--- a/api/app/models/project.rb
+++ b/api/app/models/project.rb
@@ -240,6 +240,10 @@ class Project < ApplicationRecord
     )
   }
 
+  has_multisearch! websearch: true,
+    against: %i[title subtitle description],
+    additional_attributes: ->(project) { { title: project.title } }
+
   has_keyword_search!(
     against: %i[title subtitle description],
     associated_against: {

--- a/api/app/models/resource.rb
+++ b/api/app/models/resource.rb
@@ -117,6 +117,9 @@ class Resource < ApplicationRecord
   after_commit :queue_fetch_thumbnail, on: [:create, :update]
   after_commit :trigger_event_creation, on: [:create]
 
+  has_multisearch! websearch: true,
+    against: %i[title description],
+    additional_attributes: ->(resource) { { title: resource.title } }
   has_keyword_search! against: %i[title description]
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,

--- a/api/app/models/text.rb
+++ b/api/app/models/text.rb
@@ -130,6 +130,9 @@ class Text < ApplicationRecord
   after_commit :trigger_text_added_event, on: [:create, :update]
   after_commit :inject_global_stylesheet, on: :create
 
+  has_multisearch! websearch: true,
+    against: %i[description],
+    additional_attributes: ->(text) { { title: text.title } }
   has_keyword_search! associated_against: { titles: [:value] }, against: [:description]
   searchkick(word_start: TYPEAHEAD_ATTRIBUTES,
              callbacks: :async,

--- a/api/app/models/text_section.rb
+++ b/api/app/models/text_section.rb
@@ -8,6 +8,7 @@ class TextSection < ApplicationRecord
   include SearchIndexable
   include Metadata
   include Attachments
+  include HasKeywordSearch
 
   # Constants
   KIND_COVER_IMAGE = "cover_image".freeze
@@ -88,6 +89,9 @@ class TextSection < ApplicationRecord
   scope :ordered, -> { order(position: :asc) }
 
   # Search
+  has_multisearch! websearch: true,
+    against: [:name, :body],
+    additional_attributes: ->(text_section) { { title: text_section.name } }
   searchkick(
     callbacks: :async,
     batch_size: 25,

--- a/api/app/serializers/v1/pg_search_serializer.rb
+++ b/api/app/serializers/v1/pg_search_serializer.rb
@@ -1,0 +1,163 @@
+module V1
+  class PgSearchSerializer < ManifoldSerializer
+    include ::V1::Concerns::ManifoldSerializer
+
+    typed_attribute :score, Types::Float, &:pg_search_rank
+    typed_attribute :searchable_id, Types::Serializer::ID
+    typed_attribute :searchable_type, Types::String.meta(example: "textSection") do |object, _params|
+      object.searchable_type.camelize(:lower)
+    end
+    typed_attribute :full_text, Types::String.optional, &:pg_search_highlight
+    typed_attribute :title, Types::String
+    typed_attribute :keywords, Types::Array.of(Types::String) do
+      []
+    end
+    typed_attribute :parent_keywords, Types::Array.of(Types::String).optional do
+      nil
+    end
+    typed_attribute :makers, Types::Array.of(Types::String) do
+      []
+    end
+    typed_attribute :highlights, Types::Hash.schema(
+      parent_keywords: Types::String.optional, # TOOD: check type
+      keywords: Types::String.optional, # TOOD: check type
+      makers: Types::String.optional, # TOOD: check type
+      full_text: Types::String.optional, # TOOD: check type
+      title: Types::String.optional # TOOD: check type
+    ).optional do |object, _params|
+      highlights(object)
+    end
+
+    typed_attribute :parents, Types::Hash.schema(
+      text: Types::Hash.schema(
+        title: Types::String,
+        slug: Types::String,
+        id: Types::Serializer::ID
+      ),
+      project: Types::Hash.schema(
+        title: Types::String,
+        slug: Types::String,
+        id: Types::Serializer::ID
+      )
+    ).optional do |object, _params|
+      parents(object)
+    end
+
+    typed_attribute :text_nodes, Types::Hash.schema(
+      total: Types::Integer,
+      hits: Types::Array.of(
+        Types::Hash.schema(
+          content: Types::String,
+          content_highlighted: Types::Array.of(Types::String),
+          node_uuid: Types::String,
+          position: Types::Integer
+        )
+      )
+    ).optional do |_object, _params|
+      {
+        total: 0,
+        hits: 0
+      }
+    end
+
+    typed_has_one :model, polymorphic: true do |object|
+      object.searchable
+    end
+
+    class << self
+
+      def parents(object)
+        message = "parents_for_#{object.searchable_type.underscore}"
+        return send(message, object) if respond_to? message
+
+        {}
+      end
+
+      def parents_for_text_section_child(object)
+        text_section = object.searchable&.text_section
+        return {} unless text_section.present?
+
+        {
+          text_section: text_section_properties(text_section),
+          text: text_properties(text_section&.text),
+          project: project_properties(text_section&.project)
+        }
+      end
+      alias parents_for_annotation parents_for_text_section_child
+
+      def parents_for_text_child(object)
+        text = object.searchable&.text
+        project = object.searchable&.project
+        return {} unless text.present?
+
+        {
+          text: text_properties(text),
+          project: project_properties(project)
+        }
+      end
+      alias parents_for_text_section parents_for_text_child
+
+      def parents_for_project_child(object)
+        return {} unless object.searchable&.project.present?
+
+        {
+          project: project_properties(object.searchable.project)
+        }
+      end
+      alias parents_for_text parents_for_project_child
+      alias parents_for_resource parents_for_project_child
+      alias parents_for_collection parents_for_project_child
+      alias parents_for_event parents_for_project_child
+
+      def project_properties(project)
+        {
+          title: project.title,
+          slug: project.slug,
+          id: project.id
+        }
+      end
+
+      def text_section_properties(text_section)
+        {
+          title: text_section.name,
+          id: text_section.id
+        }
+      end
+
+      def text_properties(text)
+        {
+          title: text.title,
+          slug: text.slug,
+          id: text.id
+        }
+      end
+
+      def text_nodes(object)
+        results = object&.dig("inner_hits", "text_nodes")
+        return nil unless results
+
+        camelize_hash(
+          total: results.hits.total,
+          hits: results.hits.hits.each_with_index.map do |hit, _index|
+            {
+              content: hit._source.content,
+              content_highlighted: hit.highlight ? hit.highlight["text_nodes.content.analyzed"] : nil,
+              nodeUuid: hit._source.node_uuid,
+              position: hit._source.position
+            }
+          end
+        )
+      end
+
+      def highlights(object)
+        {
+          parent_keywords: "",
+          keywords: "",
+          makers: "",
+          full_text: [object.pg_search_highlight],
+          title: ""
+        }
+      end
+    end
+  end
+end

--- a/api/app/services/search/results.rb
+++ b/api/app/services/search/results.rb
@@ -42,6 +42,8 @@ module Search
 
     def adjusted_results
       @adjusted_results ||= begin
+        # Remove these conditionals when removing Searchkick
+        return @searchkick_results unless @searchkick_results.respond_to?(:options)
         return @searchkick_results.results if @searchkick_results.options[:load]
 
         inject_associations(@searchkick_results)

--- a/api/config/initializers/pg_search.rb
+++ b/api/config/initializers/pg_search.rb
@@ -1,0 +1,29 @@
+# 0 (the default) ignores the document length
+# 1 divides the rank by 1 + the logarithm of the document length
+# 2 divides the rank by the document length
+# 4 divides the rank by the mean harmonic distance between extents
+# 8 divides the rank by the number of unique words in document
+# 16 divides the rank by 1 + the logarithm of the number of unique words in document
+# 32 divides the rank by itself + 1
+
+T_SEARCH_NORMALIZATION = 1 + 2 + 4
+
+PgSearch.multisearch_options = {
+  using: {
+    tsearch: {
+      normalization: T_SEARCH_NORMALIZATION,
+      prefix: true,
+      highlight: {
+        StartSel: "<mark>",
+        StopSel: "</mark>",
+        MinWords: 12,
+        MaxWords: 80,
+        ShortWord: 4,
+        HighlightAll: true,
+        MaxFragments: 3,
+        FragmentDelimiter: "&hellip;"
+      }
+    }
+  },
+  ignoring: :accents
+}

--- a/api/db/migrate/20250312204629_create_pg_search_documents.rb
+++ b/api/db/migrate/20250312204629_create_pg_search_documents.rb
@@ -3,7 +3,8 @@ class CreatePgSearchDocuments < ActiveRecord::Migration[6.1]
     say_with_time("Creating table for pg_search multisearch") do
       create_table :pg_search_documents do |t|
         t.text :content
-        t.belongs_to :searchable, polymorphic: true, index: true
+        t.text :title
+        t.belongs_to :searchable, polymorphic: true, index: true, type: :uuid
         t.timestamps null: false
       end
     end

--- a/api/db/structure.sql
+++ b/api/db/structure.sql
@@ -1796,8 +1796,9 @@ CREATE VIEW public.permissions AS
 CREATE TABLE public.pg_search_documents (
     id bigint NOT NULL,
     content text,
+    title text,
     searchable_type character varying,
-    searchable_id bigint,
+    searchable_id uuid,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );

--- a/api/lib/patches/support_websearch.rb
+++ b/api/lib/patches/support_websearch.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+module Patches
+  # A very simple opt-in addon to support for using `websearch_to_tsquery` with PgSearch.
+  #
+  # It ignores most all options (aside from dictionary) and assumes you are ignoring accents.
+  #
+  # @see https://www.postgresql.org/docs/current/textsearch-controls.html
+  module SupportWebsearch
+    def rank_prefixed
+      arel_wrap(prefixed_query)
+    end
+
+    def rank_query
+      arel_wrap(tsquery)
+    end
+
+    def tsdocument
+      if options[:composite]
+        Arel.sql("#{quoted_table_name}.#{options[:composite]}")
+      else
+        super
+      end
+    end
+
+    # @return [String]
+    def tsquery
+      return "''" if query.blank?
+
+      if options[:websearch]
+        quoted_query = Arel::Nodes.build_quoted(query)
+
+        unaccented_query = Arel::Nodes::NamedFunction.new(PgSearch.unaccent_function, [quoted_query])
+
+        Arel::Nodes::NamedFunction.new("websearch_to_tsquery", [dictionary, unaccented_query]).to_sql
+      else
+        super
+      end
+    end
+
+    def ts_rank_function
+      options[:ts_rank_function] || default_ts_rank_function
+    end
+
+    def tsearch_rank
+      Arel::Nodes::NamedFunction.new(
+        ts_rank_function,
+        [
+          arel_wrap(tsdocument),
+          arel_wrap(tsquery),
+          normalization
+        ]
+      ).to_sql
+    end
+
+    def prefixed_query
+      query_terms = query.split.compact
+
+      tsquery_terms = query_terms.map do |unsanitized_term|
+        sanitized_term = unsanitized_term.gsub(PgSearch::Features::TSearch::DISALLOWED_TSQUERY_CHARACTERS, " ")
+
+        term_sql = Arel.sql(normalize(connection.quote(sanitized_term)))
+
+        tsquery = tsquery_expression(term_sql, negated: false, prefix: true)
+
+        Arel::Nodes::NamedFunction.new("to_tsquery", [dictionary, tsquery]).to_sql
+      end
+
+      tsquery_terms.join(" && ")
+    end
+
+    private
+
+    def default_ts_rank_function
+      options[:websearch] ? "ts_rank_cd" : "ts_rank"
+    end
+
+    module ClassMethods
+      def valid_options
+        super + %i[composite ts_rank_function websearch]
+      end
+    end
+
+    class << self
+      def prepended(base)
+        class << base
+          prepend ClassMethods
+        end
+      end
+    end
+  end
+
+  module SupportDMetaphoneComposite
+    module ClassMethods
+      def valid_options
+        super + %i[composite]
+      end
+    end
+
+    class << self
+      def prepended(base)
+        base.delegate :rank_prefixed, :rank_query, to: :tsearch
+
+        class << base
+          prepend ClassMethods
+        end
+      end
+    end
+  end
+
+  module SupportTrigramComposite
+    def rank_prefixed
+      Arel::Nodes::Grouping.new(
+        Arel::Nodes::InfixOperation.new(
+          "||",
+          normalized_query,
+          Arel::Nodes.build_quoted(?%)
+        )
+      )
+    end
+
+    def rank_query
+      Arel::Nodes::Grouping.new(normalized_query)
+    end
+
+    def normalized_document
+      if options[:composite]
+        Arel.sql("#{quoted_table_name}.#{options[:composite]}")
+      else
+        super
+      end
+    end
+
+    module ClassMethods
+      def valid_options
+        super + %i[composite]
+      end
+    end
+
+    class << self
+      def prepended(base)
+        class << base
+          prepend ClassMethods
+        end
+      end
+    end
+  end
+
+  module SupportRankQueries
+    def rank
+      (config.ranking_sql || ":tsearch").gsub(/(?::(?<feature>trigram|tsearch|dmetaphone)(?:_(?<subfield>prefixed|query))?)/) do
+        feature = feature_for(Regexp.last_match[:feature])
+
+        case Regexp.last_match[:subfield]
+        when "prefixed"
+          feature.rank_prefixed.to_sql
+        when "query"
+          feature.rank_query.to_sql
+        else
+          feature.rank.to_sql
+        end
+      end
+    end
+  end
+end
+
+PgSearch::Features::DMetaphone.prepend Patches::SupportDMetaphoneComposite
+PgSearch::Features::TSearch.prepend Patches::SupportWebsearch
+PgSearch::Features::Trigram.prepend Patches::SupportTrigramComposite
+PgSearch::ScopeOptions.prepend Patches::SupportRankQueries


### PR DESCRIPTION
This PR converts the general search for manifold from Elasticsearch to Postgres.

To test, you will need to set the ENV variable `USE_PG_SEARCH=true`, otherwise the server will continue to use elasticsearch. You can do this by adding that line to the `docker/manifold.env` file.