### PR TITLE
[B] Address several authorization issues

### DIFF
--- a/api/app/authorizers/entitlement_authorizer.rb
+++ b/api/app/authorizers/entitlement_authorizer.rb
@@ -14,6 +14,12 @@ class EntitlementAuthorizer < ApplicationAuthorizer
       provided_by?(user) || provides_to?(user)
   end
 
+  def creatable_by?(user, options = {})
+    return false if resource.persisted?
+
+    default(:create, user, options)
+  end
+
   def updatable_by?(_user, _options = {})
     false
   end

--- a/api/app/authorizers/journal_authorizer.rb
+++ b/api/app/authorizers/journal_authorizer.rb
@@ -84,7 +84,10 @@ class JournalAuthorizer < ApplicationAuthorizer
 
   private
 
+  # @param [User, nil]
   def issues_editable_by?(user)
+    return false if user.blank? || user.anonymous?
+
     resource.journal_issues.includes(:project).any? do |journal_issue|
       user.has_cached_role?(:project_editor, journal_issue.project)
     end

--- a/api/app/authorizers/project_authorizer.rb
+++ b/api/app/authorizers/project_authorizer.rb
@@ -107,6 +107,7 @@ class ProjectAuthorizer < ApplicationAuthorizer
   # @param [Hash] options
   def entitlements_creatable_by?(user, options = {})
     return false if resource.draft? && !has_any_role?(user, :admin, :editor)
+
     options ||= {}
 
     options[:for] = resource
@@ -119,6 +120,7 @@ class ProjectAuthorizer < ApplicationAuthorizer
   # @param [Hash] options
   def entitlements_manageable_by?(user, options = {})
     return false if resource.draft? && !has_any_role?(user, :admin, :editor)
+
     options ||= {}
 
     options[:for] = resource
@@ -140,7 +142,7 @@ class ProjectAuthorizer < ApplicationAuthorizer
   # @param [User] user
   # @param [Hash] _options
   def drafts_readable_by?(user, options = {})
-    has_any_role?(user, *RoleName.draft_access) || with_journal { |j| j.readable_by? user, options }
+    has_any_role?(user, *RoleName.draft_access) || with_journal { |j| j.drafts_readable_by? user, options }
   end
 
   def publicly_engageable_by?(user, _options = {})

--- a/api/spec/authorizers/entitlement_authorizer_spec.rb
+++ b/api/spec/authorizers/entitlement_authorizer_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe EntitlementAuthorizer, :authorizer do
     subject { project_editor }
 
     it { is_expected.to be_unable_to(:read, :create, :manage, :update, :delete).on(entitlement) }
-    it { is_expected.to be_unable_to(:read, :create, :manage, :update, :delete).on(Entitlement) }
+    it { is_expected.to be_able_to(:read).on(Entitlement).and(be_unable_to(:create, :manage, :update, :delete).on(Entitlement)) }
 
     context "when for a specific project that the user has access to" do
       let(:entitlement_traits) { [:project_read_access] }
       let(:entitlement_attributes) { super().merge(subject: project) }
 
-      it { is_expected.to be_able_to(:read, :create, :manage, :delete).on(entitlement).and be_unable_to(:update).on(entitlement) }
+      it { is_expected.to be_able_to(:read, :manage, :delete).on(entitlement).and be_unable_to(:create, :update).on(entitlement) }
       it { is_expected.to be_able_to(:read, :create, :manage, :delete).on(Entitlement).with(for: project).and be_unable_to(:update).on(Entitlement).with(for: project) }
     end
   end
@@ -48,7 +48,7 @@ RSpec.describe EntitlementAuthorizer, :authorizer do
   context "with the entitler" do
     subject { creator }
 
-    it { is_expected.to be_able_to(:read, :create, :manage, :delete).on(entitlement).and be_unable_to(:update).on(entitlement) }
+    it { is_expected.to be_able_to(:read, :manage, :delete).on(entitlement).and be_unable_to(:create, :update).on(entitlement) }
     it { is_expected.to be_able_to(:read, :create, :manage, :delete).on(Entitlement).and be_unable_to(:update).on(Entitlement) }
   end
 
@@ -56,7 +56,7 @@ RSpec.describe EntitlementAuthorizer, :authorizer do
     subject { a_random_user }
 
     it { is_expected.to be_unable_to(:read, :create, :manage, :update, :delete).on(entitlement) }
-    it { is_expected.to be_unable_to(:read, :create, :manage, :update, :delete).on(Entitlement) }
+    it { is_expected.to be_able_to(:read).on(Entitlement).and(be_unable_to(:create, :manage, :update, :delete).on(Entitlement)) }
   end
 
   context "with the target user" do

--- a/api/spec/authorizers/journal_authorizer_spec.rb
+++ b/api/spec/authorizers/journal_authorizer_spec.rb
@@ -88,14 +88,13 @@ RSpec.describe "Journal Abilities", :authorizer do
 
   shared_examples_for "unauthorized to manage journal issues" do
     it "is unable to manage journal issues" do
-      is_expected.to be_unable_to(
+      is_expected.to be_able_to(:read).on(journal_issue).and(be_unable_to(
         :manage_permissions,
         :create_permissions,
         :create,
-        :read,
         :update,
         :delete
-      ).on(journal_issue)
+      ).on(journal_issue))
     end
   end
 
@@ -152,7 +151,7 @@ RSpec.describe "Journal Abilities", :authorizer do
   context "when unauthenticated" do
     let(:user) { anonymous_user }
 
-    include_examples "no access"
+    include_examples "read only"
   end
 
   context "when the user is a regular reader" do

--- a/api/spec/support/matchers/authority.rb
+++ b/api/spec/support/matchers/authority.rb
@@ -87,6 +87,18 @@ RSpec::Matchers.define :be_able_to do |*verbs|
     @disallowed.none?
   end
 
+  match_when_negated do |user|
+    validate_resource! resource
+
+    @actions = validate_verbs! verbs
+
+    @allowed, @disallowed = @actions.partition do |action|
+      Authority.action_authorized?(action, resource, user, options)
+    end
+
+    @allowed.none?
+  end
+
   chain :on, :resource
   chain :with, :options
 


### PR DESCRIPTION
* Ensure that draft projects remain inaccessible even if they belong to a journal that is *not* a draft.
* Correct an issue with the negated version of `be_able_to` matcher from failing to properly check that _all_ abilities are negated.
* Address a number of minor authorization checks that were surfaced by fixing the above bug, almost all of which were simply things which should have been fixed but were missed because the tests obfuscated them.