### PR TITLE
Fix various Epub export bugs

### DIFF
--- a/api/app/services/packaging/epub_v3/book_compilation/add_text_sections.rb
+++ b/api/app/services/packaging/epub_v3/book_compilation/add_text_sections.rb
@@ -32,7 +32,7 @@ module Packaging
 
           item.toc_text section.toc_text
 
-          item.landmark section.landmark if section.has_landmark?
+          item.landmark **section.landmark if section.has_landmark?
 
           item.set_media_type CoreMediaTypeKind::XHTML
 

--- a/api/app/services/packaging/epub_v3/convert_cover_image.rb
+++ b/api/app/services/packaging/epub_v3/convert_cover_image.rb
@@ -29,6 +29,7 @@ module Packaging
       # @return [(File, String)]
       # @return [(Tempfile, String)]
       def maybe_convert
+        uploaded_file.open unless uploaded_file.opened?
         file_reference = uploaded_file.tempfile
         return [file_reference, content_type] if content_type.in? ACCEPTABLE_CONTENT_TYPES
 

--- a/api/app/services/packaging/epub_v3/convert_cover_image.rb
+++ b/api/app/services/packaging/epub_v3/convert_cover_image.rb
@@ -29,8 +29,7 @@ module Packaging
       # @return [(File, String)]
       # @return [(Tempfile, String)]
       def maybe_convert
-        file_reference = uploaded_file.to_io
-
+        file_reference = uploaded_file.tempfile
         return [file_reference, content_type] if content_type.in? ACCEPTABLE_CONTENT_TYPES
 
         [

--- a/api/app/services/packaging/epub_v3/text_compilation/link_external_sources.rb
+++ b/api/app/services/packaging/epub_v3/text_compilation/link_external_sources.rb
@@ -14,6 +14,8 @@ module Packaging
           remote_resources, text = state.values_at :remote_resources, :text
 
           remote_resources.each do |remote_resource|
+            next if remote_resource.external_source.blank?
+
             remote_resource.external_source.links.by_text(text).build.upsert!
           end
 


### PR DESCRIPTION
Fixes issues where Epub generation fails if:

* A text section node has a landmark
* The project cover is not a png/jpg
* A remote resource has no defined external source