### PR TITLE
[E] Improve soft deletion process

### DIFF
--- a/api/app/jobs/soft_deletions/purge_job.rb
+++ b/api/app/jobs/soft_deletions/purge_job.rb
@@ -5,12 +5,13 @@ module SoftDeletions
   class PurgeJob < ApplicationJob
     queue_as :deletions
 
-    discard_on ActiveJob::DeserializationError, ActiveRecord::RecordNotFound, ActiveRecord::RecordNotDestroyed
+    discard_on ActiveJob::DeserializationError, ActiveRecord::RecordNotFound, ActiveRecord::RecordNotDestroyed,
+                SoftDeletions::Unpurgeable
 
     # @param [SoftDeletable] record
     # @return [void]
     def perform(record)
-      record.destroy! if record.marked_for_purge?
+      record.soft_deletion_purge!
     end
   end
 end

--- a/api/app/models/concerns/soft_deletable.rb
+++ b/api/app/models/concerns/soft_deletable.rb
@@ -6,6 +6,7 @@ module SoftDeletable
   SOFT_DELETABLE_DEPENDENTS = %i[destroy delete_all].freeze
 
   include Filterable
+  include SoftDeletionSupport
 
   included do
     define_model_callbacks :mark_for_purge, :soft_delete
@@ -76,6 +77,13 @@ module SoftDeletable
   # @return [SoftDeletable]
   def soft_delete!
     soft_delete or raise ActiveRecord::RecordNotDestroyed.new("Failed to destroy the record", self)
+  end
+
+  # @see SoftDeletions::Purge
+  # @see SoftDeletions::Purger
+  # @return [void]
+  def soft_deletion_purge!
+    ManifoldApi::Container["soft_deletions.purge"].call(self).value!
   end
 
   private

--- a/api/app/models/concerns/soft_deletion_support.rb
+++ b/api/app/models/concerns/soft_deletion_support.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Support methods for detecting if soft-deletion is happening.
+# Models do not have to be soft-deletable to take advantage of this concern.
+module SoftDeletionSupport
+  extend ActiveSupport::Concern
+
+  # @see SoftDeletions::Current
+  def soft_deleting?
+    SoftDeletions::Current.active?
+  end
+end

--- a/api/app/models/stylesheet.rb
+++ b/api/app/models/stylesheet.rb
@@ -12,6 +12,8 @@ class Stylesheet < ApplicationRecord
   include SerializedAbilitiesFor
   self.authorizer_name = "ProjectChildAuthorizer"
 
+  self.filter_attributes = [/\Araw_styles\z/, /\Astyles\z/].freeze
+
   # Associations
   belongs_to :text
   has_one :project, through: :text

--- a/api/app/models/text.rb
+++ b/api/app/models/text.rb
@@ -75,6 +75,8 @@ class Text < ApplicationRecord
   has_many :text_sections, -> { order(position: :asc) }, dependent: :destroy,
            inverse_of: :text, autosave: true
   has_one_readonly :text_section_aggregation, inverse_of: :text
+  has_many :text_section_nodes, -> { reorder(nil) }, through: :text_sections
+  has_many :text_section_stylesheets, -> { reorder(nil) }, through: :text_sections
   has_many :stylesheets, -> { order(position: :asc) }, dependent: :destroy,
            inverse_of: :text
   has_many :favorites, as: :favoritable, dependent: :destroy, inverse_of: :favoritable

--- a/api/app/operations/soft_deletions/purge.rb
+++ b/api/app/operations/soft_deletions/purge.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SoftDeletions
+  # @see SoftDeletable
+  # @see SoftDeletions::PurgeJob
+  # @see SoftDeletions::Purger
+  class Purge
+    def call(...)
+      SoftDeletions::Purger.new(...).call
+    end
+  end
+end

--- a/api/app/services/soft_deletions/current.rb
+++ b/api/app/services/soft_deletions/current.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module SoftDeletions
+  # Current attributes for tracking the status of the soft-deletion process.
+  #
+  # @see SoftDeletionSupport
+  class Current < ActiveSupport::CurrentAttributes
+    attribute :active
+
+    class << self
+      alias active? active
+
+      # @return [void]
+      def active!
+        set(active: true) do
+          yield
+        end
+      end
+    end
+  end
+end

--- a/api/app/services/soft_deletions/purger.rb
+++ b/api/app/services/soft_deletions/purger.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+module SoftDeletions
+  # We use this service to delete large objects in the background in order to avoid
+  # long-running requests, and specifically to avoid massive table locks happening
+  # within a single transaction during a soft-deletion.
+  #
+  # Normally we would want to keep a transaction active around processes like this
+  # in order to ensure data integrity, but if a model has reached this object, it
+  # is already marked for deletion and we don't need to maintain the ability to
+  # roll things back.
+  #
+  # @see SoftDeletable
+  # @see SoftDeletions::PurgeJob
+  # @see SoftDeletions::Purge
+  class Purger
+    extend ActiveModel::Callbacks
+
+    include Dry::Monads[:result]
+    include Dry::Initializer[undefined: false].define -> do
+      param :original_record, SoftDeletions::Types::SoftDeletable
+    end
+
+    define_model_callbacks :perform
+
+    around_perform :activate_soft_deletion!
+
+    around_perform :disable_acts_as_list!
+
+    # @raise [SoftDeletions::Unpurgeable] if the record could not be purged
+    # @return [Dry::Monads::Success(void)]
+    def call
+      # :nocov:
+      return Success() unless original_record.marked_for_purge?
+      # :nocov:
+
+      handle! original_record
+    rescue ActiveRecord::RecordNotDestroyed => e
+      raise SoftDeletions::Unpurgeable, "Could not soft delete #{original_record.class.name}(#{original_record.id.inspect}): #{e.message}"
+    else
+      Success()
+    end
+
+    private
+
+    # @param [ApplicationRecord] record
+    # @return [void]
+    def handle!(record)
+      case record
+      when Annotation
+        on_annotation! record
+      when Comment
+        on_comment! record
+      when Project
+        on_project! record
+      when ReadingGroup
+        on_reading_group! record
+      when Text
+        on_text! record
+      when TextSection
+        on_text_section! record
+      when User
+        on_user! record
+      end
+
+      record.destroy!
+    end
+
+    # @return [void]
+    def activate_soft_deletion!
+      SoftDeletions::Current.active! do
+        yield
+      end
+    end
+
+    def disable_acts_as_list!
+      TextSection.acts_as_list_no_update do
+        yield
+      end
+    end
+
+    # @param [Annotation] record
+    # @return [void]
+    def on_annotation!(record)
+      record.comments.where(parent_id: nil).find_each do |comment|
+        handle! comment
+      end
+    end
+
+    # @param [Comment] record
+    # @return [void]
+    def on_comment!(record)
+      record.children.find_each do |child_comment|
+        handle! child_comment
+      end
+    end
+
+    # @param [Project] record
+    # @return [void]
+    def on_project!(record)
+      record.texts.find_each do |text|
+        handle!(text)
+      end
+    end
+
+    # @param [ReadingGroup] record
+    # @return [void]
+    def on_reading_group!(record)
+      # We perform this outside of the transaction even though it's part of
+      # the callback.
+      record.update_annotations_privacy
+      record.reading_group_memberships.reorder(nil).delete_all
+      record.reading_group_categories.reorder(nil).delete_all
+    end
+
+    # @param [Text] record
+    # @return [void]
+    def on_text!(record)
+      # These are the biggest offender. Some texts can have tens of thousands of nodes,
+      # and we want to delete them outside of any transactions that lock other updates.
+      TextSectionNode.where(id: record.text_section_nodes.select(:id)).delete_all
+
+      TextSectionStylesheet.where(id: record.text_section_stylesheets.select(:id)).delete_all
+
+      record.action_callouts.destroy_all
+
+      record.text_sections.find_each do |text_section|
+        handle!(text_section)
+      end
+
+      record.stylesheets.delete_all
+    end
+
+    # @param [TextSection] record
+    # @return [void]
+    def on_text_section!(record)
+      record.text_section_nodes.delete_all
+      record.text_section_stylesheets.delete_all
+      record.annotations.update_all(text_section_id: nil)
+    end
+
+    # @param [User] record
+    # @return [void]
+    def on_user!(record)
+      record.annotations.find_each do |annotation|
+        handle! annotation
+      end
+    end
+  end
+end

--- a/api/app/services/soft_deletions/types.rb
+++ b/api/app/services/soft_deletions/types.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SoftDeletions
+  module Types
+    include Dry.Types
+
+    SoftDeletable = Types.Instance(::SoftDeletable)
+  end
+end

--- a/api/app/services/soft_deletions/unpurgeable.rb
+++ b/api/app/services/soft_deletions/unpurgeable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SoftDeletions
+  # Exception raised when attempting to purge an unpurgeable record.
+  # @see SoftDeletions::Purger
+  class Unpurgeable < StandardError; end
+end

--- a/api/spec/factories/text_section.rb
+++ b/api/spec/factories/text_section.rb
@@ -65,5 +65,13 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :with_hydrated_nodes do
+      after(:create) do |text_section, _|
+        ts = TextSection.find(text_section.id)
+        ts.index_nodes!
+        ts.maintain_current_nodes!
+      end
+    end
   end
 end

--- a/api/spec/operations/soft_deletions/purge_spec.rb
+++ b/api/spec/operations/soft_deletions/purge_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+RSpec.describe SoftDeletions::Purge, type: :operation do
+  let_it_be(:user, refind: true) { FactoryBot.create(:user) }
+  let_it_be(:creator) { user }
+  let_it_be(:reading_group, refind: true) { FactoryBot.create(:reading_group, creator:) }
+  let_it_be(:category, refind: true) { FactoryBot.create(:reading_group_category, reading_group:) }
+  let_it_be(:project, refind: true) { FactoryBot.create(:project, creator:) }
+  let_it_be(:text, refind: true) { FactoryBot.create(:text, creator:, project:) }
+  let_it_be(:stylesheet, refind: true) { FactoryBot.create(:stylesheet, text:) }
+  let_it_be(:text_section, refind: true) { FactoryBot.create(:text_section, :with_simple_body, :with_hydrated_nodes, text:) }
+  let_it_be(:text_section_stylesheet, refind: true) { TextSectionStylesheet.create!(text_section:, stylesheet:) }
+  let_it_be(:annotation, refind: true) { FactoryBot.create(:annotation, creator:, text_section:, reading_group:) }
+  let_it_be(:comment, refind: true) { FactoryBot.create(:comment, creator:, subject: annotation) }
+  let_it_be(:subcomment, refind: true) { FactoryBot.create(:comment, creator:, parent: comment, subject: annotation) }
+
+  let(:node_count) { 8 }
+
+  let(:record) { comment }
+  let(:record_change_count) { -1 }
+  let(:unpurgeable_change_count) { 0 }
+
+  # @abstract
+  def meet_expectations!
+    change(record.class, :count).by(record_change_count)
+  end
+
+  # @return [void]
+  def meet_expectations_when_not_purgable!
+    change(record.class, :count).by(unpurgeable_change_count)
+      .and(raise_error(SoftDeletions::Unpurgeable))
+  end
+
+  shared_examples_for "a soft deletable record purgation" do
+    let(:operation_args) { [record] }
+
+    it "does nothing if the record has not been deleted" do
+      expect(record).not_to be_marked_for_purge
+
+      expect do
+        expect_calling_the_operation.to succeed
+      end.to keep_the_same(record.class, :count)
+    end
+
+    it "purges the record and all its dependents" do
+      expect do
+        record.async_destroy
+      end.to change { record.reload.marked_for_purge? }.from(false).to(true)
+
+      expect do
+        expect_calling_the_operation.to succeed
+      end.to meet_expectations!
+    end
+
+    it "raises the proper error if something prevents destruction" do
+      record.async_destroy
+
+      allow(record).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
+
+      expect do
+        expect_calling_the_operation
+      end.to meet_expectations_when_not_purgable!
+    end
+  end
+
+  context "when purging an annotation" do
+    let(:record) { annotation }
+
+    def meet_expectations!
+      super.and(change(Comment, :count).by(-2))
+    end
+
+    it_behaves_like "a soft deletable record purgation"
+  end
+
+  context "when purging a comment" do
+    let(:record) { comment }
+    let(:record_change_count) { -2 }
+
+    # The subcomment will still get purged,
+    # we want this job to always clean up as much as possible.
+    let(:unpurgeable_change_count) { -1 }
+
+    it_behaves_like "a soft deletable record purgation"
+  end
+
+  context "when purging a reading group" do
+    let(:record) { reading_group }
+
+    def meet_expectations!
+      super
+        .and(change(ReadingGroupCategory, :count).by(-1))
+        .and(change { annotation.reload.reading_group_id }.from(reading_group.id).to(nil))
+    end
+
+    it_behaves_like "a soft deletable record purgation"
+  end
+
+  context "when purging a project" do
+    let(:record) { project }
+
+    def meet_expectations!
+      super
+        .and(change(Text, :count).by(-1))
+        .and(change(TextSection, :count).by(-1))
+        .and(change(Stylesheet, :count).by(-1))
+        .and(change(TextSectionStylesheet, :count).by(-1))
+        .and(change(TextSectionNode, :count).by(-node_count))
+    end
+
+    it_behaves_like "a soft deletable record purgation"
+  end
+
+  context "when purging a text" do
+    let(:record) { text }
+
+    def meet_expectations!
+      super
+        .and(change(Stylesheet, :count).by(-1))
+        .and(change(TextSectionStylesheet, :count).by(-1))
+        .and(change(TextSection, :count).by(-1))
+        .and(change(TextSectionNode, :count).by(-node_count))
+    end
+
+    it_behaves_like "a soft deletable record purgation"
+  end
+
+  context "when purging a user" do
+    let(:record) { user }
+
+    def meet_expectations!
+      super
+        .and(keep_the_same(Project, :count))
+        .and(keep_the_same(Text, :count))
+        .and(keep_the_same(TextSection, :count))
+        .and(keep_the_same(TextSectionNode, :count))
+        .and(keep_the_same(ReadingGroup, :count))
+        .and(keep_the_same(ReadingGroupCategory, :count))
+        .and(change(Annotation, :count).by(-1))
+        .and(change(Comment, :count).by(-2))
+    end
+
+    it_behaves_like "a soft deletable record purgation"
+  end
+end


### PR DESCRIPTION
* We need to destroy certain large / unwieldy associations outside of the transaction that happens during the `destroy!` process. This prevents performance issues that come from locking too many rows at once. Records that reach this job already are intended to be taken out of the database, so we do not need to follow the normal type of data integrity concerns in order to remove them.
* Slight adjustment to stylesheets to prevent the styles from blowing up the console when inspecting stylesheet records.