### PR TITLE
[B][C] Few bug fixes

### DIFF
--- a/client/src/backend/containers/reading-group/Annotations.js
+++ b/client/src/backend/containers/reading-group/Annotations.js
@@ -204,7 +204,7 @@ function ReadingGroupAnnotationsContainer({
 ReadingGroupAnnotationsContainer.propTypes = {
   readingGroup: PropTypes.object,
   refresh: PropTypes.func,
-  route: PropTypes.string,
+  route: PropTypes.object,
   confirm: PropTypes.func,
   entitiesListSearchProps: PropTypes.func,
   entitiesListSearchParams: PropTypes.object

--- a/client/src/backend/containers/reading-group/Members.js
+++ b/client/src/backend/containers/reading-group/Members.js
@@ -89,7 +89,7 @@ function ReadingGroupMembersContainer({
 ReadingGroupMembersContainer.propTypes = {
   readingGroup: PropTypes.object,
   refresh: PropTypes.func,
-  route: PropTypes.string,
+  route: PropTypes.object,
   confirm: PropTypes.func
 };
 

--- a/client/src/frontend/components/collecting/reading-group/edit/CollectionEditor/CategoryCreator/CategoryNewToggle.js
+++ b/client/src/frontend/components/collecting/reading-group/edit/CollectionEditor/CategoryCreator/CategoryNewToggle.js
@@ -34,7 +34,6 @@ CategoryNewToggle.propTypes = {
   isMarkdown: PropTypes.bool,
   groupId: PropTypes.string.isRequired,
   onError: PropTypes.func.isRequired,
-  confirm: PropTypes.func.isRequired,
   count: PropTypes.number
 };
 

--- a/client/src/frontend/components/collecting/reading-group/edit/CollectionEditor/index.js
+++ b/client/src/frontend/components/collecting/reading-group/edit/CollectionEditor/index.js
@@ -103,14 +103,12 @@ export default function CollectionEditor({
           <CategoryNewToggle
             groupId={readingGroup.id}
             onError={onCategoryEditError}
-            confirm={confirm}
             refresh={refresh}
           />
           <CategoryNewToggle
             isMarkdown
             groupId={readingGroup.id}
             onError={onCategoryEditError}
-            confirm={confirm}
             count={categories?.length ?? 0}
             refresh={refresh}
           />

--- a/client/src/helpers/router/index.js
+++ b/client/src/helpers/router/index.js
@@ -1,2 +1,2 @@
-export childRoutes from "./childRoutes";
-export RedirectToFirstMatch from "./RedirectToFirstMatch";
+export { default as childRoutes } from "./childRoutes";
+export { default as RedirectToFirstMatch } from "./RedirectToFirstMatch";


### PR DESCRIPTION
@1aurend take a look at the third commit in particular. This resolves that weird `Could not find "store"` error we were seeing. I traced the issue to a `confirm` prop that you were trying to pass through the `<CategoryNewToggle>` component you created to the existing `<NewCategory>` component. `<NewCategory>` is wrapped in the `withConfirmation` HOC, so the prop doesn't need to be passed down. And in `<CollectionEditor>`, where you first tried to pass it down, the value `confirm` didn't exist, meaning that `confirm` was interpreted as the [built-in browser function](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm). My guess is that the server-side error and blank screen are the result of calling a browser function in node. It's odd that the error surfaced as a Redux error, but that's my best guess.

If you want to test it, the reliable way I've found to reproduce the issue is on a fresh `yarn watch`. Once the error has been triggered once, the SSR server shuts down, so you won't see it again until you restart (and the client-side JS is fine with using `confirm`). So on a fresh `yarn watch`, you'll know it's working if you reload the RG edit route and don't see the error or a browser console warning that SSR is missing.