### PR TITLE
Optimize API load times

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -107,3 +107,6 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
 RUN rm -rf /var/lib/apt/lists/*
 
 FROM base AS production
+
+# Precompile Bootsnap cache for faster production load times
+RUN bundle exec bootsnap precompile --gemfile app/ lib/

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -19,6 +19,7 @@ gem "authority", "~>3.3.0"
 gem "aws-sdk-s3", "~> 1.146"
 gem "bagit", "~> 0.6.0"
 gem "bcrypt", "~> 3.0"
+gem "bootsnap", ">= 1.18", require: false
 gem "charlock_holmes", "~> 0.7.9"
 gem "csv"
 gem "chroma", "~> 0.2"

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -155,6 +155,8 @@ GEM
     bcrypt (3.1.22)
     benchmark (0.5.0)
     bigdecimal (4.1.2)
+    bootsnap (1.25.0)
+      msgpack (~> 1.5)
     buftok (0.2.0)
     builder (3.3.0)
     cgi (0.5.1)
@@ -526,6 +528,7 @@ GEM
     minitest (5.27.0)
     money (6.19.0)
       i18n (>= 0.6.4, <= 2)
+    msgpack (1.8.4)
     multi_json (1.19.1)
     multi_xml (0.8.1)
       bigdecimal (>= 3.1, < 5)
@@ -942,6 +945,7 @@ DEPENDENCIES
   base64
   bcrypt (~> 3.0)
   bigdecimal
+  bootsnap (>= 1.18)
   charlock_holmes (~> 0.7.9)
   chroma (~> 0.2)
   chronic

--- a/api/app/services/system_upgrades.rb
+++ b/api/app/services/system_upgrades.rb
@@ -4,12 +4,9 @@ module SystemUpgrades
   UPGRADES_ROOT = Rails.root.join("app", "services", "system_upgrades", "upgrades")
 
   class << self
-    # @return [<Class>]
-    def eager_load_upgrades!
+    def load_upgrade_classes!
       # :nocov:
       return upgrades if Rails.env.test?
-
-      Rails.application.eager_load!
 
       UPGRADES_ROOT.each_child do |child|
         next unless child.fnmatch("*.rb")

--- a/api/app/services/system_upgrades/perform.rb
+++ b/api/app/services/system_upgrades/perform.rb
@@ -17,9 +17,13 @@ module SystemUpgrades
 
     # @return [String]
     def execute
+      pending = pending_upgrades
+
+      eager_load_application! if pending.any? && !noop
+
       applied = false
 
-      filtered_upgrades.each do |upgrade_interaction|
+      pending.each do |upgrade_interaction|
         result, upgrade_output = compose upgrade_interaction, inputs
         applied = true if result && !noop
         output.write upgrade_output
@@ -31,6 +35,26 @@ module SystemUpgrades
     end
 
     private
+
+    # Upgrades not yet recorded as applied. Forcing treats all as pending.
+    # @return [<Class>]
+    def pending_upgrades
+      return filtered_upgrades if force
+
+      filtered_upgrades.reject { |klass| applied_version_strings.include?(klass.version_string) }
+    end
+
+    # @return [Set<String>]
+    def applied_version_strings
+      @applied_version_strings ||= UpgradeResult.pluck(:version).to_set
+    end
+
+    # Rake tasks don't eager load by default
+    def eager_load_application!
+      return if Rails.env.test?
+
+      Rails.application.eager_load!
+    end
 
     def rebuild_pg_search_documents
       logger.info("[-ANY-]===================================================================")
@@ -52,7 +76,7 @@ module SystemUpgrades
     end
 
     def load_upgrades!
-      @upgrade_interactions = SystemUpgrades.eager_load_upgrades!
+      @upgrade_interactions = SystemUpgrades.load_upgrade_classes!
     end
   end
 end

--- a/api/config/boot.rb
+++ b/api/config/boot.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.
 require "logger" # Fix concurrent-ruby removing logger dependency which Rails itself does not have
 
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)

--- a/api/spec/services/system_upgrades/system_upgrades_spec.rb
+++ b/api/spec/services/system_upgrades/system_upgrades_spec.rb
@@ -16,7 +16,7 @@ end if Rails.env.test?
 
 RSpec.describe SystemUpgrades do
   it "retrieves and orders upgrade version files", :aggregate_failures do
-    upgrades = described_class.eager_load_upgrades!
+    upgrades = described_class.load_upgrade_classes!
 
     expect(upgrades).to include(Test000100)
     expect(upgrades).to include(Test000200)


### PR DESCRIPTION
The API can take some time to load after a deployment, in part due to the post-deploy hook tasks (database migrations, seeds, and upgrades).

This PR re-introduces Bootsnap into the API and precompiles production builds for faster boot times.

Additionally, it short-circuits the upgrade task eager-loading the entire Rails app if no upgrades are needed.