### PR TITLE
Update Docker build CI branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,9 +3,9 @@ name: "Build & Push Docker"
 on:
   push:
     branches:
-      - next # Next, tags as "next"
-      - main # Edge, tags as "edge"
-      - release # Production, tags as "latest"
+      - edge # Edge, tags as "edge"; next major version; deploys to edge.manifoldapp.org
+      - main # Preview, tags as "preview"; bugfix/minor version preview; deploys to preview.manifoldapp.org
+      - release # Stable production build, tags as "latest"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -47,7 +47,7 @@ jobs:
             ${{ env.MANAGED_REGISTRY }}/${{ env.MANAGED_IMAGE_NAME }}-api
           tags: |
             type=raw,value=latest,enable=${{ github.ref_name == 'release' }}
-            type=raw,value=edge,enable={{ is_default_branch }}
+            type=raw,value=preview,enable={{ is_default_branch }}
             type=ref,event=branch
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,8 +12,9 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
     libglib2.0-dev \
     libicu-dev \
     libsndfile1-dev \
-    libvips-dev \
-    && rm -rf /var/lib/apt/lists/*
+    libvips-dev
+
+RUN rm -rf /var/lib/apt/lists/*
 
 COPY Gemfile /srv/app/Gemfile
 COPY Gemfile.lock /srv/app/Gemfile.lock
@@ -61,14 +62,14 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
     mediainfo \
     nodejs \
     pandoc \
-    postgresql-common \
-    && rm -rf /var/lib/apt/lists/*
+    postgresql-common
 
 RUN DEBIAN_FRONTEND=noninteractive /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
 
 RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
-    postgresql-client-13 \
-    && rm -rf /var/lib/apt/lists/*
+    postgresql-client-13
+
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g mammoth@^1.4.16
 
@@ -101,7 +102,8 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
     libglib2.0-dev \
     libicu-dev \
     libsndfile1-dev \
-    libvips-dev \
-    && rm -rf /var/lib/apt/lists/*
+    libvips-dev
+
+RUN rm -rf /var/lib/apt/lists/*
 
 FROM base AS production


### PR DESCRIPTION
Small changes to CI Docker build to reflect upcoming changes to Manifold's hosted staging/preview environments.

Branch `edge` now builds images tagged `edge`, which will deploy to https://edge.manifoldapp.org. This represents the next major version and may contain breaking changes.

Branch `main` now builds images tagged `preview`, which will deploy to https://preview.manifoldapp.org. This represents unreleased minor version / bugfixes, and is considered stable.

Branch `release` continues to build images tagged `latest` and represents the current production version of Manifold.