### PR TITLE
[B] Ensure feature updates persist

### DIFF
--- a/api/app/controllers/api/v1/features_controller.rb
+++ b/api/app/controllers/api/v1/features_controller.rb
@@ -25,7 +25,7 @@ module API
 
       def update
         @feature = load_and_authorize_feature
-        ::Updaters::Feature.new(**feature_params).update(@feature)
+        ::Updaters::Feature.new(feature_params).update(@feature)
         render_single_resource(@feature)
       end
 


### PR DESCRIPTION
I noticed what seems like a regression (from upgrades?) where feature updates aren't returning an error but aren't saving any of the field changes on Edge. This fixes it for me locally.