### PR TITLE
[B] Fix notes links 500 + formats filter

### DIFF
--- a/client/src/frontend/components/collecting/Toggle/index.js
+++ b/client/src/frontend/components/collecting/Toggle/index.js
@@ -31,7 +31,7 @@ function determineView(collected, hovered, confirmed, isCollecting) {
 }
 
 function normalizeTitle(collectable) {
-  const attrs = collectable.attributes;
+  const attrs = collectable?.attributes;
   if (!attrs) return "";
 
   if (attrs.titlePlaintext) return attrs.titlePlaintext;
@@ -175,7 +175,7 @@ function CollectingToggle({
 
   if (
     !currentUser ||
-    COLLECTABLE_TYPE_RESTRICTED_LIST.includes(collectable.type)
+    COLLECTABLE_TYPE_RESTRICTED_LIST.includes(collectable?.type)
   )
     return null;
 

--- a/client/src/frontend/components/collecting/helpers.js
+++ b/client/src/frontend/components/collecting/helpers.js
@@ -34,7 +34,7 @@ export function inCollection(collectionOrEntity, collectable) {
   if (!collection) return false;
 
   const collectedIds = collectedIdsForCollection(collection);
-  return collectedIds.includes(collectable.id);
+  return collectedIds.includes(collectable?.id);
 }
 
 export function inCollections(collectable, ...collectionsOrEntities) {

--- a/client/src/hooks/useListQueryParams/index.js
+++ b/client/src/hooks/useListQueryParams/index.js
@@ -12,7 +12,14 @@ export default function useListQueryParams({
 } = {}) {
   const navigate = useNavigate();
   const { pathname, search } = useLocation();
-  const { page, ...filterParams } = queryString.parse(search);
+  const { page, formats, ...filterParams } = queryString.parse(search);
+
+  /* eslint-disable no-nested-ternary */
+  const formatsValue = formats
+    ? Array.isArray(formats)
+      ? { formats }
+      : { formats: [formats] }
+    : {};
 
   const [number, setNumber] = useState(page || initPage);
   const size = useRef(initSize);
@@ -39,7 +46,8 @@ export default function useListQueryParams({
 
   const [filters, setFilterState] = useState({
     ...initFilters,
-    ...filterParams
+    ...filterParams,
+    ...formatsValue
   });
 
   const updateFilterParams = useCallback(

--- a/client/src/reader/components/TextTitles/index.js
+++ b/client/src/reader/components/TextTitles/index.js
@@ -22,7 +22,7 @@ export default class TextTitles extends Component {
   }
 
   get textTitle() {
-    return this.text.attributes.titleFormatted;
+    return this.text?.attributes.titleFormatted;
   }
 
   get section() {


### PR DESCRIPTION
This PR resolves two bugs:
1. Because of the conditional renders removed to fix Reader SSR, links to the annotation drawer from My Notes can 500 if the relevant text hasn't previously been loaded.
2. The formats filter isn't explicitly set as an array if only one query param is present on first load. If it is sent as a string, the api ignores it and returns unwanted results.