### PR TITLE
fix: clean up ingestion tempfiles proactively

### DIFF
--- a/api/app/services/ingestions/abstract_contextual_ingestor.rb
+++ b/api/app/services/ingestions/abstract_contextual_ingestor.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Ingestions
+  # Base for ingestors that build an {Ingestions::Context}, run their ingestion,
+  # and guarantee that context (and every tempfile it owns) is torn down
+  # afterward, on both the success and failure paths.
+  #
+  # Subclasses implement {#run_ingestion} with the ingestion body and return the
+  # resulting record.
+  #
+  # @abstract
+  class AbstractContextualIngestor < AbstractBaseInteraction
+    record :ingestion
+    object :logger, default: nil
+
+    def execute
+      @context = shared_inputs[:context] = build_context
+
+      report_start
+
+      run_ingestion
+    ensure
+      @context&.teardown
+    end
+
+    private
+
+    # @abstract
+    # @return [ApplicationRecord, nil]
+    def run_ingestion
+      raise NotImplementedError, "Must implement #{self.class}##{__method__}"
+    end
+
+    def build_context
+      Ingestions::Context.new(ingestion, logger)
+    end
+
+    def report_start
+      @context.info "services.ingestions.logging.ingestion_start",
+                    name: @context.basename
+    end
+  end
+end

--- a/api/app/services/ingestions/concerns/file_operations.rb
+++ b/api/app/services/ingestions/concerns/file_operations.rb
@@ -31,7 +31,20 @@ module Ingestions
         end
       end
 
+      # Track and return a tempfile so it can be closed at teardown
+      #
+      # @param [Tempfile] file
+      # @return [Tempfile] the same file, for chaining
+      def track_tempfile(file)
+        return file if file.blank?
+        return file unless file.respond_to?(:close!) # If it quacks like a TempFile...
+
+        (@tracked_tempfiles ||= []) << file
+        file
+      end
+
       def teardown
+        maybe_close_tracked_tempfiles
         FileUtils.rm_rf(root_path)
       end
 
@@ -283,6 +296,19 @@ module Ingestions
         raise IngestionError, "Manifold could not locate one of the source files
             specified.  Make sure all assets referred to are included with the
             source file."
+      end
+
+      def maybe_close_tracked_tempfiles
+        return unless @tracked_tempfiles.present?
+
+        @tracked_tempfiles.reject! do |file|
+          file.close!
+        rescue SystemCallError => e
+          # A filesystem error we don't control must never block teardown. Log and
+          # drop the reference; Ruby's finalizer retries the unlink at GC.
+          Rails.logger.warn("Ingestion teardown could not remove tempfile #{file.path}: #{e.message}")
+          true
+        end
       end
     end
   end

--- a/api/app/services/ingestions/context.rb
+++ b/api/app/services/ingestions/context.rb
@@ -12,7 +12,7 @@ module Ingestions
       @identifier = ingestion.id
       @creator = ingestion.creator
       source = ingestion_source_tempfile(ingestion)
-      @source = source[:file]
+      @source = track_tempfile(source[:file])
       @source_title = source[:title]
       @source_path = @source.path
       @loggable = loggable

--- a/api/app/services/ingestions/ingestor.rb
+++ b/api/app/services/ingestions/ingestor.rb
@@ -3,15 +3,10 @@
 # This class takes an Ingestion record and
 # returns a new Text record.
 module Ingestions
-  class Ingestor < AbstractBaseInteraction
-    record :ingestion
-    object :logger, default: nil
+  class Ingestor < AbstractContextualIngestor
+    private
 
-    def execute
-      @context = shared_inputs[:context] = build_context
-
-      report_start
-
+    def run_ingestion
       strategy = compose Ingestions::Pickers::Strategy
 
       compose_into :manifest, strategy.interaction
@@ -28,30 +23,14 @@ module Ingestions
       text
     end
 
-    private
-
-    def build_context
-      Ingestions::Context.new(ingestion, logger)
-    end
-
     def text
       shared_inputs[:text]
-    end
-
-    def report_start
-      @context.info "services.ingestions.logging.ingestion_start",
-                    name: @context.basename
     end
 
     def set_ingestion_text
       return unless text.present?
 
       ingestion.update text: text
-    end
-
-    # Removes temporary dir
-    def clean_up
-      @context.teardown
     end
   end
 end

--- a/api/app/services/ingestions/strategies/manifest.rb
+++ b/api/app/services/ingestions/strategies/manifest.rb
@@ -28,7 +28,8 @@ module Ingestions
 
           filename = Digest::MD5.hexdigest(source["source_path"])
           inspector.update_source_map(source["source_path"], "#{filename}.html")
-          context.update_working_dirs(fetched[:file].path, filename)
+          file = context.track_tempfile(fetched[:file])
+          context.update_working_dirs(file.path, filename)
         end
         inspector.update_toc
       end

--- a/api/app/services/ingestions/text_section/ingestor.rb
+++ b/api/app/services/ingestions/text_section/ingestor.rb
@@ -4,16 +4,12 @@
 # returns a new TextSection record.
 module Ingestions
   module TextSection
-    class Ingestor < Ingestions::AbstractBaseInteraction
-      record :ingestion
+    class Ingestor < Ingestions::AbstractContextualIngestor
       record :text
-      object :logger, default: nil
 
-      def execute
-        @context = shared_inputs[:context] = build_context
+      private
 
-        report_start
-
+      def run_ingestion
         strategy = compose Ingestions::Pickers::Strategy
 
         set_ingestion_text
@@ -35,19 +31,8 @@ module Ingestions
         text_section
       end
 
-      private
-
-      def build_context
-        Ingestions::Context.new(ingestion, logger)
-      end
-
       def text_section
         shared_inputs[:text_section]
-      end
-
-      def report_start
-        @context.info "services.ingestions.logging.ingestion_start",
-                      name: @context.basename
       end
 
       def set_ingestion_text
@@ -60,11 +45,6 @@ module Ingestions
         return unless text_section.present?
 
         ingestion.update text_section: text_section
-      end
-
-      # Removes temporary dir
-      def clean_up
-        @context.teardown
       end
     end
   end

--- a/api/spec/services/ingestions/context_spec.rb
+++ b/api/spec/services/ingestions/context_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ingestions::Context do
+  include TestHelpers::IngestionHelper
+
+  let(:path) { Rails.root.join("spec", "data", "ingestion", "epubs", "minimal-v3.zip") }
+  let!(:ingestion) { FactoryBot.create :ingestion, :uningested, :file_source, source_path: path }
+
+  subject { create_context(ingestion) }
+
+  describe "#teardown" do
+    it "removes the working directory" do
+      root_path = subject.root_path
+      expect(File.directory?(root_path)).to be true
+      subject.teardown
+      expect(File.directory?(root_path)).to be false
+    end
+
+    it "closes and unlinks the downloaded source tempfile" do
+      source_path = subject.source_path
+      expect(File.exist?(source_path)).to be true
+      subject.teardown
+      expect(File.exist?(source_path)).to be false
+    end
+
+    it "closes and unlinks tempfiles registered with #track_tempfile" do
+      tempfile = Tempfile.new("tracked")
+      subject.track_tempfile(tempfile)
+      tracked_path = tempfile.path
+
+      subject.teardown
+
+      expect(tempfile.closed?).to be true
+      expect(File.exist?(tracked_path)).to be false
+    end
+
+    it "does not raise when a tracked tempfile was already closed" do
+      tempfile = Tempfile.new("tracked")
+      subject.track_tempfile(tempfile)
+      tempfile.close!
+
+      expect { subject.teardown }.not_to raise_error
+    end
+  end
+end

--- a/api/spec/services/ingestions/ingestor_spec.rb
+++ b/api/spec/services/ingestions/ingestor_spec.rb
@@ -26,6 +26,26 @@ RSpec.describe Ingestions::Ingestor do
     end
   end
 
+  describe "temp file cleanup" do
+    let(:path) { Rails.root.join("spec", "data", "ingestion", "html", "minimal-single", "index.html") }
+    let!(:ingestion) { FactoryBot.create :ingestion, :uningested, :file_source, source_path: path }
+
+    it "tears down the context on success" do
+      expect_any_instance_of(Ingestions::Context).to receive(:teardown).and_call_original
+
+      described_class.run ingestion: ingestion
+    end
+
+    it "tears down the context when ingestion raises" do
+      allow_any_instance_of(Ingestions::Compilers::TextSection)
+        .to receive(:text_section).and_raise(::Ingestions::IngestionError)
+
+      expect_any_instance_of(Ingestions::Context).to receive(:teardown).and_call_original
+
+      described_class.run ingestion: ingestion
+    end
+  end
+
   describe "manifest ingestion" do
     let(:path) { Rails.root.join("spec", "data", "ingestion", "manifest", "all_local.zip") }
     let!(:ingestion) { FactoryBot.create :ingestion, :uningested, :file_source, source_path: path }


### PR DESCRIPTION
Fixes an issue where tempfiles weren't being explicitly unlinked, and the teardown method wasn't being invoked.

This PR creates a new base interaction class for ingestions that better manages the Ingestions::Context that's passed in, using an `ensure` block to, well, ensure that teardown happens after success, failure, or exception.