### PR TITLE
Destroy content block refs when referencable is destroy

### DIFF
--- a/api/app/models/resource.rb
+++ b/api/app/models/resource.rb
@@ -52,6 +52,7 @@ class Resource < ApplicationRecord
   has_many :comments, as: :subject, dependent: :destroy, inverse_of: :subject
   has_many :annotations, dependent: :destroy, inverse_of: :resource
   has_many :text_tracks, dependent: :destroy, inverse_of: :resource
+  has_many :content_block_references, as: :referencable, dependent: :destroy
 
   delegate :slug, to: :project, prefix: true
 

--- a/api/app/models/text.rb
+++ b/api/app/models/text.rb
@@ -97,6 +97,7 @@ class Text < ApplicationRecord
   has_many :action_callouts,
            dependent: :destroy,
            inverse_of: :text
+  has_many :content_block_references, as: :referencable, dependent: :destroy
 
   delegate :creator_names_array, to: :project, prefix: true, allow_nil: true
   delegate :publication_date, to: :project, prefix: true, allow_nil: true

--- a/api/spec/models/content_block_reference_spec.rb
+++ b/api/spec/models/content_block_reference_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe ContentBlockReference do
     expect(association.macro).to eq :belongs_to
   end
 
+  it "is destroyed when the referenceable is destroyed" do
+    content_block_reference.referencable.destroy!
+    expect { content_block_reference.reload }.to raise_error ActiveRecord::RecordNotFound
+  end
+
   it "is invalid without a kind" do
     expect(FactoryBot.build(:content_block_reference, kind: nil)).not_to be_valid
   end


### PR DESCRIPTION
- Resolves an issue where content blocks could return null references if an associated resource or text is destroyed