### PR TITLE
Do not submit verified user content for spam; loosen resource annotation creation auth for authors

### DIFF
--- a/api/app/authorizers/annotation_authorizer.rb
+++ b/api/app/authorizers/annotation_authorizer.rb
@@ -45,8 +45,9 @@ class AnnotationAuthorizer < ApplicationAuthorizer
 
   private
 
-  # Only public annotations need reputation to create.
+  # Only public annotations need reputation to create. Resource annotations are gated by role, not reputation.
   def requires_reputation_to_create?
+    return false if annotation_is_resource_annotation?
     return true if annotation_is_public? && !annotation_in_reading_group?
     return true if annotation_in_reading_group? && !reading_group_is_private?
 

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -131,6 +131,12 @@ class User < ApplicationRecord
 
   alias email_confirmed? email_confirmed
 
+  # Verified users and users explicitly given a role are exempt from spam checks
+  # @return [Boolean]
+  def spam_exempt?
+    established? || trusted?
+  end
+
   def email=(value)
     super(value.try(:strip))
   end

--- a/api/app/services/spam_mitigation/checker.rb
+++ b/api/app/services/spam_mitigation/checker.rb
@@ -18,12 +18,11 @@ module SpamMitigation
       option :type, Types::String.optional, default: proc { "comment" }
     end
 
-    delegate :trusted?, to: :user, allow_nil: true, prefix: true
+    delegate :spam_exempt?, to: :user, allow_nil: true, prefix: true
 
     # @return [Dry::Monads::Success(Boolean)]
     def call
-      # Bypass detection entirely for users who have privileged access,
-      return Failure[:user_trusted] if user_trusted?
+      return Failure[:user_trusted] if user_spam_exempt?
 
       return Failure[:spam_detection_disabled] if Settings.current.general.disable_spam_detection?
 

--- a/api/app/services/spam_mitigation/submitter.rb
+++ b/api/app/services/spam_mitigation/submitter.rb
@@ -21,8 +21,12 @@ module SpamMitigation
 
     STRATEGIES = %i[akismet].freeze
 
-    # @return [Dry::Monads::Success({ Symbol => Dry::Monads::Result })]
+    delegate :spam_exempt?, to: :user, allow_nil: true, prefix: true
+
+    # @return [Dry::Monads::Result]
     def call
+      return Failure[:user_trusted] if user_spam_exempt?
+
       results = STRATEGIES.index_with do |strategy|
         __send__(:"submit_with_#{strategy}")
       end

--- a/api/app/validators/spam_validator.rb
+++ b/api/app/validators/spam_validator.rb
@@ -13,7 +13,7 @@ class SpamValidator < ActiveModel::EachValidator
     # :nocov:
 
     user = RequestStore[:current_user] || record.try(:creator)
-    return if user&.trusted?
+    return if user&.spam_exempt?
 
     type = options[:type].presence || "comment"
 

--- a/api/spec/authorizers/annotation_authorizer_spec.rb
+++ b/api/spec/authorizers/annotation_authorizer_spec.rb
@@ -48,6 +48,27 @@ RSpec.describe "Annotation Abilities", :authorizer do
     end
   end
 
+  context "when the subject is a project author with an unverified email" do
+    let_it_be(:subject) do
+      FactoryBot.create(:user).tap do |user|
+        user.add_role :project_author, project
+      end
+    end
+
+    context "when the annotation is a text annotation created by another user" do
+      abilities = { create: false, read: true, update: false, delete: false }
+      the_subject_behaves_like "instance abilities", Annotation, abilities
+    end
+
+    context "when the annotation is a resource annotation created by another user" do
+      let_it_be(:object, refind: true) do
+        FactoryBot.create(:resource_annotation, :is_public, creator: creator, text: text)
+      end
+      abilities = { create: true, read: true, update: true, delete: true }
+      the_subject_behaves_like "instance abilities", Annotation, abilities
+    end
+  end
+
   context "when the subject is a reader" do
     context "when the annotation is a resource annotation created by another user" do
       let_it_be(:object, refind: true) do

--- a/api/spec/models/user_spec.rb
+++ b/api/spec/models/user_spec.rb
@@ -96,6 +96,24 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#spam_exempt?" do
+    it "is false for an unverified reader" do
+      expect(FactoryBot.create(:user, :reader)).not_to be_spam_exempt
+    end
+
+    it "is true for an email-verified reader" do
+      expect(FactoryBot.create(:user, :reader, :with_confirmed_email)).to be_spam_exempt
+    end
+
+    it "is true for an admin-verified reader" do
+      expect(FactoryBot.create(:user, :reader, admin_verified: true)).to be_spam_exempt
+    end
+
+    it "is true for a privileged role without verification" do
+      expect(FactoryBot.create(:user, :admin)).to be_spam_exempt
+    end
+  end
+
   context "when changing a role" do
     let!(:user) { FactoryBot.create :user, :editor }
     let!(:project) { FactoryBot.create :project }

--- a/api/spec/operations/spam_mitigation/check_spec.rb
+++ b/api/spec/operations/spam_mitigation/check_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe SpamMitigation::Check, type: :operation do
         end
       end
 
+      context "when the user is merely email-verified" do
+        let(:user) { FactoryBot.create(:user, :reader, :with_confirmed_email) }
+
+        it "is skipped without contacting akismet" do
+          expect_calling_the_operation.to monad_fail.with_key(:user_trusted)
+        end
+      end
+
       context "when spam detection has been disabled globally" do
         before do
           spam_detection_disabled!

--- a/api/spec/operations/spam_mitigation/submit_spec.rb
+++ b/api/spec/operations/spam_mitigation/submit_spec.rb
@@ -32,5 +32,13 @@ RSpec.describe SpamMitigation::Submit, type: :operation do
         expect_calling_the_operation.to succeed.with(akismet: succeed.with(/thanks/i))
       end
     end
+
+    context "when the content belongs to a trusted user" do
+      let(:user) { FactoryBot.create(:user, :reader, :with_confirmed_email) }
+
+      it "is not reported to akismet" do
+        expect_calling_the_operation.to monad_fail.with_key(:user_trusted)
+      end
+    end
   end
 end

--- a/api/spec/requests/comments_spec.rb
+++ b/api/spec/requests/comments_spec.rb
@@ -135,21 +135,6 @@ RSpec.describe "Comments API", type: :request do
 
           expect(response).to have_http_status(:too_many_requests)
         end
-
-        context "when the comment is spammy" do
-          before do
-            akismet_enabled!
-            akismet_stub_comment_check!(situation: :spam)
-          end
-
-          it "does not create a comment" do
-            expect do
-              post path, headers: headers, params: params
-            end.to keep_the_same(Comment, :count)
-
-            expect(response).to have_http_status(:unprocessable_entity)
-          end
-        end
       end
 
       context "when the user is a reader with an unconfirmed email" do

--- a/api/spec/requests/reading_groups_spec.rb
+++ b/api/spec/requests/reading_groups_spec.rb
@@ -249,23 +249,6 @@ RSpec.describe "Reading Groups API", type: :request do
           expect(response).to have_http_status(:created)
         end
       end
-
-      context "with a public reading group" do
-        let(:attributes) do
-          {
-            name: "My Reading Group",
-            privacy: "public",
-          }
-        end
-
-        it "does not create the reading group" do
-          expect do
-            making_the_request
-          end.to keep_the_same(ReadingGroup, :count)
-
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
-      end
     end
   end
 

--- a/api/spec/requests/text_sections/relationships/annotations_spec.rb
+++ b/api/spec/requests/text_sections/relationships/annotations_spec.rb
@@ -240,18 +240,6 @@ RSpec.describe "Text Section Annotations API", type: :request do
             expect(response).to have_http_status(:created)
           end
         end
-
-        context "when the annotation is public" do
-          let(:annotation_privacy) { :is_public }
-
-          it "does not create the annotation" do
-            expect do
-              post path, headers: reader_headers, params: params
-            end.to keep_the_same(Annotation, :count)
-
-            expect(response).to have_http_status(:unprocessable_entity)
-          end
-        end
       end
     end
 


### PR DESCRIPTION
- Expands spam check exemption to any user who is `trusted?` or `established?`
- Removes reputation check to create resource annotations, relying instead on role (`notatable_by?`)