### PR TITLE
fix: do not check trusted user input for spam

### DIFF
--- a/api/app/validators/spam_validator.rb
+++ b/api/app/validators/spam_validator.rb
@@ -7,12 +7,13 @@
 # @see SpamMitigation::Check
 # @see SpamMitigation::Checker
 class SpamValidator < ActiveModel::EachValidator
-  def validate_each(record, attribute, value)
+  def validate_each(record, attribute, value) # rubocop:disable Metrics/CyclomaticComplexity
     # :nocov:
     return if value.blank? || Settings.current.general.disable_spam_detection?
     # :nocov:
 
     user = RequestStore[:current_user] || record.try(:creator)
+    return if user&.trusted?
 
     type = options[:type].presence || "comment"
 


### PR DESCRIPTION
Trust trusted users to not spam.

Simply short-circuits the spam validator if the user is trusted.