### PR TITLE
[B] Fix focus-trap error when switching dialogs

### DIFF
--- a/client/src/global/components/Overlay/index.js
+++ b/client/src/global/components/Overlay/index.js
@@ -42,20 +42,21 @@ function Overlay({
 
   return (
     <BodyClass className={open ? "no-scroll overlay" : ""}>
-      <div
-        className={appearance || "overlay-full"}
-        ref={overlayRef}
-        id={id}
-        role="dialog"
-        aria-modal
-        aria-labelledby={headerId}
-        inert={!open ? "" : undefined}
+      <FocusTrap
+        active={open}
+        focusTrapOptions={{
+          escapeDeactivates: e => handleCloseEvent(e),
+          fallbackFocus: overlayRef
+        }}
       >
-        <FocusTrap
-          active={open}
-          focusTrapOptions={{
-            escapeDeactivates: e => handleCloseEvent(e)
-          }}
+        <div
+          className={appearance || "overlay-full"}
+          ref={overlayRef}
+          id={id}
+          role="dialog"
+          aria-modal
+          aria-labelledby={headerId}
+          inert={!open ? "" : undefined}
         >
           <div>
             <Header
@@ -70,8 +71,8 @@ function Overlay({
               {children}
             </div>
           </div>
-        </FocusTrap>
-      </div>
+        </div>
+      </FocusTrap>
     </BodyClass>
   );
 }


### PR DESCRIPTION
Moves the focus trap outside of the dialog and makes the dialog a
fallback for focus so that at least one focusable node always exists.
This resolves an issue in the reader where moving from the full notes
overlay to the annotation drawer caused an exception.
