### PR TITLE
Add service label to Dockerfiles

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1: Build gems with native extensions
 FROM ruby:3.4-bookworm AS builder
 
+LABEL service=manifold-api
+
 RUN mkdir -pv /bundle/bin
 
 ENV BUNDLE_PATH=/bundle \

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1: Install dependencies and copy source
 FROM node:22.17.1 AS base
 
+LABEL service=manifold-client
+
 WORKDIR /srv/app
 
 COPY package.json yarn.lock .yarnrc.yml ./


### PR DESCRIPTION
Adds `LABEL service=manifold-{role}` to API and Client Dockerfiles.

Required for Kamal deployments using a pre-existing Dockerfile.