### PR TITLE
[E] Avoid N+1 when serializing text section node hits

### DIFF
--- a/api/app/serializers/v1/pg_search_serializer.rb
+++ b/api/app/serializers/v1/pg_search_serializer.rb
@@ -68,8 +68,6 @@ module V1
         value: Types::Integer
       )
     ).optional do |object, params|
-      object.load_text_node_hits_for!(params[:search_keyword])
-
       camelize_hash(object.text_nodes)
     end
 


### PR DESCRIPTION
Move the fetch for all possible text section node results in a given search within the `Search::Query` interaction instead of in each serialization of a given search result.