### PR TITLE
[POC] Handle selection around resources

### DIFF
--- a/client/src/global/components/Annotation/Annotation/TextContent/FromNodes/index.js
+++ b/client/src/global/components/Annotation/Annotation/TextContent/FromNodes/index.js
@@ -94,7 +94,7 @@ function AnnotationWithNodes({
   };
 
   const adjustedEndChar =
-    subjectInSingleNode && textSplit
+    subjectInSingleNode && textSplit.current
       ? endChar - textSplit.current - 1
       : endChar;
 
@@ -108,7 +108,9 @@ function AnnotationWithNodes({
           annotationStyle,
           format: "annotation",
           ...annotation.attributes,
-          startChar: textSplit ? startChar - textSplit.current - 1 : startChar,
+          startChar: textSplit.current
+            ? startChar - textSplit.current - 1
+            : startChar,
           endChar: adjustedEndChar
         }
       }

--- a/client/src/global/components/atomic/Box/index.js
+++ b/client/src/global/components/atomic/Box/index.js
@@ -1,8 +1,8 @@
 import * as Styled from "./styles";
 
-export default function Box({ children, className }) {
+export default function Box({ children, className, ...props }) {
   return (
-    <Styled.Container className={className}>
+    <Styled.Container className={className} {...props}>
       <Styled.Background>{children}</Styled.Background>
     </Styled.Container>
   );

--- a/client/src/reader/components/resource-annotation/Block/index.js
+++ b/client/src/reader/components/resource-annotation/Block/index.js
@@ -11,7 +11,7 @@ export default function ResourceBlock({ annotation }) {
   const entity = resource ?? collection;
 
   return entity ? (
-    <Styled.Block>
+    <Styled.Block data-annotation-resource-unselectable>
       <p>Resource block for:</p>
       <p>{entity?.attributes.title}</p>
       {annotation.readerDisplayFormat === "embed" ? (

--- a/client/src/reader/components/resource-annotation/Block/styles.js
+++ b/client/src/reader/components/resource-annotation/Block/styles.js
@@ -1,6 +1,9 @@
 import styled from "@emotion/styled";
+import { unselectable } from "../Marker/Sidebar/styles";
 import Box from "global/components/atomic/Box";
 
 export const Block = styled(Box)`
   margin-block: 1rem;
+
+  ${unselectable}
 `;

--- a/client/src/reader/components/resource-annotation/Marker/Thumbnail/Mobile/index.js
+++ b/client/src/reader/components/resource-annotation/Marker/Thumbnail/Mobile/index.js
@@ -36,7 +36,10 @@ export default function ThumbnailMobile({
     attachmentStyles?.medium;
 
   return active ? (
-    <Styled.Wrapper data-hover-override={hoverOverride}>
+    <Styled.Wrapper
+      data-annotation-resource-mobile
+      data-hover-override={hoverOverride}
+    >
       <Styled.Content>
         <Styled.ImageWrapper>
           {imgSrc ? (

--- a/client/src/reader/components/resource-annotation/Marker/index.js
+++ b/client/src/reader/components/resource-annotation/Marker/index.js
@@ -92,7 +92,7 @@ export default function Marker({ annotation }) {
   );
 
   return (
-    <Styled.Wrapper ref={markerRef}>
+    <Styled.Wrapper data-annotation-resource-unselectable ref={markerRef}>
       <Styled.Marker
         $active={id === activeAnnotation}
         data-annotation-notation={id}

--- a/client/src/reader/containers/Annotatable/handlers/CaptureSelection.js
+++ b/client/src/reader/containers/Annotatable/handlers/CaptureSelection.js
@@ -237,6 +237,20 @@ class AnnotatableCaptureSelection extends Component {
       endRange.setStart(endNode, 0);
       endRange.setEnd(range.endContainer, range.endOffset);
     }
+
+    const contents = endRange.cloneContents();
+    const resources = contents.querySelectorAll(
+      "[data-annotation-resource-unselectable]"
+    );
+    const unselectable = new DocumentFragment();
+    unselectable.replaceChildren(...resources);
+
+    if (unselectable.textContent.length) {
+      const adjustedOffset = range.endOffset - unselectable.textContent.length;
+      if (adjustedOffset > 0)
+        endRange.setEnd(range.endContainer, adjustedOffset);
+    }
+
     const endChar = endRange.toString().length;
     return { endNode, endChar };
   }

--- a/client/src/reader/containers/Annotatable/handlers/CaptureSelection.js
+++ b/client/src/reader/containers/Annotatable/handlers/CaptureSelection.js
@@ -246,9 +246,10 @@ class AnnotatableCaptureSelection extends Component {
     if (!selection) return null;
 
     const range = selection.range;
+    const endRange = selection.endRange;
     const { startNode, startChar, adjustStart } = this.findStartValues(range);
     const { endNode, endChar, adjustEnd } = this.findEndValues(
-      range,
+      endRange,
       startNode
     );
 
@@ -292,12 +293,17 @@ class AnnotatableCaptureSelection extends Component {
 
   mapNativeSelection(nativeSelection) {
     if (!nativeSelection) return null;
+
+    const count = nativeSelection.rangeCount;
     const range = nativeSelection.getRangeAt(0);
+    const endRange = count > 1 ? nativeSelection.getRangeAt(count - 1) : range;
+
     const text = nativeSelection.toString();
     if (text.length === 0 || !text.trim()) return null;
 
     const mappedSelection = {
       range,
+      endRange,
       text,
       anchorNode: nativeSelection.anchorNode,
       anchorOffset: nativeSelection.anchorOffset,

--- a/client/src/reader/containers/Annotatable/handlers/CaptureSelection.js
+++ b/client/src/reader/containers/Annotatable/handlers/CaptureSelection.js
@@ -202,8 +202,18 @@ class AnnotatableCaptureSelection extends Component {
     } catch (error) {
       startRange.setEnd(range.startContainer, range.startOffset);
     }
+
+    const contents = startRange.cloneContents();
+    const resources = contents.querySelectorAll(
+      "[data-annotation-resource-unselectable]"
+    );
+    const unselectable = new DocumentFragment();
+    unselectable.replaceChildren(...resources);
+
     // 3. Find the offset from the data-node-uuid start element
-    const startChar = startRange.toString().length;
+    const startChar =
+      startRange.toString().length - unselectable.textContent?.length;
+
     return { startNode, startChar };
   }
 
@@ -245,13 +255,8 @@ class AnnotatableCaptureSelection extends Component {
     const unselectable = new DocumentFragment();
     unselectable.replaceChildren(...resources);
 
-    if (unselectable.textContent.length) {
-      const adjustedOffset = range.endOffset - unselectable.textContent.length;
-      if (adjustedOffset > 0)
-        endRange.setEnd(range.endContainer, adjustedOffset);
-    }
-
-    const endChar = endRange.toString().length;
+    const endChar =
+      endRange.toString().length - unselectable.textContent?.length;
     return { endNode, endChar };
   }
 


### PR DESCRIPTION
Fixes preexisting bug where multiple ranges in FF selections were ignored and adds support for selection where the content includes a resource annotation.

Known issues:
- [x] Clicking on a highlight that includes a resource block does not open popup
         - Update: I had created an edge case here where the last node in included in the selection grabbed by the highlight click was empty. Added a fix to account for this. The fix also revealed that my previous attempt at omitting resource block content from annotation subjects wasn't nuanced enough. Added a fix for this too.
- [x] Annotation maker placement is off by one character in the annotation drawer when annotation includes a resource
- [ ] API service placing orphans needs corresponding update