### PR TITLE
fix: recalculate text fingerprint on text section or stylesheet change

### DIFF
--- a/api/app/models/stylesheet.rb
+++ b/api/app/models/stylesheet.rb
@@ -33,6 +33,10 @@ class Stylesheet < ApplicationRecord
 
   # AR Callbacks
   before_save :beautify_raw, :revalidate, :set_hashed_content, if: :raw_styles_changed?
+  after_commit :text_recalculate_fingerprint!, if: :saved_change_to_raw_styles?
+
+  # Delegation
+  delegate :recalculate_fingerprint!, to: :text, prefix: true, allow_nil: true
 
   # Concerns
   acts_as_list scope: :text_id

--- a/api/app/models/text_section.rb
+++ b/api/app/models/text_section.rb
@@ -60,6 +60,7 @@ class TextSection < ApplicationRecord
   attribute :body_json, :indifferent_hash
 
   delegate :citation_parts, to: :text, prefix: true, allow_nil: true
+  delegate :recalculate_fingerprint!, to: :text, prefix: true, allow_nil: true
   delegate :source_path, to: :ingestion_source, allow_nil: true
   delegate :project, to: :text, allow_nil: true
   delegate :metadata, to: :text, prefix: true, allow_nil: true
@@ -80,6 +81,7 @@ class TextSection < ApplicationRecord
   after_destroy :remove_linked_toc_entries, unless: :skip_removal_of_toc_entries?
   after_save_commit :asynchronously_index_nodes!
   after_commit :maybe_adopt_or_orphan_annotations!, on: [:update, :destroy]
+  after_commit :text_recalculate_fingerprint!, if: :saved_change_to_body?
 
   scope :in_texts, ->(texts) { where(text: texts) }
   scope :ordered, -> { order(position: :asc) }


### PR DESCRIPTION
Correctly marks `TextExportStatus` as `stale` by recalculating the text's fingerprint when the content of a text section or stylesheet changes.

This will cause text exports to regenerate dynamically in the next scheduled job.