### PR TITLE
[E] Background text section node indexing

### DIFF
--- a/api/app/jobs/text_sections/index_contained_content_job.rb
+++ b/api/app/jobs/text_sections/index_contained_content_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module TextSections
+  # @see TextSection#index_contained_content!
+  # @see TextSections::IndexContainedContent
+  class IndexContainedContentJob < ApplicationJob
+    queue_as :low_priority
+
+    # @see TextSection#index_contained_content!
+    # @param [TextSection] text_section
+    # @return [void]
+    def perform(text_section)
+      text_section.index_contained_content!
+    end
+  end
+end

--- a/api/app/jobs/text_sections/index_current_node_content_job.rb
+++ b/api/app/jobs/text_sections/index_current_node_content_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module TextSections
+  # A job to index the contained content for all nodes in a {TextSection}.
+  #
+  # A single text section may have several thousand current nodes and we
+  # want to background the indexing of each node rather than handle it
+  # all at once in a single request.
+  class IndexCurrentNodeContentJob < ApplicationJob
+    include JobIteration::Iteration
+
+    queue_as :low_priority
+
+    # @param [TextSection] text_section
+    # @param [String, nil] cursor
+    # @return [Enumerator]
+    def build_enumerator(text_section, cursor:)
+      enumerator_builder.active_record_on_records(
+        text_section.text_section_nodes.current.reorder(nil).all,
+        cursor:,
+      )
+    end
+
+    # @param [TextSectionNode] text_section_node
+    # @param [Project] _project
+    # @return [void]
+    def each_iteration(text_section_node, _project)
+      text_section_node.index_contained_content!
+    end
+  end
+end

--- a/api/app/models/text_section_node.rb
+++ b/api/app/models/text_section_node.rb
@@ -42,6 +42,8 @@ class TextSectionNode < ApplicationRecord
   has_many_readonly :text_section_node_links, -> { in_order }, inverse_of: :parent, foreign_key: :parent_id
   has_many_readonly :ancestor_links, -> { in_reverse_order }, class_name: "TextSectionNodeLink", inverse_of: :child, foreign_key: :child_id
 
+  has_one_readonly :text_section_node_derivation, inverse_of: :text_section_node
+
   has_many :parents, -> { terminal }, through: :ancestor_links, source: :parent
   has_many :children, through: :text_section_node_links, source: :child
 
@@ -92,6 +94,13 @@ class TextSectionNode < ApplicationRecord
   # @note Override default behavior. Highlights don't perform well on large corpuses.
   def pg_search_highlight
     ""
+  end
+
+  # @api private
+  # @see TextSectionNodes::IndexContainedContent
+  # @return [void]
+  def index_contained_content!
+    ManifoldApi::Container["text_section_nodes.index_contained_content"].(self).value!
   end
 
   # @api private

--- a/api/app/operations/text_section_nodes/index_contained_content.rb
+++ b/api/app/operations/text_section_nodes/index_contained_content.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module TextSectionNodes
+  # Index the contained content for a {TextSectionNode}.
+  # This needs to happen this way rather than during node extrapolation
+  # owing to the expensiveness of the query that figures out what each
+  # node contains. Postgres isn't able to take advantage of indexing on
+  # the generated ltrees that represent node paths, so it is actually
+  # several orders of magnitude faster to do this for each node in
+  # a separate query.
+  class IndexContainedContent
+    include Dry::Monads[:do, :result]
+    include QueryOperation
+
+    QUERY = <<~SQL
+    WITH derived AS (
+      SELECT pn.id AS text_section_node_id,
+        COALESCE(array_agg(cn.node_uuid ORDER BY cn.node_indices) FILTER (WHERE cn.node_uuid IS NOT NULL), '{}'::text[]) AS contained_node_uuids,
+        string_agg(cn.content, ' ' ORDER BY cn.node_indices) FILTER (WHERE cn.content IS NOT NULL AND cn.content ~ '[^[:space:]]+') AS contained_content
+        FROM text_section_nodes pn
+        INNER JOIN text_section_nodes cn ON cn.text_section_id = %<text_section_id>s AND cn.body_hash = %<body_hash>s AND pn.node_path @> cn.node_path
+        WHERE pn.id = %<text_section_node_id>s
+        GROUP BY pn.id
+    )
+    UPDATE text_section_nodes tsn SET
+      contained_node_uuids = COALESCE(d.contained_node_uuids, '{}'::text[]),
+      contained_content = CASE WHEN char_length(d.contained_content) <= 4096 THEN d.contained_content ELSE '' END,
+      search_indexed = TRUE
+      FROM derived d
+      WHERE tsn.id = %<text_section_node_id>s
+    ;
+    SQL
+
+    # @param [TextSectionNode] text_section_node
+    # @return [Dry::Monads::Result]
+    def call(text_section_node)
+      params = {
+        text_section_node_id: text_section_node.quoted_id,
+        text_section_id: quote_value(text_section_node.text_section_id),
+        body_hash: text_section_node.body_hash,
+      }
+
+      query = QUERY % params
+
+      response = sql_update!(query)
+
+      Success response
+    end
+  end
+end

--- a/api/app/operations/text_sections/extrapolate_nodes.rb
+++ b/api/app/operations/text_sections/extrapolate_nodes.rb
@@ -64,14 +64,6 @@ module TextSections
         FROM nodes
         LEFT JOIN LATERAL jsonb_array_elements(nodes.children) WITH ORDINALITY AS c(node, index) ON true
         WHERE nodes.children_count <> 0
-    ), contained_data AS (
-      SELECT
-        pn.node_path,
-        COALESCE(array_agg(cn.node_uuid ORDER BY cn.node_indices) FILTER (WHERE cn.node_uuid IS NOT NULL), '{}'::text[]) AS contained_node_uuids,
-        string_agg(cn.content, ' ' ORDER BY cn.node_indices) FILTER (WHERE cn.content IS NOT NULL AND cn.content ~ '[^[:space:]]+') AS contained_content
-        FROM nodes pn
-        INNER JOIN nodes cn ON pn.node_path @> cn.node_path
-        GROUP BY pn.node_path
     ), finalized AS (
       SELECT
         text_section_id, body_hash,
@@ -80,8 +72,6 @@ module TextSections
         node_type, tag,
         COALESCE(attributes, '{}'::jsonb) AS node_attributes,
         node_uuid, text_digest, content,
-        contained_node_uuids,
-        CASE WHEN char_length(contained_content) <= 4096 THEN contained_content ELSE '' END AS contained_content,
         COALESCE(node_extra, '{}'::jsonb) AS node_extra,
         COALESCE(children_count, 0) AS children_count,
         (#{TAG_IS_INTERMEDIATE}) AS intermediate,
@@ -89,7 +79,6 @@ module TextSections
         CURRENT_TIMESTAMP AS search_indexed_at,
         TRUE AS search_indexed
       FROM nodes
-      LEFT OUTER JOIN contained_data USING (node_path)
     )
     SQL
 
@@ -101,8 +90,6 @@ module TextSections
       node_type, tag,
       node_attributes,
       node_uuid, text_digest, content,
-      contained_node_uuids,
-      contained_content,
       node_extra,
       children_count,
       intermediate,
@@ -116,8 +103,6 @@ module TextSections
       node_type, tag,
       node_attributes,
       node_uuid, text_digest, content,
-      contained_node_uuids,
-      contained_content,
       node_extra,
       children_count,
       intermediate,
@@ -139,8 +124,6 @@ module TextSections
       "node_uuid" = EXCLUDED."node_uuid",
       "text_digest" = EXCLUDED."text_digest",
       "content" = EXCLUDED."content",
-      "contained_node_uuids" = EXCLUDED."contained_node_uuids",
-      "contained_content" = EXCLUDED."contained_content",
       "node_extra" = EXCLUDED."node_extra",
       "children_count" = EXCLUDED."children_count",
       "intermediate" = EXCLUDED."intermediate",
@@ -172,10 +155,6 @@ module TextSections
         EXCLUDED."text_digest" IS DISTINCT FROM text_section_nodes."text_digest"
         OR
         EXCLUDED."content" IS DISTINCT FROM text_section_nodes."content"
-        OR
-        EXCLUDED."contained_node_uuids" IS DISTINCT FROM text_section_nodes."contained_node_uuids"
-        OR
-        EXCLUDED."contained_content" IS DISTINCT FROM text_section_nodes."contained_content"
         OR
         EXCLUDED."node_extra" IS DISTINCT FROM text_section_nodes."node_extra"
         OR

--- a/api/app/operations/text_sections/index_contained_content.rb
+++ b/api/app/operations/text_sections/index_contained_content.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module TextSections
+  # A batch version of {TextSectionNodes::IndexContainedContent},
+  # included for troubleshooting and possible future use.
+  class IndexContainedContent
+    include Dry::Monads[:do, :result]
+    include QueryOperation
+
+    QUERY = <<~SQL
+    WITH derived AS (
+      SELECT pn.id AS text_section_node_id,
+        COALESCE(array_agg(cn.node_uuid ORDER BY cn.node_indices) FILTER (WHERE cn.node_uuid IS NOT NULL), '{}'::text[]) AS contained_node_uuids,
+        string_agg(cn.content, ' ' ORDER BY cn.node_indices) FILTER (WHERE cn.content IS NOT NULL AND cn.content ~ '[^[:space:]]+') AS contained_content
+        FROM text_section_nodes pn
+        INNER JOIN text_section_nodes cn ON cn.text_section_id = %<text_section_id>s AND cn.body_hash = %<body_hash>s AND pn.node_path @> cn.node_path
+        WHERE
+        pn.text_section_id = %<text_section_id>s
+        AND
+        pn.body_hash = %<body_hash>s
+        GROUP BY pn.id
+    )
+    UPDATE text_section_nodes tsn SET
+      contained_node_uuids = COALESCE(d.contained_node_uuids, '{}'::text[]),
+      contained_content = CASE WHEN char_length(d.contained_content) <= 4096 THEN d.contained_content ELSE '' END,
+      search_indexed = TRUE
+      FROM derived d
+      WHERE tsn.id = d.text_section_node_id
+    ;
+    SQL
+
+    # @param [TextSection] text_section
+    # @return [Dry::Monads::Result]
+    def call(text_section)
+      params = {
+        text_section_id: text_section.quoted_id,
+        body_hash: text_section.body_hash,
+      }
+
+      query = QUERY % params
+
+      response = sql_update!(query)
+
+      Success response
+    end
+  end
+end

--- a/api/app/services/concerns/query_operation.rb
+++ b/api/app/services/concerns/query_operation.rb
@@ -48,6 +48,12 @@ module QueryOperation
     ApplicationRecord.connection
   end
 
+  # @api private
+  # @return [String]
+  def quote_value(value)
+    connection.quote(value)
+  end
+
   # Join components of a query with the separator value in `join_with`.
   #
   # @param [<String>] parts

--- a/api/db/migrate/20251016204352_add_contained_content_helper_index.rb
+++ b/api/db/migrate/20251016204352_add_contained_content_helper_index.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddContainedContentHelperIndex < ActiveRecord::Migration[7.0]
+  # Needed for CREATE INDEX CONCURRENTLY
+  disable_ddl_transaction!
+
+  def change
+    change_table :text_section_nodes do |t|
+      t.index %i[text_section_id body_hash node_path id],
+        name: "index_text_section_nodes_contained_content_indexing",
+        opclass: { node_path: "gist_ltree_ops(siglen=100)" },
+        algorithm: :concurrently,
+        using: :gist
+    end
+  end
+end

--- a/api/db/structure.sql
+++ b/api/db/structure.sql
@@ -6022,6 +6022,13 @@ CREATE INDEX index_text_section_nodes_child_ordering ON public.text_section_node
 
 
 --
+-- Name: index_text_section_nodes_contained_content_indexing; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_text_section_nodes_contained_content_indexing ON public.text_section_nodes USING gist (text_section_id, body_hash, node_path public.gist_ltree_ops (siglen='100'), id);
+
+
+--
 -- Name: index_text_section_nodes_extrapolation; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7753,6 +7760,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250530205742'),
 ('20250603192547'),
 ('20250609191642'),
-('20250609192241');
+('20250609192241'),
+('20251016204352');
 
 

--- a/api/spec/jobs/text_sections/index_contained_content_job_spec.rb
+++ b/api/spec/jobs/text_sections/index_contained_content_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe TextSections::IndexContainedContentJob, type: :job do
+  let_it_be(:text_section, refind: true) { FactoryBot.create :text_section, :with_simple_body }
+
+  let_it_be(:expected_count) { TextSectionNode.where(search_indexed: true).count }
+
+  before do
+    TextSectionNode.update_all(search_indexed: false)
+  end
+
+  it "updates search indices" do
+    expect do
+      described_class.perform_now(text_section)
+    end.to change(TextSectionNode.sans_search_indexed, :count).by(-expected_count)
+  end
+end

--- a/api/spec/jobs/text_sections/index_current_node_content_job_spec.rb
+++ b/api/spec/jobs/text_sections/index_current_node_content_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe TextSections::IndexCurrentNodeContentJob, type: :job do
+  let_it_be(:text_section, refind: true) { FactoryBot.create :text_section, :with_simple_body }
+
+  let_it_be(:expected_count) { TextSectionNode.where(search_indexed: true).count }
+
+  before do
+    TextSectionNode.update_all(search_indexed: false)
+  end
+
+  it "updates search indices" do
+    expect do
+      described_class.perform_now(text_section)
+    end.to change(TextSectionNode.sans_search_indexed, :count).by(-expected_count)
+  end
+end


### PR DESCRIPTION
This addresses a regression that caused large text sections to take an extremely long time to save.

Resolves MNFLD-1100